### PR TITLE
Hidden field

### DIFF
--- a/docs/core_components/form_builder.rst
+++ b/docs/core_components/form_builder.rst
@@ -49,6 +49,8 @@ AbstractEmailForm defines the fields 'to_address', 'from_address' and 'subject',
 
 If you do not want your form page type to offer form-to-email functionality, you can inherit from AbstractForm instead of AbstractEmailForm, and omit the 'to_address', 'from_address' and 'subject' fields from the content_panels definition.
 
+If you want to enable hidden form fields, so your forms can submit extra data not seen by the user (for example when building on the wagtailforms module to submit data to an external service), then your FormField class can instead inherit from AbstractHideableFormField.
+
 You now need to create two templates named form_page.html and form_page_landing.html (where 'form_page' is the underscore-formatted version of the class name). form_page.html differs from a standard Wagtail template in that it is passed a variable 'form', containing a Django form object, in addition to the usual 'self' variable. A very basic template for the form would thus be:
 
 .. code:: html

--- a/wagtail/tests/fixtures/test.json
+++ b/wagtail/tests/fixtures/test.json
@@ -23,7 +23,7 @@
     "model": "wagtailcore.page",
     "fields": {
         "title": "Welcome to the Wagtail test site!",
-        "numchild": 5,
+        "numchild": 6,
         "show_in_menus": false,
         "live": true,
         "depth": 2,
@@ -329,6 +329,90 @@
         "cost": "free"
     }
 },
