### PR TITLE
Added new image operations

### DIFF
--- a/wagtail/wagtailimages/exceptions.py
+++ b/wagtail/wagtailimages/exceptions.py
@@ -1,0 +1,2 @@
+class InvalidFilterSpecError(ValueError):
+    pass

--- a/wagtail/wagtailimages/image_operations.py
+++ b/wagtail/wagtailimages/image_operations.py
@@ -147,6 +147,21 @@ class FillOperation(object):
 
         willow.resize(width, height)
 
+    def get_vary(self, image):
+        focal_point = image.get_focal_point()
+
+        if focal_point is not None:
+            focal_point_key = "%(x)d-%(y)d-%(width)dx%(height)d" % {
+                'x': int(focal_point.centroid_x),
+                'y': int(focal_point.centroid_y),
+                'width': int(focal_point.width),
+                'height': int(focal_point.height),
+            }
+        else:
+            focal_point_key = ''
+
+        return [focal_point_key]
+
 
 class MinMaxOperation(object):
     def __init__(self, method, size):

--- a/wagtail/wagtailimages/image_operations.py
+++ b/wagtail/wagtailimages/image_operations.py
@@ -56,7 +56,7 @@ class FillOperation(object):
             crop_min_height = crop_min_scale / crop_aspect_ratio
 
             # Sometimes, the focal point may be bigger than the image...
