### PR TITLE
Allow file uploads in snippet forms

### DIFF
--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/create.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/create.html
@@ -6,7 +6,7 @@
     {% trans "New" as new_str %}
     {% include "wagtailadmin/shared/header.html" with title=new_str subtitle=snippet_type_name icon="snippet" %}
 
-    <form action="{% url 'wagtailsnippets_create' content_type.app_label content_type.model %}" method="POST">
+    <form action="{% url 'wagtailsnippets_create' content_type.app_label content_type.model %}" method="POST" enctype="multipart/form-data">
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
         

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
@@ -6,7 +6,7 @@
     {% trans "Editing" as editing_str %}
     {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=instance icon="snippet" usage_object=instance %}
 
-    <form action="{% url 'wagtailsnippets_edit' content_type.app_label content_type.model instance.id %}" method="POST">
+    <form action="{% url 'wagtailsnippets_edit' content_type.app_label content_type.model instance.id %}" method="POST" enctype="multipart/form-data">
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
 


### PR DESCRIPTION
I had a model registered as a snippet in Wagtail where one of the fields was something like this:

```python
file = models.FileField(upload_to='uploads')
```

When I tried to upload a file within Wagtail's admin interface, the file never got stored and associated with the model. I fixed the issue by changing the HTML templates of the forms to post their data as enctype="multipart/form-data".