### PR TITLE
Fixed bug that prevented sitemap generation override in a Page subclass

### DIFF
--- a/wagtail/contrib/wagtailsitemaps/sitemap_generator.py
+++ b/wagtail/contrib/wagtailsitemaps/sitemap_generator.py
@@ -12,7 +12,7 @@ class Sitemap(object):
 
     def get_urls(self):
         for page in self.get_pages():
-            for url in page.get_sitemap_urls():
+            for url in page.specific.get_sitemap_urls():
                 yield url
 
     def render(self):


### PR DESCRIPTION
If a developer wants to turn off urls for a specific page as documented in http://docs.wagtail.io/en/latest/contrib_components/sitemap_generation.html#customising they should be able to add:

    def get_sitemap_urls(self):
        return []

but get_urls() calls only the parent class rather than the specific child class. This bug is also mentioned in issue #833