### PR TITLE
get_image_form now takes model parameter

### DIFF
--- a/wagtail/wagtailimages/forms.py
+++ b/wagtail/wagtailimages/forms.py
@@ -2,7 +2,6 @@ from django import forms
 from django.forms.models import modelform_factory
 from django.utils.translation import ugettext as _
 
-from wagtail.wagtailimages.models import get_image_model
 from wagtail.wagtailimages.formats import get_image_formats
 from wagtail.wagtailimages.fields import WagtailImageField
 
@@ -17,9 +16,9 @@ def formfield_for_dbfield(db_field, **kwargs):
     return db_field.formfield(**kwargs)
 
 
-def get_image_form():
+def get_image_form(model):
     return modelform_factory(
-        get_image_model(),
+        model,
         formfield_callback=formfield_for_dbfield,
         # set the 'file' widget to a FileInput rather than the default ClearableFileInput
         # so that when editing, we don't get the 'currently: ...' banner which is

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -37,7 +37,7 @@ def chooser(request):
     Image = get_image_model()
 
     if request.user.has_perm('wagtailimages.add_image'):
-        ImageForm = get_image_form()
+        ImageForm = get_image_form(Image)
         uploadform = ImageForm()
     else:
         uploadform = None
@@ -113,7 +113,7 @@ def image_chosen(request, image_id):
 @permission_required('wagtailimages.add_image')
 def chooser_upload(request):
     Image = get_image_model()
-    ImageForm = get_image_form()
+    ImageForm = get_image_form(Image)
 
     searchform = SearchForm()
 

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -80,7 +80,7 @@ def index(request):
 @permission_required('wagtailadmin.access_admin')  # more specific permission tests are applied within the view
 def edit(request, image_id):
     Image = get_image_model()
-    ImageForm = get_image_form()
+    ImageForm = get_image_form(Image)
 
     image = get_object_or_404(Image, id=image_id)
 
@@ -217,8 +217,8 @@ def delete(request, image_id):
 
 @permission_required('wagtailimages.add_image')
 def add(request):
-    ImageForm = get_image_form()
     ImageModel = get_image_model()
+    ImageForm = get_image_form(ImageModel)
 
     if request.POST:
         image = ImageModel(uploaded_by_user=request.user)

--- a/wagtail/wagtailimages/views/multiple.py
+++ b/wagtail/wagtailimages/views/multiple.py
@@ -29,14 +29,13 @@ def json_response(document):
     return HttpResponse(json.dumps(document), content_type='application/json')
 
 
-def get_image_edit_form():
-    Image = get_image_model()
-    ImageForm = get_image_form()
+def get_image_edit_form(ImageModel):
+    ImageForm = get_image_form(ImageModel)
 
     # Make a new form with the file and focal point fields excluded
     class ImageEditForm(ImageForm):
         class Meta(ImageForm.Meta):
-            model = Image
+            model = ImageModel
             exclude = (
                 'file',
                 'focal_point_x',
@@ -52,7 +51,7 @@ def get_image_edit_form():
 @vary_on_headers('X-Requested-With')
 def add(request):
     Image = get_image_model()
-    ImageForm = get_image_form()
+    ImageForm = get_image_form(Image)
 
     if request.method == 'POST':
         if not request.is_ajax():
@@ -80,7 +79,7 @@ def add(request):
                 'image_id': int(image.id),
                 'form': render_to_string('wagtailimages/multiple/edit_form.html', {
                     'image': image,
-                    'form': get_image_edit_form()(instance=image, prefix='image-%d' % image.id),
+                    'form': get_image_edit_form(Image)(instance=image, prefix='image-%d' % image.id),
                 }, context_instance=RequestContext(request)),
             })
         else:
@@ -105,7 +104,7 @@ def add(request):
 @permission_required('wagtailadmin.access_admin')  # more specific permission tests are applied within the view
 def edit(request, image_id, callback=None):
     Image = get_image_model()
-    ImageForm = get_image_edit_form()
+    ImageForm = get_image_edit_form(Image)
 
     image = get_object_or_404(Image, id=image_id)
 


### PR DESCRIPTION
I've recently been working on a project that uses multiple image models.

Implementing this was surprisingly easier than I thought. I created a custom image model and copied the wagtailimages views folder into a new app (searching and replacing ``get_image_model()`` with my new model name). The chooser and ``{% image %}`` tag works as expected with both image models.

There was a little annoyance where the ``get_image_form`` function calls ``get_image_model`` internally requiring me to duplicate the forms.py module to fix this. Everywhere this function is called, the image model is already known so it's simply a case of passing that model through as a parameter.

This PR doesn't add support for multiple image models into Wagtail, just makes it slightly easier. Even though this isn't useful for most people, I think this gives a minor code-quality improvement for Wagtail.