### PR TITLE
Fixed icon-spinner in Chrome. Fixed Styleguide icon listing.

### DIFF
--- a/wagtail/contrib/wagtailstyleguide/static/wagtailstyleguide/scss/styleguide.scss
+++ b/wagtail/contrib/wagtailstyleguide/static/wagtailstyleguide/scss/styleguide.scss
@@ -92,12 +92,6 @@ section{
     li{
         margin-bottom:1em;
     }
-    .spinner{
-        position:relative;
-    }
-    .icon-spinner:after{
-        position:absolute;
-    }
 }
 
 .timepicker{

--- a/wagtail/contrib/wagtailstyleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/wagtailstyleguide/templates/wagtailstyleguide/base.html
@@ -501,7 +501,7 @@
                 <li class="icon icon-order-down">order-down</li>
                 <li class="icon icon-order-up">order-up</li>
                 <li class="icon icon-bin">bin</li>
-                <li class="spinner"><div class="icon icon-spinner">spinner</div> spinner</li>
+                <li class="icon icon-spinner">spinner</li>
                 <li class="icon icon-pick">pick</li>
                 <li class="icon icon-redirect">redirect</li>
                 <li class="icon icon-view">view</li>

--- a/wagtail/contrib/wagtailstyleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/wagtailstyleguide/templates/wagtailstyleguide/base.html
@@ -501,7 +501,7 @@
                 <li class="icon icon-order-down">order-down</li>
                 <li class="icon icon-order-up">order-up</li>
                 <li class="icon icon-bin">bin</li>
-                <li class="icon icon-spinner">spinner</li>
+                <li><span class="icon icon-spinner"></span>spinner</li>
                 <li class="icon icon-pick">pick</li>
                 <li class="icon icon-redirect">redirect</li>
                 <li class="icon icon-view">view</li>

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/components/icons.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/components/icons.scss
@@ -207,7 +207,9 @@
 .icon-bin:before{
     content:"Z";
 }
-.icon-spinner:before{
+/* Spinners, unlike other icons, are placed in :after so that they can
+ * be applied to the same element as another icon. */
+.icon-spinner:after{
     width:1em;
     animation: spin 0.5s infinite linear;
     -webkit-animation: spin 0.5s infinite linear;

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/components/icons.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/components/icons.scss
@@ -207,7 +207,7 @@
 .icon-bin:before{
     content:"Z";
 }
-.icon-spinner:after{
+.icon-spinner:before{
     width:1em;
     animation: spin 0.5s infinite linear;
     -webkit-animation: spin 0.5s infinite linear;

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/components/icons.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/components/icons.scss
@@ -213,6 +213,7 @@
     -webkit-animation: spin 0.5s infinite linear;
     -moz-animation: spin 0.5s infinite linear;
     content:"1";
+    display: inline-block;
 }
 .icon-pick:before{
     content:"2";


### PR DESCRIPTION
All other icons place themselves in the :before pseudo-element, but `icon-spinner` was using :after for some reason. This broke it in Chrome (though not any other browsers), and also led to a kludge being put in place in the styleguide to handle that issue. A kludge that also minorly screwed up the icon listing in every browser.

This patch fixes both of those problems.