### PR TITLE
Fix 'move page' permissions to enforce subpage_types / parent_page_types business rules

### DIFF
--- a/wagtail/tests/fixtures/test.json
+++ b/wagtail/tests/fixtures/test.json
@@ -39,7 +39,7 @@
     "model": "wagtailcore.page",
     "fields": {
         "title": "Events",
-        "numchild": 4,
+        "numchild": 5,
         "show_in_menus": true,
         "live": true,
         "depth": 3,
@@ -327,6 +327,52 @@
         "location": "Marks and Spencer",
         "body": "<p>meet in the menswear department at noon</p>",
         "cost": "free"
+    }
+},
+
+{
+    "pk": 13,
+    "model": "wagtailcore.page",
+    "fields": {
+        "title": "Businessy events",
+        "numchild": 1,
+        "show_in_menus": true,
+        "live": false,
+        "depth": 4,
+        "content_type": ["tests", "businessindex"],
+        "path": "0001000100010005",
+        "url_path": "/home/events/businessy-events/",
+        "slug": "businessy-events",
+        "owner": 2
+    }
+},
+{
+    "pk": 13,
+    "model": "tests.businessindex",
+    "fields": {
+    }
+},
+
+{
+    "pk": 14,
+    "model": "wagtailcore.page",
+    "fields": {
+        "title": "Board meetings",
+        "numchild": 0,
+        "show_in_menus": true,
+        "live": false,
+        "depth": 5,
+        "content_type": ["tests", "businesssubindex"],
+        "path": "00010001000100050001",
+        "url_path": "/home/events/businessy-events/board-meetings/",
+        "slug": "board-meetings",
+        "owner": 2
+    }
+},
+{
+    "pk": 14,
+    "model": "tests.businesssubindex",
+    "fields": {
     }
 },
 

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1145,8 +1145,20 @@ class PagePermissionTester(object):
 
         # reject moves that are forbidden by subpage_types / parent_page_types rules
         # (these rules apply to superusers too)
-        if ContentType.objects.get_for_model(self.page.specific_class) not in destination.allowed_subpage_types():
-            return False
+
+        # We need to roll our own tests here rather than just checking allowed_subpage_types, because
+        # allowed_subpage_types does not include 'abstract' page types such as Page itself, which makes
+        # it impossible to move wagtailcore's default homepage record even if no actual business rules
+        # have been set
+        if getattr(self.page.specific_class, 'parent_page_types', None) is not None:
+            destination_page_type = ContentType.objects.get_for_model(destination.specific_class)
+            if destination_page_type not in self.page.specific_class.clean_parent_page_types():
+                return False
+
+        if getattr(destination.specific_class, 'subpage_types', None) is not None:
+            moved_page_type = ContentType.objects.get_for_model(self.page.specific_class)
+            if moved_page_type not in destination.specific_class.clean_subpage_types():
+                return False
 
         # shortcut the trivial 'everything' / 'nothing' permissions
         if not self.user.is_active:

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -562,7 +562,7 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
     @classmethod
     def allowed_subpage_types(cls):
         """
-        Returns the list of page types that this page type can be a subpage of
+        Returns the list of page types that this page type can have as subpages
         """
         # Special case the 'Page' class, such as the Root page or Home page -
         # otherwise you can not add initial pages when setting up a site
@@ -1143,7 +1143,12 @@ class PagePermissionTester(object):
         if self.page == destination or destination.is_descendant_of(self.page):
             return False
 
-        # and shortcut the trivial 'everything' / 'nothing' permissions
+        # reject moves that are forbidden by subpage_types / parent_page_types rules
+        # (these rules apply to superusers too)
+        if ContentType.objects.get_for_model(self.page.specific_class) not in destination.allowed_subpage_types():
+            return False
+
+        # shortcut the trivial 'everything' / 'nothing' permissions
         if not self.user.is_active:
             return False
         if self.user.is_superuser:

--- a/wagtail/wagtailcore/tests/test_page_permissions.py
+++ b/wagtail/wagtailcore/tests/test_page_permissions.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.contrib.auth import get_user_model
 
 from wagtail.wagtailcore.models import Page, UserPagePermissionsProxy
-from wagtail.tests.models import EventPage
+from wagtail.tests.models import EventPage, BusinessSubIndex
 
 
 class TestPagePermission(TestCase):
@@ -14,11 +14,13 @@ class TestPagePermission(TestCase):
         christmas_page = EventPage.objects.get(url_path='/home/events/christmas/')
         unpublished_event_page = EventPage.objects.get(url_path='/home/events/tentative-unpublished-event/')
         someone_elses_event_page = EventPage.objects.get(url_path='/home/events/someone-elses-event/')
+        board_meetings_page = BusinessSubIndex.objects.get(url_path='/home/events/businessy-events/board-meetings/')
 
         homepage_perms = homepage.permissions_for_user(event_editor)
         christmas_page_perms = christmas_page.permissions_for_user(event_editor)
         unpub_perms = unpublished_event_page.permissions_for_user(event_editor)
         someone_elses_event_perms = someone_elses_event_page.permissions_for_user(event_editor)
