### PR TITLE
Fix false positive search results when model class does not index any database fields

### DIFF
--- a/wagtail/wagtailsearch/backends/db.py
+++ b/wagtail/wagtailsearch/backends/db.py
@@ -60,7 +60,11 @@ class DBSearchResults(BaseSearchResults):
         model = self.query.queryset.model
         q = self.query.get_q()
 
-        return model.objects.filter(q).distinct()[self.start:self.stop]
+        # Make sure there are values to filter on
+        if q.children:
+            return model.objects.filter(q).distinct()[self.start:self.stop]
+        else:
+            return model.objects.none()
 
     def _do_search(self):
         return self.get_queryset()


### PR DESCRIPTION
If the Q instance returned by DBSearchQuery.get_q() does not contain any child nodes, the filter method of the model's manager instance returns all of its model instances.  This may be an edge case - I found it while working with a model class that exclusively indexes properties rather than database fields.  I suppose this is a design decision - in these cases, is it better to return everything or nothing?