### PR TITLE
API for registering a custom page edit handler

### DIFF
--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -534,6 +534,11 @@ def set_page_position(request, page_to_move_id):
 PAGE_EDIT_HANDLERS = {}
 
 
+def register_page_edit_handler(page_class, handler):
+    assert page_class not in PAGE_EDIT_HANDLERS
+    PAGE_EDIT_HANDLERS[page_class] = handler
+
+
 def get_page_edit_handler(page_class):
     if page_class not in PAGE_EDIT_HANDLERS:
         PAGE_EDIT_HANDLERS[page_class] = TabbedInterface([


### PR DESCRIPTION
For some page types I'd like to define custom admin interfaces with a different set of tabs, like "Main Content // Sidebar Content // Promote" instead of the default "Content // Promote."

I see that I can already do this by adding an entry to the `wagtailadmin.views.pages.PAGE_EDIT_HANDLERS` dictionary in my `models.py` at import time.

This PR proposes a `wagtailadmin.views.pages.register_page_edit_handler(page_class, handler)` function to formalize that approach.  It would be used in a `models.py` like

    MyPage.main_content_panels = [
      FieldPanel("title"),
      FieldPanel("main_section_content")
      ]
    MyPage.promote_panels = MultiFieldPanel(COMMON_PANELS, "Common page configuration"),
    MyPage.sidebar_panels = [
      ImageChooserPanel("sidebar_image"),
      InlinePanel(MyPage, "related_links", label="Related pages"),
    ]
    
    from wagtail.wagtailadmin.views.pages import (register_page_edit_handler,
                                              TabbedInterface,
                                              ObjectList)
    register_page_edit_handler(TabbedInterface([
           ObjectList(MyPage.main_content_panels, heading="Main Content"),
           ObjectList(MyPage.sidebar_panels, heading="Sidebar Content"),
           ObjectList(MyPage.promote_panels, heading="Promote")])
