### PR TITLE
Admin modules

### DIFF
--- a/wagtail/wagtailadmin/modules/base.py
+++ b/wagtail/wagtailadmin/modules/base.py
@@ -1,0 +1,54 @@
+from functools import wraps
+
+from django.template.response import TemplateResponse
+
+from wagtail.utils.urlpatterns import decorate_urlpatterns
+
+
+class Module(object):
+    app_name = ''
+
+    def __init__(self, namespace, **kwargs):
+        self.namespace = namespace
+
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def has_module_permission(self, request):
+        return True
+
+    def get_urls(self):
+        return ()
+
+    def process_request(self, request):
+        # Add link to module to request object
+        request.module = self
+
+        # Add current_app to request object
+        request.current_app = self.namespace
+
+    def _wrap_view(self, view):
+        @wraps(view)
+        def wrapper(request, *args, **kwargs):
+            self.process_request(request)
+
+            return view(request, *args, **kwargs)
+
+        return wrapper
+
+    def _get_wrapped_urls(self):
+        urls = self.get_urls()
+        return decorate_urlpatterns(urls, self._wrap_view)
+
+    @property
+    def urls(self):
+        return self._get_wrapped_urls(), self.namespace, self.app_name
+
+
+# module_view decorator for function-based views
+def module_view(view):
+    @wraps(view)
+    def wrapper(request, *args, **kwargs):
+        return view(request.module, request, *args, **kwargs)
+
+    return wrapper

--- a/wagtail/wagtailadmin/tests/test_modules.py
+++ b/wagtail/wagtailadmin/tests/test_modules.py
@@ -1,0 +1,63 @@
+from django.test import TestCase
+from django.test.client import RequestFactory
+from django.core.urlresolvers import resolve
+from django.conf.urls import url
+
+from wagtail.wagtailadmin.modules.base import Module, module_view
+
+
+class TestBaseModule(TestCase):
+    def test_init(self):
+        module = Module('modulename', testattr="Hello world!")
+
+        self.assertEqual(module.namespace, "modulename")
+        self.assertEqual(module.testattr, "Hello world!")
+
+    def test_has_module_permission(self):
+        module = Module('modulename')
+
+        request = RequestFactory().get('/')
+        self.assertTrue(module.has_module_permission(request))
+
+    def test_urls(self):
+        module = Module('modulename')
+
+        self.assertEqual(module.urls[1], 'modulename')
+        self.assertEqual(module.urls[2], '')
+
+    def test_request_module_attribute(self):
+        view_called = [False]
+        assertEqual = self.assertEqual
+
+        class MyModule(Module):
+            def test_view(self, request):
+                view_called[0] = True
+
+                # Module should be passed through on request object
+                assertEqual(request.module, module)
+
+            def get_urls(self):
+                return (
+                    url(r'^$', self.test_view, name='index'),
+                )
+
+        module = MyModule('test')
+        view, args, kwargs = resolve('/', module.urls[0])
+
+        request = RequestFactory().get('/')
+        view(request, *args, **kwargs)
+
+        self.assertTrue(view_called[0])
+
+
+class TestModuleViewDecorator(TestCase):
+    def test_module_view_decorator(self):
+        @module_view
+        def view(module, request, myarg, mykwarg=None):
+            self.assertEqual(module, "Module")
+            self.assertEqual(myarg, "Hello")
+            self.assertEqual(mykwarg, "World")
+
+        request = RequestFactory().get('/')
+        request.module = "Module"
+        view(request, "Hello", mykwarg="World")


### PR DESCRIPTION
Just looking for some early feedback on this little feature I've been working on. I think it would make changing and extending the wagtailadmin interface much easier for developers. I hope it would also cut out a tonne of repeated code as well.

The idea is to build the admin site up using "modules". These provide a url config and menu items for wagtail. Modules are all class based and are easy to subclass.

This also includes a basic implementation of ``ModelModule``. You can use this to create a section in the admin for any model in your project:

```python
from wagtail.wagtailadmin.modules.models import ModelModule
from .models import MyModel

@hooks.register('register_admin_urls')
def register_admin_urls():
    mymodule = ModelModule('mymodeladmin', model=MyModel)

    return [
        url(r'^mymodel/', include(mymodule.urls)),
    ]
```

Multiple instances of the same module class can exist in the same admin site. The URL names are namespaced using the first paramter to the constructor. For example, (with the above sample code) the URL for the view that creates a new instance of ``MyModel`` would be ``mymodeladmin:create``. When a module has been registered multiple times, it will make use of Djangos "reversing namespaced urls" behaviour: https://docs.djangoproject.com/en/1.7/topics/http/urls/#reversing-namespaced-urls

ModelModule can easily be subclassed and extended. See #890 for an example of that.