### PR TITLE
Update form_builder.rst

### DIFF
--- a/docs/core_components/form_builder.rst
+++ b/docs/core_components/form_builder.rst
@@ -53,7 +53,7 @@ You now need to create two templates named form_page.html and form_page_landing.
 
 .. code:: html
 
-    {% load pageurl rich_text %}
+    {% load wagtailcore_tags %}
     <html>
         <head>
             <title>{{ self.title }}</title>


### PR DESCRIPTION
The old ```rich_text``` and ```pageurl``` tag libraries have been replaced by ```wagtailcore_tags``` according to [here](http://wagtail.readthedocs.org/en/latest/core_components/pages/writing_templates.html?highlight=pageurl#internal-links-tag) and [here](http://wagtail.readthedocs.org/en/latest/core_components/pages/writing_templates.html?highlight=rich_text#rich-text-filter).