### PR TITLE
Make search view accept "page" GET parameter

### DIFF
--- a/wagtail/wagtailsearch/tests/test_frontend.py
+++ b/wagtail/wagtailsearch/tests/test_frontend.py
@@ -1,25 +1,120 @@
 from django.test import TestCase
+from django.core.urlresolvers import reverse
+from django.core import paginator
+
+from wagtail.wagtailcore.models import Page
+from wagtail.wagtailsearch.models import Query
+
+from wagtail.tests.models import EventPage
 
 
 class TestSearchView(TestCase):
-    def get(self, params={}):
-        return self.client.get('/search/', params)
+    fixtures = ['test.json']
 
-    def test_simple(self):
-        response = self.get()
+    def test_get(self):
+        response = self.client.get(reverse('wagtailsearch_search'))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailsearch/search_results.html')
 
-    def test_search(self):
-        response = self.get({'q': "Hello"})
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context['query_string'], "Hello")
+        # Check that search_results/query are set to None
+        self.assertIsNone(response.context['search_results'])
+        self.assertIsNone(response.context['query'])
 
-    def test_pagination(self):
-        pages = ['0', '1', '-1', '9999', 'Not a page']
-        for page in pages:
-            response = self.get({'p': page})
-            self.assertEqual(response.status_code, 200)
+    def test_search(self):
+        response = self.client.get(reverse('wagtailsearch_search') + '?q=Christmas')
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailsearch/search_results.html')
+        self.assertEqual(response.context['query_string'], "Christmas")
+
+        # Check that search_results is an instance of paginator.Page
+        self.assertIsInstance(response.context['search_results'], paginator.Page)
+
+        # Check that the christmas page was in the results (and is the only result)
+        search_results = response.context['search_results'].object_list
+        christmas_event_page = Page.objects.get(url_path='/home/events/christmas/')
+        self.assertEqual(list(search_results), [christmas_event_page])
+
+        # Check the query object
+        self.assertIsInstance(response.context['query'], Query)
+        query = response.context['query']
+        self.assertEqual(query.query_string, "christmas")
+
+    def pagination_test(test):
+        def wrapper(*args, **kwargs):
+            # Create some pages
+            event_index = Page.objects.get(url_path='/home/events/')
+            for i in range(100):
+                event = EventPage(
+                    title="Event " + str(i),
+                    slug='event-' + str(i),
+                    live=True,
+                )
+                event_index.add_child(instance=event)
+
+            return test(*args, **kwargs)
+
+        return wrapper
+
+    @pagination_test
+    def test_get_first_page(self):
+        response = self.client.get(reverse('wagtailsearch_search') + '?q=Event&page=1')
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailsearch/search_results.html')
+
+        # Test that we got the first page
+        search_results = response.context['search_results']
+        self.assertEqual(search_results.number, 1)
+
+    @pagination_test
+    def test_get_10th_page(self):
+        response = self.client.get(reverse('wagtailsearch_search') + '?q=Event&page=10')
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailsearch/search_results.html')
+
+        # Test that we got the tenth page
+        search_results = response.context['search_results']
+        self.assertEqual(search_results.number, 10)
+
+    @pagination_test
+    def test_get_invalid_page(self):
+        response = self.client.get(reverse('wagtailsearch_search') + '?q=Event&page=Not a Page')
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailsearch/search_results.html')
+
+        # Test that we got the first page
+        search_results = response.context['search_results']
+        self.assertEqual(search_results.number, 1)
+
+    @pagination_test
+    def test_get_out_of_range_page(self):
+        response = self.client.get(reverse('wagtailsearch_search') + '?q=Event&page=9999')
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailsearch/search_results.html')
+
+        # Test that we got the last page
+        search_results = response.context['search_results']
+        self.assertEqual(search_results.number, search_results.paginator.num_pages)
+
+    @pagination_test
+    def test_get_zero_page(self):
+        response = self.client.get(reverse('wagtailsearch_search') + '?q=Event&page=0')
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailsearch/search_results.html')
+
+        # Test that we got the first page
+        search_results = response.context['search_results']
+        self.assertEqual(search_results.number, search_results.paginator.num_pages)
+
+    @pagination_test
+    def test_get_10th_page_backwards_compatibility_with_p(self):
+        response = self.client.get(reverse('wagtailsearch_search') + '?q=Event&p=10')
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailsearch/search_results.html')
+
+        # Test that we got the tenth page
+        search_results = response.context['search_results']
+        self.assertEqual(search_results.number, 10)
+
 
 
 class TestSuggestionsView(TestCase):

--- a/wagtail/wagtailsearch/views/frontend.py
+++ b/wagtail/wagtailsearch/views/frontend.py
@@ -37,7 +37,7 @@ def search(
 
     # Get query string and page from GET paramters
     query_string = request.GET.get('q', '')
-    page = request.GET.get('p', 1)
+    page = request.GET.get('page', request.GET.get('p', 1))
 
     # Search
     if query_string != '':


### PR DESCRIPTION
Currently, the search view uses a GET parameter named "p" to indicate the page. This can sometimes be confusing as usually people use "page" for this. This pull request fixes this by allowing both "p" and "page" to specify the page number.

This PR also includes some test improvements.