+        board_meetings_perms = board_meetings_page.permissions_for_user(event_editor)
 
         self.assertFalse(homepage_perms.can_add_subpage())
         self.assertTrue(christmas_page_perms.can_add_subpage())
@@ -60,6 +62,10 @@ class TestPagePermission(TestCase):
         self.assertTrue(unpub_perms.can_move_to(christmas_page))
         self.assertFalse(unpub_perms.can_move_to(homepage))  # no permission to create pages at destination
         self.assertFalse(unpub_perms.can_move_to(unpublished_event_page))  # cannot make page a child of itself
+        self.assertFalse(unpub_perms.can_move_to(board_meetings_page))  # cannot move because the subpage_types rule of BusinessSubIndex forbids EventPage as a subpage
+
+        self.assertTrue(board_meetings_perms.can_move())
+        self.assertFalse(board_meetings_perms.can_move_to(christmas_page))  # cannot move because the parent_page_types rule of BusinessSubIndex forbids EventPage as a parent
 
 
     def test_publisher_page_permissions(self):
@@ -67,10 +73,12 @@ class TestPagePermission(TestCase):
         homepage = Page.objects.get(url_path='/home/')
         christmas_page = EventPage.objects.get(url_path='/home/events/christmas/')
         unpublished_event_page = EventPage.objects.get(url_path='/home/events/tentative-unpublished-event/')
+        board_meetings_page = BusinessSubIndex.objects.get(url_path='/home/events/businessy-events/board-meetings/')
 
         homepage_perms = homepage.permissions_for_user(event_moderator)
         christmas_page_perms = christmas_page.permissions_for_user(event_moderator)
         unpub_perms = unpublished_event_page.permissions_for_user(event_moderator)
+        board_meetings_perms = board_meetings_page.permissions_for_user(event_moderator)
 
         self.assertFalse(homepage_perms.can_add_subpage())
         self.assertTrue(christmas_page_perms.can_add_subpage())
@@ -108,6 +116,10 @@ class TestPagePermission(TestCase):
         self.assertTrue(unpub_perms.can_move_to(christmas_page))
         self.assertFalse(unpub_perms.can_move_to(homepage))  # no permission to create pages at destination
         self.assertFalse(unpub_perms.can_move_to(unpublished_event_page))  # cannot make page a child of itself
+        self.assertFalse(unpub_perms.can_move_to(board_meetings_page))  # cannot move because the subpage_types rule of BusinessSubIndex forbids EventPage as a subpage
+
+        self.assertTrue(board_meetings_perms.can_move())
+        self.assertFalse(board_meetings_perms.can_move_to(christmas_page))  # cannot move because the parent_page_types rule of BusinessSubIndex forbids EventPage as a parent
 
     def test_inactive_user_has_no_permissions(self):
         user = get_user_model().objects.get(username='inactiveuser')
@@ -132,10 +144,12 @@ class TestPagePermission(TestCase):
         homepage = Page.objects.get(url_path='/home/')
         root = Page.objects.get(url_path='/')
         unpublished_event_page = EventPage.objects.get(url_path='/home/events/tentative-unpublished-event/')
+        board_meetings_page = BusinessSubIndex.objects.get(url_path='/home/events/businessy-events/board-meetings/')
 
         homepage_perms = homepage.permissions_for_user(user)
         root_perms = root.permissions_for_user(user)
         unpub_perms = unpublished_event_page.permissions_for_user(user)
+        board_meetings_perms = board_meetings_page.permissions_for_user(user)
 
         self.assertTrue(homepage_perms.can_add_subpage())
         self.assertTrue(root_perms.can_add_subpage())
@@ -164,6 +178,10 @@ class TestPagePermission(TestCase):
 
         self.assertTrue(homepage_perms.can_move_to(root))
         self.assertFalse(homepage_perms.can_move_to(unpublished_event_page))
+
+        self.assertFalse(unpub_perms.can_move_to(board_meetings_page))  # cannot move because the subpage_types rule of BusinessSubIndex forbids EventPage as a subpage
+        self.assertTrue(board_meetings_perms.can_move())
+        self.assertFalse(board_meetings_perms.can_move_to(unpublished_event_page))  # cannot move because the parent_page_types rule of BusinessSubIndex forbids EventPage as a parent
 
     def test_editable_pages_for_user_with_add_permission(self):
         event_editor = get_user_model().objects.get(username='eventeditor')


### PR DESCRIPTION
Ref: https://groups.google.com/d/msg/wagtail/OsInDdBCVOM/lxr8c5U5opsJ

Currently it's possible to move pages into any section you have permission for, regardless of any subpage_types / parent_page_types business rules that would prevent it. This PR fixes the can_move_to permission check to properly enforce these rules. 