### PR TITLE
Add the page type to the page creator/editor template

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block titletag %}{% blocktrans with page_type=content_type.model_class.get_verbose_name %}New {{ page_type }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-explorer page-editor create {{ content_type.model }}{% endblock %}
+{% block bodyclass %}menu-explorer page-editor create model-{{ content_type.model }}{% endblock %}
 
 {% block content %}
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
@@ -17,7 +17,7 @@
         </div>
     </header>
 
-    <form id="page-edit-form" action="{% url 'wagtailadmin_pages_create' content_type.app_label content_type.model parent_page.id %}" method="POST">
+    <form id="page-edit-form" class="{{ content_type.model }}" action="{% url 'wagtailadmin_pages_create' content_type.app_label content_type.model parent_page.id %}" method="POST">
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block titletag %}{% blocktrans with page_type=content_type.model_class.get_verbose_name %}New {{ page_type }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-explorer page-editor create{% endblock %}
+{% block bodyclass %}menu-explorer page-editor create {{ content_type.model }}{% endblock %}
 
 {% block content %}
 
@@ -17,7 +17,7 @@
         </div>
     </header>
 
-    <form id="page-edit-form" class="{{ content_type.model }}" action="{% url 'wagtailadmin_pages_create' content_type.app_label content_type.model parent_page.id %}" method="POST">
+    <form id="page-edit-form" action="{% url 'wagtailadmin_pages_create' content_type.app_label content_type.model parent_page.id %}" method="POST">
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -3,7 +3,7 @@
 {% load gravatar %}
 {% load i18n %}
 {% block titletag %}{% blocktrans with title=page.title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }}: {{ title }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-explorer page-editor {{ content_type.model }}{% endblock %}
+{% block bodyclass %}menu-explorer page-editor model-{{ content_type.model }}{% endblock %}
 
 {% block content %}
     {% page_permissions page as page_perms %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -2,7 +2,7 @@
 {% load wagtailadmin_tags %}
 {% load gravatar %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with title=page.title %}Editing {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans with title=page.title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }}: {{ title }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}menu-explorer  page-editor{% endblock %}
 
 {% block content %}
@@ -12,7 +12,7 @@
 
         <div class="row row-flush">
             <div class="left col9">
-                <h1 class="icon icon-doc-empty-inverse">{% blocktrans with title=page.title %}Editing <span>{{ title }}</span>{% endblocktrans %}</h1>
+                <h1 class="icon icon-doc-empty-inverse">{% blocktrans with title=page.title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }} <span>{{ title }}</span>{% endblocktrans %}</h1>
             </div>
             <div class="right col3">
                 {% trans "Status" %}
@@ -28,7 +28,7 @@
         </div>
     </header>
 
-    <form id="page-edit-form" action="{% url 'wagtailadmin_pages_edit' page.id %}" method="POST">
+    <form id="page-edit-form" class="{{ content_type.model }}" action="{% url 'wagtailadmin_pages_edit' page.id %}" method="POST">
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -3,7 +3,7 @@
 {% load gravatar %}
 {% load i18n %}
 {% block titletag %}{% blocktrans with title=page.title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }}: {{ title }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-explorer  page-editor{% endblock %}
+{% block bodyclass %}menu-explorer page-editor {{ content_type.model }}{% endblock %}
 
 {% block content %}
     {% page_permissions page as page_perms %}
@@ -28,7 +28,7 @@
         </div>
     </header>
 
-    <form id="page-edit-form" class="{{ content_type.model }}" action="{% url 'wagtailadmin_pages_edit' page.id %}" method="POST">
+    <form id="page-edit-form" action="{% url 'wagtailadmin_pages_edit' page.id %}" method="POST">
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
 

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -255,6 +255,8 @@ def edit(request, page_id):
     page = get_object_or_404(Page, id=page_id).get_latest_revision_as_page()
     parent = page.get_parent()
 
+    content_type = ContentType.objects.get_for_model(page)
+
     page_perms = page.permissions_for_user(request.user)
     if not page_perms.can_edit():
         raise PermissionDenied
@@ -373,6 +375,7 @@ def edit(request, page_id):
 
     return render(request, 'wagtailadmin/pages/edit.html', {
         'page': page,
+        'content_type': content_type,
         'edit_handler': edit_handler,
         'errors_debug': errors_debug,
         'preview_modes': page.preview_modes,


### PR DESCRIPTION
As mentioned in #749, the page editor is missing any and all indication of which type of page one is editing. This patch remedies this in two ways:

1. Adds a class (`content_type.model`'s string value) to the `<body>` element on both the create and edit templates, to allow javascript and css to identify the page type. I originally had it on the `<form>`, but realized that this would prevent site designers from styling the header differently per page type.
2. Includes the verbose name of the model in the `<title>` tag and header in the edit template (e.g. EDITING ARTICLE PAGE Page Title).
