### PR TITLE
Fixing preview

### DIFF
--- a/wagtail/wagtailadmin/static/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static/wagtailadmin/js/page-editor.js
@@ -341,45 +341,27 @@ $(function() {
 
     /* Set up behaviour of preview button */
     var previewWindow = null;
-    var previewOnloadRun = false;
-
     $('.action-preview').click(function(e) {
         e.preventDefault();
         var $this = $(this);
 
-        if(!previewWindow || previewWindow.closed){
-            previewOnloadRun = false;
-            previewWindow = window.open($this.data('placeholder'), $this.data('windowname'));
+        if(previewWindow){
+            previewWindow.close();
         }
+
+        previewWindow = window.open($this.data('placeholder'), $this.data('windowname'));
 
         if(/MSIE/.test(navigator.userAgent)){
             // If IE, load contents immediately without fancy effects
             submitPreview.call($this, false);
         } else {
-            // If not IE, check if the onload has already fired
-            if(!previewOnloadRun){
-                // This only runs once per new window creation
-                previewWindow.onload = function(){
-                    previewOnloadRun = true;
-                    submitPreview.call($this, true);
-                }
-            }else{
+            previewWindow.onload = function(){
                 submitPreview.call($this, true);
             }
         }
 
         function submitPreview(enhanced){
             var previewDoc = previewWindow.document;
-
-            // If onload already fired, make window appear like it's loading the content again
-            var spinner = previewDoc.getElementById('loading-spinner-wrapper');
-            previewWindow.focus();
-            
-            if(spinner){
-                spinner.className = spinner.className.replace('remove','');
-            }
-
-           
 
             $.ajax({
                 type: "POST",
@@ -396,7 +378,7 @@ $(function() {
                             frame.document.close();
 
                             var hideTimeout = setTimeout(function(){
-                                spinner.className += ' remove';
+                                previewDoc.getElementById('loading-spinner-wrapper').className += ' remove';;
                                 clearTimeout(hideTimeout);
                             }) // just enough to give effect without adding discernible slowness                       
                         } else {

--- a/wagtail/wagtailadmin/static/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static/wagtailadmin/js/page-editor.js
@@ -340,31 +340,55 @@ $(function() {
     });
 
     /* Set up behaviour of preview button */
+    var previewWindow = null;
+    var previewOnloadRun = false;
+
     $('.action-preview').click(function(e) {
         e.preventDefault();
         var $this = $(this);
 
-        var previewWindow = window.open($this.data('placeholder'), $this.data('windowname'));
-        
+        if(!previewWindow || previewWindow.closed){
+            previewOnloadRun = false;
+            previewWindow = window.open($this.data('placeholder'), $this.data('windowname'));
+        }
+
         if(/MSIE/.test(navigator.userAgent)){
+            // If IE, load contents immediately without fancy effects
             submitPreview.call($this, false);
         } else {
-            previewWindow.onload = function(){
+            // If not IE, check if the onload has already fired
+            if(!previewOnloadRun){
+                // This only runs once per new window creation
+                previewWindow.onload = function(){
+                    previewOnloadRun = true;
+                    submitPreview.call($this, true);
+                }
+            }else{
                 submitPreview.call($this, true);
             }
         }
 
         function submitPreview(enhanced){
+            var previewDoc = previewWindow.document;
+
+            // If onload already fired, make window appear like it's loading the content again
+            var spinner = previewDoc.getElementById('loading-spinner-wrapper');
+            previewWindow.focus();
+            
+            if(spinner){
+                spinner.className = spinner.className.replace('remove','');
+            }
+
+           
+
             $.ajax({
                 type: "POST",
                 url: $this.data('action'),
                 data: $('#page-edit-form').serialize(),
                 success: function(data, textStatus, request) {
                     if (request.getResponseHeader('X-Wagtail-Preview') == 'ok') {
-                        var pdoc = previewWindow.document;
-                        
                         if(enhanced){
-                            var frame = pdoc.getElementById('preview-frame');
+                            var frame = previewDoc.getElementById('preview-frame');
 
                             frame = frame.contentWindow || frame.contentDocument.document || frame.contentDocument;
                             frame.document.open();
@@ -372,14 +396,15 @@ $(function() {
                             frame.document.close();
 
                             var hideTimeout = setTimeout(function(){
-                                pdoc.getElementById('loading-spinner-wrapper').className += 'remove';
+                                spinner.className += ' remove';
                                 clearTimeout(hideTimeout);
                             }) // just enough to give effect without adding discernible slowness                       
                         } else {
-                            pdoc.open();
-                            pdoc.write(data);                 
-                            pdoc.close()
+                            previewDoc.open();
+                            previewDoc.write(data);                 
+                            previewDoc.close()
                         }
+
                     } else {
                         previewWindow.close();
                         document.open();
@@ -394,9 +419,9 @@ $(function() {
                     developers can debug template errors. (On a production site, we'd
                     typically be serving a friendly custom 500 page anyhow.) */
 
-                    previewWindow.document.open();
-                    previewWindow.document.write(xhr.responseText);
-                    previewWindow.document.close();
+                    previewDoc.open();
+                    previewDoc.write(xhr.responseText);
+                    previewDoc.close();
                 }
             });
 

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/layouts/preview.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/layouts/preview.scss
@@ -25,9 +25,9 @@ html,body {
     font-size:0em;
     z-index:999999;
     background:white;
-    @include transition(all 0.3s ease);
-
+    
     &.remove{
+        @include transition(all 0.3s ease);
         bottom:-100%;
     }
 


### PR DESCRIPTION
Addresses #659, where pressing preview having already pressed it once, caused the preview window to hang.

Firefox and IE don't allow you to re-raise a child window (`window.focus()`) without the user having explicitly allowed it with some setting in their browser. So even once I'd fixed the problem, it still meant previewing was clumsy as the user was required to press preview *then* click the tab. Not exactly fluid.

The best solution for usability is just to close any existing preview windows, then re-open them every time preview is clicked. That way the browser can focus it every time.