### PR TITLE
[WIP] Added greyscale/blur image operations

### DIFF
--- a/wagtail/wagtailimages/image_operations.py
+++ b/wagtail/wagtailimages/image_operations.py
@@ -281,16 +281,59 @@ class BlurOperation(object):
         willow.blur(self.radius)
 
 
+class MonochromeOperation(object):
+    def __init__(self, method):
+        pass
+
+    def run(self, willow, image):
+        willow.monochrome()
+
+
+def parse_colour(self, colour_string):
+    if len(colour_string) == 3:
+        return (
+            int(colour_string[0], 16) * 16,
+            int(colour_string[1], 16) * 16,
+            int(colour_string[2], 16) * 16,
+        )
+    elif len(colour_string) == 6:
+        return (
+            int(colour_string[0:1], 16),
+            int(colour_string[2:3], 16),
+            int(colour_string[4:5], 16),
+        )
+    else:
+        raise ValueError("Invalid length of colour (must be 3 or 6 characters long): %s" % colour_string)
+
+
+class ColorizeOperation(object):
+    def __init__(self, method, black, white):
+        self.black = parse_colour(black)
+        self.white = parse_colour(white)
+
+    def run(self, willow, image):
+        willow.colorize(self.black, self.white)
+
 
 from willow.backends.pillow import PillowBackend
-from PIL import ImageFilter
+from PIL import ImageFilter, ImageOps
 
 
 @PillowBackend.register_operation('grayscale')
 def pillow_grayscale(backend):
-    backend.image = backend.image.convert('LA').convert('RGBA')
+    backend.image = backend.image.convert('L')
 
 
 @PillowBackend.register_operation('blur')
 def pillow_blur(backend, radius):
     backend.image = backend.image.filter(ImageFilter.GaussianBlur(radius))
+
+
+@PillowBackend.register_operation('monochrome')
+def pillow_monochrome(backend):
+    backend.image = backend.image.convert('1')
+
+
+@PillowBackend.register_operation('colorize')
+def pillow_colorize(backend, black, white):
+    backend.image = ImageOps.colorize(backend.image.convert('L'), black, white)

--- a/wagtail/wagtailimages/image_operations.py
+++ b/wagtail/wagtailimages/image_operations.py
@@ -263,3 +263,34 @@ class WidthHeightOperation(Operation):
             return
 
         willow.resize(width, height)
+
+
+class GrayscaleOperation(object):
+    def __init__(self, method):
+        pass
+
+    def run(self, willow, image):
+        willow.grayscale()
+
+
+class BlurOperation(object):
+    def __init__(self, method, radius):
+        self.radius = int(radius)
+
+    def run(self, willow, image):
+        willow.blur(self.radius)
+
+
+
+from willow.backends.pillow import PillowBackend
+from PIL import ImageFilter
+
+
+@PillowBackend.register_operation('grayscale')
+def pillow_grayscale(backend):
+    backend.image = backend.image.convert('LA').convert('RGBA')
+
+
+@PillowBackend.register_operation('blur')
+def pillow_blur(backend, radius):
+    backend.image = backend.image.filter(ImageFilter.GaussianBlur(radius))

--- a/wagtail/wagtailimages/templatetags/wagtailimages_tags.py
+++ b/wagtail/wagtailimages/templatetags/wagtailimages_tags.py
@@ -12,7 +12,7 @@ filters = {}
 def image(parser, token):
     bits = token.split_contents()[1:]
     image_var = bits[0]
-    filter_spec = bits[1]
+    filter_spec = bits[1].strip('\"')
     bits = bits[2:]
 
     if len(bits) == 2 and bits[0] == 'as':

--- a/wagtail/wagtailimages/wagtail_hooks.py
+++ b/wagtail/wagtailimages/wagtail_hooks.py
@@ -109,4 +109,6 @@ def register_image_operations():
         ('height', image_operations.WidthHeightOperation),
         ('grayscale', image_operations.GrayscaleOperation),
         ('blur', image_operations.BlurOperation),
+        ('monochrome', image_operations.MonochromeOperation),
+        ('colorize', image_operations.ColorizeOperation),
     ]

--- a/wagtail/wagtailimages/wagtail_hooks.py
+++ b/wagtail/wagtailimages/wagtail_hooks.py
@@ -107,4 +107,6 @@ def register_image_operations():
         ('max', image_operations.MinMaxOperation),
         ('width', image_operations.WidthHeightOperation),
         ('height', image_operations.WidthHeightOperation),
+        ('grayscale', image_operations.GrayscaleOperation),
+        ('blur', image_operations.BlurOperation),
     ]


### PR DESCRIPTION
This pull request makes it possible to convert an image to greyscale and add a Gaussian blur effect from within the filter spec string.

Syntax: ``fill-100x100 grayscale blur-10``

The blur filter takes a single parameter which is the radius in pixels. grayscale takes no parameters

TODO:
 - [ ] Move Willow operations into Willow