### PR TITLE
Send the correct mime type when serving documents

### DIFF
--- a/wagtail/wagtaildocs/views/serve.py
+++ b/wagtail/wagtaildocs/views/serve.py
@@ -1,3 +1,5 @@
+import mimetypes
+
 from django.shortcuts import get_object_or_404
 from django.core.servers.basehttp import FileWrapper
 from django.http import HttpResponse
@@ -8,11 +10,16 @@ from wagtail.wagtaildocs.models import Document, document_served
 def serve(request, document_id, document_filename):
     doc = get_object_or_404(Document, id=document_id)
     wrapper = FileWrapper(doc.file)
-    response = HttpResponse(wrapper, content_type='application/octet-stream')
+    response = HttpResponse(wrapper, content_type=mimetypes.guess_type(doc.filename)[0])
 
-    # TODO: strip out weird characters like semicolons from the filename
-    # (there doesn't seem to be an official way of escaping them)
-    response['Content-Disposition'] = 'attachment; filename=%s' % doc.filename
+    # Make PDFs open in the browser where possible rather than save
+    if doc.file_extension == 'pdf':
+        response['Content-Disposition'] = 'filename=%s' % doc.filename
+    else:
+        # TODO: strip out weird characters like semicolons from the filename
+        # (there doesn't seem to be an official way of escaping them)
+        response['Content-Disposition'] = 'attachment; filename=%s' % doc.filename
+
     response['Content-Length'] = doc.file.size
 
     # Send document_served signal

--- a/wagtail/wagtaildocs/views/serve.py
+++ b/wagtail/wagtaildocs/views/serve.py
@@ -10,7 +10,11 @@ from wagtail.wagtaildocs.models import Document, document_served
 def serve(request, document_id, document_filename):
     doc = get_object_or_404(Document, id=document_id)
     wrapper = FileWrapper(doc.file)
-    response = HttpResponse(wrapper, content_type=mimetypes.guess_type(doc.filename)[0])
+    mimetype = mimetypes.guess_type(doc.filename)[0]
+    if mimetype:
+        response = HttpResponse(wrapper, content_type=mimetype)
+    else:
+        response = HttpResponse(wrapper, content_type='application/octet-stream')
 
     # Make PDFs open in the browser where possible rather than save
     if doc.file_extension == 'pdf':


### PR DESCRIPTION
...and for PDFs instruct the browser to display them.

For file formats such as PDFs and Images, the user's browser can usually display the downloaded file without asking the user to save it first. For this to happen, you need to send the correct content type e.g. 'application/pdf'. Python has a mimetypes module in stdlib which can guess these based on the filename. I use this and fall back to the generic 'application/octet-stream' if it cannot be guessed.

I have special cased PDF as not being an attachment as this seems to be what most of the clients at our company want to happen on their sites.