### PR TITLE
RoutablePageMixin's serve method fallback to Page's serve method on error

### DIFF
--- a/wagtail/contrib/wagtailroutablepage/models.py
+++ b/wagtail/contrib/wagtailroutablepage/models.py
@@ -63,7 +63,11 @@ class RoutablePageMixin(object):
         return super(RoutablePageMixin, self).route(request, path_components)
 
     def serve(self, request, view, args, kwargs):
-        return view(request, *args, **kwargs)
+        try:
+            return view(request, *args, **kwargs)
+        except TypeError:
+            # fall back to the parent's serve method
+            return super(RoutablePageMixin, self).serve(request, *args, **kwargs)
 
     def serve_preview(self, request, mode_name):
         view, args, kwargs = self.resolve_subpage('/')


### PR DESCRIPTION
For example A blog might have archives, but a default listing view.
If so, falling back to Page's serve method will grab the template
and serve it like a regular page.