### PR TITLE
Added the ability to use a different revision of a page

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/list.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/list.html
@@ -86,6 +86,9 @@
                             {% if parent_page_perms.can_unpublish and 'unpublish' not in hide_actions|default:'' %}
                                 <li><a href="{% url 'wagtailadmin_pages_unpublish' parent_page.id %}" class="button button-small">{% trans 'Unpublish' %}</a></li>
                             {% endif %}
+                            {% if 'versions' not in hide_actions|default:'' %}
+                                <li><a href="{% url 'wagtailadmin_pages_revisions' parent_page.id %}" class="button button-small">{% trans 'Revisions' %}</a></li>
+                            {% endif %}
                             {% if parent_page_perms.can_add_subpage and 'add_subpage' not in hide_actions|default:'' %}
                                 <li><a href="{% url 'wagtailadmin_pages_add_subpage' parent_page.id %}" class="button button-small bicolor icon white icon-plus">{% trans 'Add child page' %}</a></li>
                             {% endif %}
@@ -206,6 +209,9 @@
                                 {% endif %}
                                 {% if page_perms.can_unpublish and 'unpublish' not in hide_actions|default:'' %}
                                     <li><a href="{% url 'wagtailadmin_pages_unpublish' page.id %}" class="button button-small">{% trans 'Unpublish' %}</a></li>
+                                {% endif %}
+                                {% if 'versions' not in hide_actions|default:'' %}
+                                    <li><a href="{% url 'wagtailadmin_pages_revisions' page.id %}" class="button button-small">{% trans 'Revisions' %}</a></li>
                                 {% endif %}
                                 {% if page_perms.can_add_subpage and 'add_subpage' not in hide_actions|default:'' %}
                                     <li><a href="{% url 'wagtailadmin_pages_add_subpage' page.id %}" class="button button-small">{% trans 'Add child page' %}</a></li>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/page_revisions.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/page_revisions.html
@@ -1,0 +1,39 @@
+{% load i18n %}
+{% load wagtailadmin_tags %}
+<table class="listing{% if full_width %} full-width{% endif %} chooser">
+    <col width="5%" />
+    <col width="50px" />
+    <col width="20%" />
+    <col width="20%" />
+    <thead>
+        <tr class="table-headers">
+            <th class="revision_id">
+                {% trans 'Revision' %}
+            </th>
+            <th class="title">
+                {% trans 'Title' %}
+            </th>
+            <th class="type">
+                {% trans 'Created' %}
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        {% if revisions %}
+            {% for revision in revisions %}
+                <tr {% if ordering == "ord" %}id="page_{{ page.id }}" data-page-title="{{ page.title }}"{% endif %} class="{% if not page.live %} unpublished{% endif %}{% if moving or choosing %}{% if not page.can_choose %}disabled{% endif %}{% endif %}">
+                    <td class="revision_id" valign="top">{{ revision.id }}</td>
+                    <td class="title" valign="top">
+                        <h2>
+                            <a href="{% url 'wagtailadmin_pages_edit' revision.page.id revision.id  %}">{{ revision.page.title }}</a>
+                        </h2>
+                    </td>
+                    <td class="type" valign="top">{{ revision.created_at }}</td>
+                </tr>
+            {% endfor %}
+        {% else %}
+            {% url 'wagtailadmin_pages_add_subpage' parent_page.id as add_page_url%}
+            <tr><td colspan="3" class="no-results-message"><p>{% trans "No pages have been created." %}{% if parent_page and parent_page_perms.can_add_subpage %} {% blocktrans %}Why not <a href="{{ add_page_url }}">add one</a>?{% endblocktrans %}{% endif %}</td></tr>
+        {% endif %}
+    </tbody>
+</table>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/select_revision.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/select_revision.html
@@ -1,0 +1,13 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n %}
+{% block titletag %}{% blocktrans with title=page.title %}Select a revision to use for {{ title }}{% endblocktrans %}{% endblock %}
+{% block bodyclass %}menu-explorer{% endblock %}
+{% block content %}
+    <header class="nice-padding">
+        <h1 class="icon icon-doc-empty-inverse">{% blocktrans with title=page.title %}Select a revision to use for <span>{{ title }}</span>{% endblocktrans %}</h1>
+    </header>
+
+    <div class="nice-padding">
+        {% include "wagtailadmin/pages/page_revisions.html" with allow_navigation=1 pages=child_pages revisions=revisions %}
+    </div>
+{% endblock %}

--- a/wagtail/wagtailadmin/urls.py
+++ b/wagtail/wagtailadmin/urls.py
@@ -48,6 +48,7 @@ urlpatterns += [
     url(r'^pages/usage/(\w+)/(\w+)/$', pages.content_type_use, name='wagtailadmin_pages_type_use'),
 
     url(r'^pages/(\d+)/edit/$', pages.edit, name='wagtailadmin_pages_edit'),
+    url(r'^pages/(\d+)/edit/(\d+)/$', pages.edit, name='wagtailadmin_pages_edit'),
     url(r'^pages/(\d+)/edit/preview/$', pages.preview_on_edit, name='wagtailadmin_pages_preview_on_edit'),
 
     url(r'^pages/preview/$', pages.preview, name='wagtailadmin_pages_preview'),
@@ -61,6 +62,7 @@ urlpatterns += [
     url(r'^pages/search/$', pages.search, name='wagtailadmin_pages_search'),
 
     url(r'^pages/(\d+)/move/$', pages.move_choose_destination, name='wagtailadmin_pages_move'),
+    url(r'^pages/(\d+)/revisions/$', pages.select_revision, name='wagtailadmin_pages_revisions'),
     url(r'^pages/(\d+)/move/(\d+)/$', pages.move_choose_destination, name='wagtailadmin_pages_move_choose_destination'),
     url(r'^pages/(\d+)/move/(\d+)/confirm/$', pages.move_confirm, name='wagtailadmin_pages_move_confirm'),
     url(r'^pages/(\d+)/set_position/$', pages.set_page_position, name='wagtailadmin_pages_set_page_position'),

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -412,6 +412,12 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
             approved_go_live_at=approved_go_live_at,
         )
 
+    def get_revision(self, revision_id):
+        return self.revisions.get(id=revision_id)
+
+    def get_revision_as_page(self, revision_id):
+        return self.revisions.get(id=revision_id).as_page_object()
+
     def get_latest_revision(self):
         return self.revisions.order_by('-created_at').first()
 


### PR DESCRIPTION
Hello, I wanted to see if this is something you guys would be interested in using before adding more to this pull request. This code is functional; it adds a button called ```Revisions``` to each page:
![](http://i.imgur.com/yljPLKs.png)

This button leads to a page listing all the revisions for a given page. A user can select one of these revisions to open in the editor:
![](http://i.imgur.com/d2mSAuK.png)

If the user chooses to save the revision via the editor, a new revision is created for the page.