-            if not crop_min_scale > crop_max_scale:
+            if not crop_min_scale >= crop_max_scale:
                 # Calculate max crop closeness to prevent upscaling
                 max_crop_closeness = max(
                     1 - (self.width - crop_min_width) / (crop_max_width - crop_min_width),

--- a/wagtail/wagtailimages/image_operations.py
+++ b/wagtail/wagtailimages/image_operations.py
@@ -1,0 +1,225 @@
+from __future__ import division
+
+
+class DoNothingOperation(object):
+    def __init__(self, method):
+        pass
+
+    def run(self, willow, image):
+        pass
+
+
+class FillOperation(object):
+    def __init__(self, method, size, *extra):
+        # Get width and height
+        width_str, height_str = size.split('x')
+        self.width = int(width_str)
+        self.height = int(height_str)
+
+        # Crop closeness
+        self.crop_closeness = 0
+
+        for extra_part in extra:
+            if extra_part.startswith('c'):
+                self.crop_closeness = int(extra_part[1:])
+            else:
+                raise ValueError("Unrecognised filter spec part: %s" % extra_part)
+
+        # Divide it by 100 (as it's a percentage)
+        self.crop_closeness /= 100
+
+        # Clamp it
+        if self.crop_closeness > 1:
+            self.crop_closeness = 1
+
+    def run(self, willow, image):
+        image_width, image_height = willow.get_size()
+        focal_point = image.get_focal_point()
+
+        # Get crop aspect ratio
+        crop_aspect_ratio = self.width / self.height
+
+        # Get crop max
+        crop_max_scale = min(image_width, image_height * crop_aspect_ratio)
+        crop_max_width = crop_max_scale
+        crop_max_height = crop_max_scale / crop_aspect_ratio
+
+        # Initialise crop width and height to max
+        crop_width = crop_max_width
+        crop_height = crop_max_height
+
+        # Use crop closeness to zoom in
+        if focal_point is not None:
+            # Get crop min
+            crop_min_scale = max(focal_point.width, focal_point.height * crop_aspect_ratio)
+            crop_min_width = crop_min_scale
+            crop_min_height = crop_min_scale / crop_aspect_ratio
+
+            # Sometimes, the focal point may be bigger than the image...
+            if not crop_min_scale > crop_max_scale:
+                # Calculate max crop closeness to prevent upscaling
+                max_crop_closeness = max(
+                    1 - (self.width - crop_min_width) / (crop_max_width - crop_min_width),
+                    1 - (self.height - crop_min_height) / (crop_max_height - crop_min_height)
+                )
+
+                # Apply max crop closeness
+                crop_closeness = min(self.crop_closeness, max_crop_closeness)
+
+                if 1 >= crop_closeness >= 0:
+                    # Get crop width and height
+                    crop_width = crop_max_width + (crop_min_width - crop_max_width) * crop_closeness
+                    crop_height = crop_max_height + (crop_min_height - crop_max_height) * crop_closeness
+
+        # Find focal point UV
+        if focal_point is not None:
+            fp_x, fp_y = focal_point.centroid
+        else:
+            # Fall back to positioning in the centre
+            fp_x = image_width / 2
+            fp_y = image_height / 2
+
+        fp_u = fp_x / image_width
+        fp_v = fp_y / image_height
+
+        # Position crop box based on focal point UV
+        crop_x = fp_x - (fp_u - 0.5) * crop_width
+        crop_y = fp_y - (fp_v - 0.5) * crop_height
+
+        # Convert crop box into rect
+        left = crop_x - crop_width / 2
+        top = crop_y - crop_height / 2
+        right = crop_x + crop_width / 2
+        bottom = crop_y + crop_height / 2
+
+        # Make sure the entire focal point is in the crop box
+        if focal_point is not None:
+            if left > focal_point.left:
+                right -= left - focal_point.left
+                left = focal_point.left
+
+            if top > focal_point.top:
+                bottom -= top - focal_point.top
+                top = focal_point.top
+
+            if right < focal_point.right:
+                left += focal_point.right - right
+                right = focal_point.right
+
+            if bottom < focal_point.bottom:
+                top += focal_point.bottom - bottom
+                bottom = focal_point.bottom
+
+        # Don't allow the crop box to go over the image boundary
+        if left < 0:
+            right -= left
+            left = 0
+
+        if top < 0:
+            bottom -= top
+            top = 0
+
+        if right > image_width:
+            left -= right - image_width
+            right = image_width
+
+        if bottom > image_height:
+            top -= bottom - image_height
+            bottom = image_height
+
+        # Crop!
+        willow.crop(int(left), int(top), int(right), int(bottom))
+
+        # Resize the final image
+        aftercrop_width, aftercrop_height = willow.get_size()
+        horz_scale = self.width / aftercrop_width
+        vert_scale = self.height / aftercrop_height
+
+        if aftercrop_width <= self.width or aftercrop_height <= self.height:
+            return
+
+        if horz_scale > vert_scale:
+            width = self.width
+            height = int(aftercrop_height * horz_scale)
+        else:
+            width = int(aftercrop_width * vert_scale)
+            height = self.height
+
+        willow.resize(width, height)
+
+
+class MinMaxOperation(object):
+    def __init__(self, method, size):
+        self.method = method
+
+        # Get width and height
+        width_str, height_str = size.split('x')
+        self.width = int(width_str)
+        self.height = int(height_str)
+
+    def run(self, willow, image):
+        image_width, image_height = willow.get_size()
+
+        horz_scale = self.width / image_width
+        vert_scale = self.height / image_height
+
+        if self.method == 'min':
+            if image_width <= self.width or image_height <= self.height:
+                return
+
+            if horz_scale > vert_scale:
+                width = self.width
+                height = int(image_height * horz_scale)
+            else:
+                width = int(image_width * vert_scale)
+                height = self.height
+
+        elif self.method == 'max':
+            if image_width <= self.width and image_height <= self.height:
+                return
+
+            if horz_scale < vert_scale:
+                width = self.width
+                height = int(image_height * horz_scale)
+            else:
+                width = int(image_width * vert_scale)
+                height = self.height
+
+        else:
+            # Unknown method
+            return
+
+        willow.resize(width, height)
+
+
+class WidthHeightOperation(object):
+    def __init__(self, method, size):
+        self.method = method
+        self.size = int(size)
+
+    def run(self, willow, image):
+        image_width, image_height = willow.get_size()
+
+        if self.method == 'width':
+            if image_width <= self.size:
+                return
+
+            scale = self.size / image_width
+
+            width = self.size
+            height = int(image_height * scale)
+
+        elif self.method == 'height':
+            if image_height <= self.size:
+                return
+
+            scale = self.size / image_height
+
+            width = int(image_width * scale)
+            height = self.size
+
+        else:
+            # Unknown method
+            return
+
+        willow.resize(width, height)

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -1,4 +1,5 @@
 import os.path
+import hashlib
 import re
 
 from six import BytesIO, text_type
@@ -427,6 +428,22 @@ class Filter(models.Model):
         willow.save_as_jpeg(output)
 
         return output
+
+    def get_vary(self, image):
+        vary = []
+
+        for operation in self.operations:
+            if hasattr(operation, 'get_vary'):
+                vary.extend(operation.get_vary(image))
+
+        return vary
+
+    def get_vary_key(self, image):
+        vary_string = '-'.join(self.get_vary(image))
+        vary_key = hashlib.sha1(vary_string.encode('utf-8')).hexdigest()
+
+        return vary_key[:8]
+
 
     _registered_operations = None
 

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -28,6 +28,7 @@ from wagtail.wagtailimages.backends import get_image_backend
 from wagtail.wagtailsearch import index
 from wagtail.wagtailimages.feature_detection import FeatureDetector, opencv_available
 from wagtail.wagtailimages.rect import Rect
+from wagtail.wagtailimages.exceptions import InvalidFilterSpecError
 from wagtail.wagtailadmin.utils import get_object_usage
 
 
@@ -414,6 +415,10 @@ class Filter(models.Model):
         operations = []
         for op_spec in self.spec.split():
             op_spec_parts = op_spec.split('-')
+
+            if op_spec_parts[0] not in self._registered_operations:
+                raise InvalidFilterSpecError("Unrecognised operation: %s" % op_spec_parts[0])
+
             op_class = self._registered_operations[op_spec_parts[0]]
             operations.append(op_class(*op_spec_parts))
 

--- a/wagtail/wagtailimages/tests/test_image_operations.py
+++ b/wagtail/wagtailimages/tests/test_image_operations.py
@@ -1,6 +1,7 @@
 import unittest
 
 from wagtail.wagtailimages import image_operations
+from wagtail.wagtailimages.exceptions import InvalidFilterSpecError
 from wagtail.wagtailimages.models import Image
 
 
@@ -52,11 +53,11 @@ class ImageOperationTestCase(unittest.TestCase):
         return test_filter_spec
 
     @classmethod
-    def make_filter_spec_error_test(cls, filter_spec, expected_exception):
+    def make_filter_spec_error_test(cls, filter_spec):
         def test_filter_spec_error(self):
-            self.assertRaises(expected_exception, self.operation_class, *filter_spec.split('-'))
+            self.assertRaises(InvalidFilterSpecError, self.operation_class, *filter_spec.split('-'))
 
-        test_name = 'test_filter_%s_raises_%s' % (filter_spec, expected_exception.__name__)
+        test_name = 'test_filter_%s_raises_%s' % (filter_spec, InvalidFilterSpecError.__name__)
         test_filter_spec_error.__name__ = test_name
         return test_filter_spec_error
 
@@ -90,8 +91,8 @@ class ImageOperationTestCase(unittest.TestCase):
             setattr(cls, filter_spec_test.__name__, filter_spec_test)
 
         # Filter spec error tests
-        for args in cls.filter_spec_error_tests:
-            filter_spec_error_test = cls.make_filter_spec_error_test(*args)
+        for filter_spec in cls.filter_spec_error_tests:
+            filter_spec_error_test = cls.make_filter_spec_error_test(filter_spec)
             setattr(cls, filter_spec_error_test.__name__, filter_spec_error_test)
 
         # Running tests
@@ -110,7 +111,7 @@ class TestDoNothingOperation(ImageOperationTestCase):
     ]
 
     filter_spec_error_tests = [
-        ('cannot-take-multiple-parameters', TypeError),
+        'cannot-take-multiple-parameters',
     ]
 
     run_tests = [
@@ -134,13 +135,13 @@ class TestFillOperation(ImageOperationTestCase):
     ]
 
     filter_spec_error_tests = [
-        ('fill', TypeError),
-        ('fill-800', ValueError),
-        ('fill-abc', ValueError),
-        ('fill-800xabc', ValueError),
-        ('fill-800x600-', ValueError),
-        ('fill-800x600x10', ValueError),
-        ('fill-800x600-d100', ValueError),
+        'fill',
+        'fill-800',
+        'fill-abc',
+        'fill-800xabc',
+        'fill-800x600-',
+        'fill-800x600x10',
+        'fill-800x600-d100',
     ]
 
     run_tests = [
@@ -265,14 +266,14 @@ class TestMinMaxOperation(ImageOperationTestCase):
     ]
 
     filter_spec_error_tests = [
-        ('min', TypeError),
-        #('hello-800x600', ValueError),
-        ('min-800', ValueError),
-        ('min-abc', ValueError),
-        ('min-800xabc', ValueError),
-        ('min-800x600-', TypeError),
-        ('min-800x600-c100', TypeError),
-        ('min-800x600x10', ValueError),
+        'min',
+        #'hello-800x600',
+        'min-800',
+        'min-abc',
+        'min-800xabc',
+        'min-800x600-',
+        'min-800x600-c100',
+        'min-800x600x10',
     ]
 
     run_tests = [
@@ -298,11 +299,11 @@ class TestWidthHeightOperation(ImageOperationTestCase):
     ]
 
     filter_spec_error_tests = [
-        ('width', TypeError),
-        #('hello-800', ValueError),
-        ('width-800x600', ValueError),
-        ('width-abc', ValueError),
-        ('width-800-c100', TypeError),
+        'width',
+        #'hello-800',
+        'width-800x600',
+        'width-abc',
+        'width-800-c100',
     ]
 
     run_tests = [

--- a/wagtail/wagtailimages/tests/test_image_operations.py
+++ b/wagtail/wagtailimages/tests/test_image_operations.py
@@ -1,0 +1,128 @@
+import unittest
+from wagtail.wagtailimages import image_operations
+
+
+class ImageOperationTestCase(unittest.TestCase):
+    operation_class = None
+    filter_spec_tests = []
+    filter_spec_error_tests = []
+
+    @classmethod
+    def make_filter_spec_test(cls, filter_spec, expected_output):
+        def test_filter_spec(self):
+            operation = self.operation_class(*filter_spec.split('-'))
+
+            # Check the attributes are set correctly
+            for attr, value in expected_output.items():
+                self.assertEqual(getattr(operation, attr), value)
+
+        test_name = 'test_filter_%s' % filter_spec
+        test_filter_spec.__name__ = test_name
+        return test_filter_spec
+
+    @classmethod
+    def make_filter_spec_error_test(cls, filter_spec, expected_exception):
+        def test_filter_spec_error(self):
+            self.assertRaises(expected_exception, self.operation_class, *filter_spec.split('-'))
+
+        test_name = 'test_filter_%s_raises_%s' % (filter_spec, expected_exception.__name__)
+        test_filter_spec_error.__name__ = test_name
+        return test_filter_spec_error
+ 
+    @classmethod
+    def setup_test_methods(cls):
+        if cls.operation_class is None:
+            return
+
+        # Filter spec tests
+        for filter_spec, expected_output in cls.filter_spec_tests:
+            filter_spec_test = cls.make_filter_spec_test(filter_spec, expected_output)
+            setattr(cls, filter_spec_test.__name__, filter_spec_test)
+
+        # Filter spec error tests
+        for filter_spec, expected_exception in cls.filter_spec_error_tests:
+            filter_spec_error_test = cls.make_filter_spec_error_test(filter_spec, expected_exception)
+            setattr(cls, filter_spec_error_test.__name__, filter_spec_error_test)
+
+
+class TestDoNothingOperation(ImageOperationTestCase):
+    operation_class = image_operations.DoNothingOperation
+
+    filter_spec_tests = [
+        ('original', dict()),
+        ('blahblahblah', dict()),
+        ('123456', dict()),
+    ]
+
+    filter_spec_error_tests = [
+        ('cannot-take-multiple-parameters', TypeError),
+    ]
+
+TestDoNothingOperation.setup_test_methods()
+
+
+class TestFillOperation(ImageOperationTestCase):
+    operation_class = image_operations.FillOperation
+
+    filter_spec_tests = [
+        ('fill-800x600', dict(width=800, height=600, crop_closeness=0)),
+        ('hello-800x600', dict(width=800, height=600, crop_closeness=0)),
+        ('fill-800x600-c0', dict(width=800, height=600, crop_closeness=0)),
+        ('fill-800x600-c100', dict(width=800, height=600, crop_closeness=1)),
+        ('fill-800x600-c50', dict(width=800, height=600, crop_closeness=0.5)),
+        ('fill-800x600-c1000', dict(width=800, height=600, crop_closeness=1)),
+        ('fill-800000x100', dict(width=800000, height=100, crop_closeness=0)),
+    ]
+
+    filter_spec_error_tests = [
+        ('fill', TypeError),
+        ('fill-800', ValueError),
+        ('fill-abc', ValueError),
+        ('fill-800xabc', ValueError),
+        ('fill-800x600-', ValueError),
+        ('fill-800x600x10', ValueError),
+        ('fill-800x600-d100', ValueError),
+    ]
+
+TestFillOperation.setup_test_methods()
+
+
+class TestMinMaxOperation(ImageOperationTestCase):
+    operation_class = image_operations.MinMaxOperation
+
+    filter_spec_tests = [
+        ('min-800x600', dict(method='min', width=800, height=600)),
+        ('max-800x600', dict(method='max', width=800, height=600)),
+    ]
+
+    filter_spec_error_tests = [
+        ('min', TypeError),
+        #('hello-800x600', ValueError),
+        ('min-800', ValueError),
+        ('min-abc', ValueError),
+        ('min-800xabc', ValueError),
+        ('min-800x600-', TypeError),
+        ('min-800x600-c100', TypeError),
+        ('min-800x600x10', ValueError),
+    ]
+
+TestMinMaxOperation.setup_test_methods()
+
+
+class TestWidthHeightOperation(ImageOperationTestCase):
+    operation_class = image_operations.WidthHeightOperation
+
+    filter_spec_tests = [
+        ('width-800', dict(method='width', size=800)),
+        ('height-600', dict(method='height', size=600)),
+    ]
+
+    filter_spec_error_tests = [
+        ('width', TypeError),
+        #('hello-800', ValueError),
+        ('width-800x600', ValueError),
+        ('width-abc', ValueError),
+        ('width-800-c100', TypeError),
+    ]
+
+TestWidthHeightOperation.setup_test_methods()

--- a/wagtail/wagtailimages/wagtail_hooks.py
+++ b/wagtail/wagtailimages/wagtail_hooks.py
@@ -10,7 +10,7 @@ from django.contrib.contenttypes.models import ContentType
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailadmin.menu import MenuItem
 
-from wagtail.wagtailimages import admin_urls
+from wagtail.wagtailimages import admin_urls, image_operations
 
 
 @hooks.register('register_admin_urls')
@@ -96,3 +96,15 @@ def register_permissions():
     image_content_type = ContentType.objects.get(app_label='wagtailimages', model='image')
     image_permissions = Permission.objects.filter(content_type = image_content_type)
     return image_permissions
+
+
+@hooks.register('register_image_operations')
+def register_image_operations():
+    return [
+        ('original', image_operations.DoNothingOperation),
+        ('fill', image_operations.FillOperation),
+        ('min', image_operations.MinMaxOperation),
+        ('max', image_operations.MinMaxOperation),
+        ('width', image_operations.WidthHeightOperation),
+        ('height', image_operations.WidthHeightOperation),
+    ]


### PR DESCRIPTION
This PR rewrites all of Wagtails image operations (``fill``, ``max``, etc) in a new format and adds code to Filter to load/parse/run the new operations.

This doesn't remove any old code and the new code doesn't get used yet (you must access it through the shell). I did this to keep this PR small and easy to review, but it should not be merged without merging later PRs as well.

The new format is intended to be more readable, testable and extensible than what we've already got. It's also making use of Willow.