+
+{
+    "pk": 13,
+    "model": "wagtailcore.page",
+    "fields": {
+        "title": "Secret Info Form",
+        "numchild": 0,
+        "show_in_menus": true,
+        "live": true,
+        "depth": 3,
+        "content_type": ["tests", "hideableformpage"],
+        "path": "000100010006",
+        "url_path": "/home/secret-info-form/",
+        "slug": "secret-info-form"
+    }
+},
+{
+    "pk": 13,
+    "model": "tests.hideableformpage",
+    "fields": {
+    }
+},
+
+{
+    "pk": 1,
+    "model": "tests.hideableformfield",
+    "fields": {
+        "sort_order": 1,
+        "label": "Your email",
+        "field_type": "email",
+        "required": true,
+        "choices": "",
+        "default_value": "",
+        "help_text": "",
+        "page": 13
+    }
+},
+{
+    "pk": 2,
+    "model": "tests.hideableformfield",
+    "fields": {
+        "sort_order": 2,
+        "label": "Your message",
+        "field_type": "multiline",
+        "required": true,
+        "choices": "",
+        "default_value": "",
+        "help_text": "",
+        "page": 13
+    }
+},
+
+
+{
+    "pk": 3,
+    "model": "tests.hideableformfield",
+    "fields": {
+        "sort_order": 3,
+        "label": "First bunch of secret data",
+        "field_type": "singleline",
+        "required": true,
+        "choices": "",
+        "default_value": "I have a hidden stash of apricot stones",
+        "help_text": "",
+        "is_hidden": true,
+        "page": 13
+    }
+},
+{
+    "pk": 4,
+    "model": "tests.hideableformfield",
+    "fields": {
+        "sort_order": 4,
+        "label": "Second secret data field",
+        "field_type": "multiline",
+        "required": true,
+        "choices": "",
+        "default_value": "",
+        "help_text": "",
+        "is_hidden": true,
+        "page": 13
+    }
+},
+
 
 {
     "pk": 1,

--- a/wagtail/tests/migrations/0005_auto_20141020_0333.py
+++ b/wagtail/tests/migrations/0005_auto_20141020_0333.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import modelcluster.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0008_populate_latest_revision_created_at'),
+        ('tests', '0004_auto_20141008_0420'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='HideableFormField',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('sort_order', models.IntegerField(null=True, editable=False, blank=True)),
+                ('label', models.CharField(help_text='The label of the form field', max_length=255)),
+                ('field_type', models.CharField(max_length=16, choices=[('singleline', 'Single line text'), ('multiline', 'Multi-line text'), ('email', 'Email'), ('number', 'Number'), ('url', 'URL'), ('checkbox', 'Checkbox'), ('checkboxes', 'Checkboxes'), ('dropdown', 'Drop down'), ('radio', 'Radio buttons'), ('date', 'Date'), ('datetime', 'Date/time')])),
+                ('required', models.BooleanField(default=True)),
+                ('choices', models.CharField(help_text='Comma separated list of choices. Only applicable in checkboxes, radio and dropdown.', max_length=512, blank=True)),
+                ('default_value', models.CharField(help_text='Default value. Comma separated values supported for checkboxes.', max_length=255, blank=True)),
+                ('help_text', models.CharField(max_length=255, blank=True)),
+                ('is_hidden', models.BooleanField(default=False, help_text='If set, this field will not be shown to the user, but its default value will be submitted with the form.')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
+            name='HideableFormPage',
+            fields=[
+                ('page_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('wagtailcore.page',),
+        ),
+        migrations.AddField(
+            model_name='hideableformfield',
+            name='page',
+            field=modelcluster.fields.ParentalKey(related_name='form_fields', to='tests.HideableFormPage'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='formfield',
+            name='choices',
+            field=models.CharField(help_text='Comma separated list of choices. Only applicable in checkboxes, radio and dropdown.', max_length=512, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='formfield',
+            name='default_value',
+            field=models.CharField(help_text='Default value. Comma separated values supported for checkboxes.', max_length=255, blank=True),
+        ),
+    ]

--- a/wagtail/tests/models.py
+++ b/wagtail/tests/models.py
@@ -15,7 +15,7 @@ from wagtail.wagtailcore.fields import RichTextField
 from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel, InlinePanel, PageChooserPanel
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 from wagtail.wagtaildocs.edit_handlers import DocumentChooserPanel
-from wagtail.wagtailforms.models import AbstractEmailForm, AbstractFormField
+from wagtail.wagtailforms.models import AbstractForm, AbstractEmailForm, AbstractFormField, AbstractHideableFormField
 from wagtail.wagtailsnippets.models import register_snippet
 from wagtail.wagtailsearch import index
 from wagtail.contrib.wagtailroutablepage.models import RoutablePage
@@ -314,6 +314,7 @@ EventIndex.content_panels = [
 class FormField(AbstractFormField):
     page = ParentalKey('FormPage', related_name='form_fields')
 
+
 class FormPage(AbstractEmailForm):
     pass
 
@@ -327,6 +328,18 @@ FormPage.content_panels = [
     ], "Email")
 ]
 
+
+class HideableFormField(AbstractHideableFormField):
+    page = ParentalKey('HideableFormPage', related_name='form_fields')
+
+
+class HideableFormPage(AbstractForm):
+    pass
+
+HideableFormPage.content_panels = [
+    FieldPanel('title', classname="full title"),
+    InlinePanel(FormPage, 'form_fields', label="Form fields"),
+]
 
 
 # Snippets

--- a/wagtail/wagtailforms/forms.py
+++ b/wagtail/wagtailforms/forms.py
@@ -81,7 +81,10 @@ class FormBuilder(object):
             options = self.get_field_options(field)
 
             if field.field_type in self.FIELD_TYPES:
-                formfields[field.clean_name] = self.FIELD_TYPES[field.field_type](self, field, options)
+                formfield = self.FIELD_TYPES[field.field_type](self, field, options)
+                if getattr(field, 'is_hidden', False) is True:
+                    formfield.widget = django.forms.widgets.HiddenInput()
+                formfields[field.clean_name] = formfield
             else:
                 raise Exception("Unrecognised field type: " + field.field_type)
 


### PR DESCRIPTION
This adds a new abstract base class `AbstractHideableFormField`, subclassing `AbstractFormField`.

It has an extra field `is_hidden`, with some validation to prevent silly combinations (such as being set to hidden and required, but with no default value).

Then in `wagtailforms.forms.FormBuilder.formfields` there's a new check for the `is_hidden` attribute, which will cause the widget to be `HiddenInput`, rather than the default.