### PR TITLE
Fix for snippet sorting of models with capitalized verbose_name.

### DIFF
--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/index.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/index.html
@@ -13,7 +13,7 @@
                     <div class="row row-flush title">
                         <h2>
                             <a href="{% url 'wagtailsnippets_list' content_type.app_label content_type.model %}" class="col6">
-                                {{ name|capfirst }} 
+                                {{ name|capfirst }}
                             </a>
                         </h2>
                         <small class="col6">{{ description }}</small>

--- a/wagtail/wagtailsnippets/views/snippets.py
+++ b/wagtail/wagtailsnippets/views/snippets.py
@@ -82,7 +82,7 @@ def index(request):
         if user_can_edit_snippet_type(request.user, content_type)
     ]
     return render(request, 'wagtailsnippets/snippets/index.html', {
-        'snippet_types': snippet_types,
+        'snippet_types': sorted(snippet_types, key=lambda x: x[0].lower()),
     })
 
 


### PR DESCRIPTION
When a developer provided a `verbose_name` for one of his snippet models, and that verbose name started with a capital letter, it was being sorted before all the other snippets on the `/admin/snippets/` page. This is because the view code was assuming that all the snippets' model names were lower case, and then upper-casing their first letter in the index template.

This commit makes the Snippet index sort snippets case-insensitively.