### PR TITLE
Admin url fixes

### DIFF
--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -143,7 +143,6 @@ TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
 
 # Wagtail settings
 
-LOGIN_URL = 'wagtailadmin_login'
 LOGIN_REDIRECT_URL = 'wagtailadmin_home'
 
 WAGTAIL_SITE_NAME = "{{ project_name }}"

--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -143,8 +143,6 @@ TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
 
 # Wagtail settings
 
-LOGIN_REDIRECT_URL = 'wagtailadmin_home'
-
 WAGTAIL_SITE_NAME = "{{ project_name }}"
 
 # Use Elasticsearch as the search backend for extra performance and better search results:

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -102,9 +102,6 @@ PASSWORD_HASHERS = (
 
 COMPRESS_ENABLED = False  # disable compression so that we can run tests on the content of the compress tag
 
-LOGIN_REDIRECT_URL = 'wagtailadmin_home'
-LOGIN_URL = 'wagtailadmin_login'
-
 
 WAGTAILSEARCH_BACKENDS = {
     'default': {

--- a/wagtail/utils/urlpatterns.py
+++ b/wagtail/utils/urlpatterns.py
@@ -1,0 +1,9 @@
+def decorate_urlpatterns(urlpatterns, decorator):
+    for pattern in urlpatterns:
+        if hasattr(pattern, 'url_patterns'):
+            decorate_urlpatterns(pattern.url_patterns, decorator)
+
+        if hasattr(pattern, '_callback'):
+            pattern._callback = decorator(pattern.callback)
+
+    return urlpatterns

--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/email.txt
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/email.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 {% trans "Please follow the link below to reset your password" %}
-{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+{{ protocol }}://{{ domain }}{% url 'wagtailadmin_password_reset_confirm' uidb64=uid token=token %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/login.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/login.html
@@ -43,7 +43,7 @@
                         </div>
                     </div>
                     {% if show_password_reset %}
-                        <p class="help"><a href="{% url 'django.contrib.auth.views.password_reset' %}">{% trans "Forgotten it?" %}</a></p>
+                        <p class="help"><a href="{% url 'wagtailadmin_password_reset' %}">{% trans "Forgotten it?" %}</a></p>
                     {% endif %}
                 </li>
                 {% comment %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/login.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/login.html
@@ -22,7 +22,10 @@
 
         <form action="{% url 'wagtailadmin_login' %}" method="post" autocomplete="off">
             {% csrf_token %}
-            <input type="hidden" name="next" value="{{ next }}" />
+
+            {% url 'wagtailadmin_home' as home_url %}
+            <input type="hidden" name="next" value="{{ next|default:home_url }}" />
+
             <h1>{% trans "Sign in to Wagtail" %}</h1>
 
           

--- a/wagtail/wagtailadmin/tests/test_account_management.py
+++ b/wagtail/wagtailadmin/tests/test_account_management.py
@@ -35,11 +35,13 @@ class TestAuthentication(TestCase, WagtailTestUtils):
         user = get_user_model().objects.create_superuser(username='test', email='test@email.com', password='password')
 
         # Post credentials to the login page
-        post_data = {
+        response = self.client.post(reverse('wagtailadmin_login'), {
             'username': 'test',
             'password': 'password',
-        }
-        response = self.client.post(reverse('wagtailadmin_login'), post_data)
+
+            # NOTE: This is set using a hidden field in reality
+            'next': reverse('wagtailadmin_home'),
+        })
 
         # Check that the user was redirected to the dashboard
         self.assertRedirects(response, reverse('wagtailadmin_home'))

--- a/wagtail/wagtailadmin/tests/test_account_management.py
+++ b/wagtail/wagtailadmin/tests/test_account_management.py
@@ -299,7 +299,7 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
         This tests that the password reset view returns a password reset page
         """
         # Get password reset page
-        response = self.client.get(reverse('password_reset'))
+        response = self.client.get(reverse('wagtailadmin_password_reset'))
 
         # Check that the user recieved a password reset page
         self.assertEqual(response.status_code, 200)
@@ -314,10 +314,10 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
         post_data = {
             'email': 'test@email.com',
         }
-        response = self.client.post(reverse('password_reset'), post_data)
+        response = self.client.post(reverse('wagtailadmin_password_reset'), post_data)
 
         # Check that the user was redirected to the done page
-        self.assertRedirects(response, reverse('password_reset_done'))
+        self.assertRedirects(response, reverse('wagtailadmin_password_reset_done'))
 
         # Check that a password reset email was sent to the user
         self.assertEqual(len(mail.outbox), 1)
@@ -332,7 +332,7 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
         post_data = {
             'email': 'unknown@email.com',
         }
-        response = self.client.post(reverse('password_reset'), post_data)
+        response = self.client.post(reverse('wagtailadmin_password_reset'), post_data)
 
         # Check that the user wasn't redirected
         self.assertEqual(response.status_code, 200)
@@ -352,7 +352,7 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
         post_data = {
             'email': 'Hello world!',
         }
-        response = self.client.post(reverse('password_reset'), post_data)
+        response = self.client.post(reverse('wagtailadmin_password_reset'), post_data)
 
         # Check that the user wasn't redirected
         self.assertEqual(response.status_code, 200)
@@ -387,7 +387,7 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
         self.setup_password_reset_confirm_tests()
 
         # Get password reset confirm page
-        response = self.client.get(reverse('password_reset_confirm', kwargs=self.url_kwargs))
+        response = self.client.get(reverse('wagtailadmin_password_reset_confirm', kwargs=self.url_kwargs))
 
         # Check that the user recieved a password confirm done page
         self.assertEqual(response.status_code, 200)
@@ -405,10 +405,10 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
             'new_password1': 'newpassword',
             'new_password2': 'newpassword',
         }
-        response = self.client.post(reverse('password_reset_confirm', kwargs=self.url_kwargs), post_data)
+        response = self.client.post(reverse('wagtailadmin_password_reset_confirm', kwargs=self.url_kwargs), post_data)
 
         # Check that the user was redirected to the complete page
-        self.assertRedirects(response, reverse('password_reset_complete'))
+        self.assertRedirects(response, reverse('wagtailadmin_password_reset_complete'))
 
         # Check that the password was changed
         self.assertTrue(get_user_model().objects.get(username='test').check_password('newpassword'))
@@ -425,7 +425,7 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
             'new_password1': 'newpassword',
             'new_password2': 'badpassword',
         }
-        response = self.client.post(reverse('password_reset_confirm', kwargs=self.url_kwargs), post_data)
+        response = self.client.post(reverse('wagtailadmin_password_reset_confirm', kwargs=self.url_kwargs), post_data)
 
         # Check that the user wasn't redirected
         self.assertEqual(response.status_code, 200)
@@ -442,7 +442,7 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
         This tests that the password reset done view returns a password reset done page
         """
         # Get password reset done page
-        response = self.client.get(reverse('password_reset_done'))
+        response = self.client.get(reverse('wagtailadmin_password_reset_done'))
 
         # Check that the user recieved a password reset done page
         self.assertEqual(response.status_code, 200)
@@ -453,7 +453,7 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
         This tests that the password reset complete view returns a password reset complete page
         """
         # Get password reset complete page
-        response = self.client.get(reverse('password_reset_complete'))
+        response = self.client.get(reverse('wagtailadmin_password_reset_complete'))
 
         # Check that the user recieved a password reset complete page
         self.assertEqual(response.status_code, 200)

--- a/wagtail/wagtailadmin/urls.py
+++ b/wagtail/wagtailadmin/urls.py
@@ -96,22 +96,24 @@ urlpatterns += [
             'email_template_name': 'wagtailadmin/account/password_reset/email.txt',
             'subject_template_name': 'wagtailadmin/account/password_reset/email_subject.txt',
             'password_reset_form': PasswordResetForm,
-        }, name='password_reset'
+            'post_reset_redirect': 'wagtailadmin_password_reset_done',
+        }, name='wagtailadmin_password_reset'
     ),
     url(
         r'^password_reset/done/$', 'django.contrib.auth.views.password_reset_done', {
             'template_name': 'wagtailadmin/account/password_reset/done.html'
-        }, name='password_reset_done'
+        }, name='wagtailadmin_password_reset_done'
     ),
     url(
         r'^password_reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
-        'django.contrib.auth.views.password_reset_confirm',
-        {'template_name': 'wagtailadmin/account/password_reset/confirm.html'},
-        name='password_reset_confirm',
+        'django.contrib.auth.views.password_reset_confirm', {
+            'template_name': 'wagtailadmin/account/password_reset/confirm.html',
+            'post_reset_redirect': 'wagtailadmin_password_reset_complete',
+        }, name='wagtailadmin_password_reset_confirm',
     ),
     url(
-        r'^password_reset/complete/$', 'django.contrib.auth.views.password_reset_complete',
-        {'template_name': 'wagtailadmin/account/password_reset/complete.html'},
-        name='password_reset_complete'
+        r'^password_reset/complete/$', 'django.contrib.auth.views.password_reset_complete',{
+            'template_name': 'wagtailadmin/account/password_reset/complete.html'
+        }, name='wagtailadmin_password_reset_complete'
     ),
 ]

--- a/wagtail/wagtailadmin/urls.py
+++ b/wagtail/wagtailadmin/urls.py
@@ -8,34 +8,6 @@ from wagtail.utils.urlpatterns import decorate_urlpatterns
 
 
 urlpatterns = [
-    # Password reset
-    url(
-        r'^password_reset/$', 'django.contrib.auth.views.password_reset', {
-            'template_name': 'wagtailadmin/account/password_reset/form.html',
-            'email_template_name': 'wagtailadmin/account/password_reset/email.txt',
-            'subject_template_name': 'wagtailadmin/account/password_reset/email_subject.txt',
-            'password_reset_form': PasswordResetForm,
-        }, name='password_reset'
-    ),
-    url(
-        r'^password_reset/done/$', 'django.contrib.auth.views.password_reset_done', {
-            'template_name': 'wagtailadmin/account/password_reset/done.html'
-        }, name='password_reset_done'
-    ),
-    url(
-        r'^password_reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
-        'django.contrib.auth.views.password_reset_confirm',
-        {'template_name': 'wagtailadmin/account/password_reset/confirm.html'},
-        name='password_reset_confirm',
-    ),
-    url(
-        r'^password_reset/complete/$', 'django.contrib.auth.views.password_reset_complete',
-        {'template_name': 'wagtailadmin/account/password_reset/complete.html'},
-        name='password_reset_complete'
-    ),
-]
-
-urlpatterns += [
     url(r'^$', home.home, name='wagtailadmin_home'),
 
     url(r'^failwhale/$', home.error_test, name='wagtailadmin_error_test'),
@@ -85,14 +57,10 @@ urlpatterns += [
 
     url(r'^tag-autocomplete/$', tags.autocomplete, name='wagtailadmin_tag_autocomplete'),
 
-    url(r'^login/$', account.login, name='wagtailadmin_login'),
     url(r'^account/$', account.account, name='wagtailadmin_account'),
     url(r'^account/change_password/$', account.change_password, name='wagtailadmin_account_change_password'),
     url(r'^account/notification_preferences/$', account.notification_preferences, name='wagtailadmin_account_notification_preferences'),
     url(r'^logout/$', account.logout, name='wagtailadmin_logout'),
-
-    url(r'^userbar/(\d+)/$', userbar.for_frontend, name='wagtailadmin_userbar_frontend'),
-    url(r'^userbar/moderation/(\d+)/$', userbar.for_moderation, name='wagtailadmin_userbar_moderation'),
 ]
 
 
@@ -103,9 +71,47 @@ for fn in hooks.get_hooks('register_admin_urls'):
         urlpatterns += urls
 
 
+# Add "wagtailadmin.access_admin" permission check
 urlpatterns = decorate_urlpatterns(urlpatterns,
     permission_required(
         'wagtailadmin.access_admin',
         login_url='wagtailadmin_login'
     )
 )
+
+
+# These url patterns do not require an authenticated admin user
+urlpatterns += [
+    url(r'^login/$', account.login, name='wagtailadmin_login'),
+
+    # These two URLs have the "permission_required" decorator applied directly
+    # as they need to fail with a 403 error rather than redirect to the login page
+    url(r'^userbar/(\d+)/$', userbar.for_frontend, name='wagtailadmin_userbar_frontend'),
+    url(r'^userbar/moderation/(\d+)/$', userbar.for_moderation, name='wagtailadmin_userbar_moderation'),
+
+    # Password reset
+    url(
+        r'^password_reset/$', 'django.contrib.auth.views.password_reset', {
+            'template_name': 'wagtailadmin/account/password_reset/form.html',
+            'email_template_name': 'wagtailadmin/account/password_reset/email.txt',
+            'subject_template_name': 'wagtailadmin/account/password_reset/email_subject.txt',
+            'password_reset_form': PasswordResetForm,
+        }, name='password_reset'
+    ),
+    url(
+        r'^password_reset/done/$', 'django.contrib.auth.views.password_reset_done', {
+            'template_name': 'wagtailadmin/account/password_reset/done.html'
+        }, name='password_reset_done'
+    ),
+    url(
+        r'^password_reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
+        'django.contrib.auth.views.password_reset_confirm',
+        {'template_name': 'wagtailadmin/account/password_reset/confirm.html'},
+        name='password_reset_confirm',
+    ),
+    url(
+        r'^password_reset/complete/$', 'django.contrib.auth.views.password_reset_complete',
+        {'template_name': 'wagtailadmin/account/password_reset/complete.html'},
+        name='password_reset_complete'
+    ),
+]

--- a/wagtail/wagtailadmin/urls.py
+++ b/wagtail/wagtailadmin/urls.py
@@ -1,8 +1,10 @@
 from django.conf.urls import url
+from django.contrib.auth.decorators import permission_required
 
 from wagtail.wagtailadmin.forms import PasswordResetForm
 from wagtail.wagtailadmin.views import account, chooser, home, pages, tags, userbar, page_privacy
 from wagtail.wagtailcore import hooks
+from wagtail.utils.urlpatterns import decorate_urlpatterns
 
 
 urlpatterns = [
@@ -106,3 +108,11 @@ for fn in hooks.get_hooks('register_admin_urls'):
     urls = fn()
     if urls:
         urlpatterns += urls
+
+
+urlpatterns = decorate_urlpatterns(urlpatterns,
+    permission_required(
+        'wagtailadmin.access_admin',
+        login_url='wagtailadmin_login'
+    )
+)

--- a/wagtail/wagtailadmin/urls.py
+++ b/wagtail/wagtailadmin/urls.py
@@ -96,13 +96,6 @@ urlpatterns += [
 ]
 
 
-# This is here to make sure that 'django.contrib.auth.views.login' is reversed correctly
-# It must be placed after 'wagtailadmin_login' to prevent this from being used
-urlpatterns += [
-    url(r'^login/$', 'django.contrib.auth.views.login'),
-]
-
-
 # Import additional urlpatterns from any apps that define a register_admin_urls hook
 for fn in hooks.get_hooks('register_admin_urls'):
     urls = fn()

--- a/wagtail/wagtailadmin/views/account.py
+++ b/wagtail/wagtailadmin/views/account.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.shortcuts import render, redirect
 from django.contrib import messages
 from django.contrib.auth.forms import SetPasswordForm
-from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.views import logout as auth_logout, login as auth_login
 from django.utils.translation import ugettext as _ 
 from django.views.decorators.debug import sensitive_post_parameters
@@ -14,7 +13,6 @@ from wagtail.wagtailusers.models import UserProfile
 from wagtail.wagtailcore.models import UserPagePermissionsProxy
 
 
-@permission_required('wagtailadmin.access_admin')
 def account(request):
     user_perms = UserPagePermissionsProxy(request.user)
     show_notification_preferences = user_perms.can_edit_pages() or user_perms.can_publish_pages()
@@ -25,7 +23,6 @@ def account(request):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def change_password(request):
     can_change_password = request.user.has_usable_password()
 
@@ -49,7 +46,6 @@ def change_password(request):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def notification_preferences(request):
 
     if request.POST:

--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -2,7 +2,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import get_object_or_404, render
 from django.http import Http404
 from django.utils.http import urlencode
-from django.contrib.auth.decorators import permission_required
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
@@ -20,7 +19,6 @@ def get_querystring(request):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def browse(request, parent_page_id=None):
     page_type = request.GET.get('page_type') or 'wagtailcore.page'
     content_type_app_name, content_type_model_name = page_type.split('.')
@@ -89,7 +87,6 @@ def browse(request, parent_page_id=None):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def external_link(request):
     prompt_for_link_text = bool(request.GET.get('prompt_for_link_text'))
 
@@ -123,7 +120,6 @@ def external_link(request):
     )
 
 
-@permission_required('wagtailadmin.access_admin')
 def email_link(request):
     prompt_for_link_text = bool(request.GET.get('prompt_for_link_text'))
 

--- a/wagtail/wagtailadmin/views/home.py
+++ b/wagtail/wagtailadmin/views/home.py
@@ -1,5 +1,4 @@
 from django.shortcuts import render
-from django.contrib.auth.decorators import permission_required
 from django.conf import settings
 from django.template import RequestContext
 from django.template.loader import render_to_string
@@ -66,7 +65,6 @@ class RecentEditsPanel(object):
         }, RequestContext(self.request))
 
 
-@permission_required('wagtailadmin.access_admin')
 def home(request):
 
     panels = [

--- a/wagtail/wagtailadmin/views/page_privacy.py
+++ b/wagtail/wagtailadmin/views/page_privacy.py
@@ -1,12 +1,11 @@
 from django.core.exceptions import PermissionDenied
-from django.contrib.auth.decorators import permission_required
 from django.shortcuts import get_object_or_404
 
 from wagtail.wagtailcore.models import Page, PageViewRestriction
 from wagtail.wagtailadmin.forms import PageViewRestrictionForm
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 
-@permission_required('wagtailadmin.access_admin')
+
 def set_privacy(request, page_id):
     page = get_object_or_404(Page, id=page_id)
     page_perms = page.permissions_for_user(request.user)

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -4,7 +4,6 @@ from django.http import Http404, HttpResponse
 from django.shortcuts import render, redirect, get_object_or_404
 from django.core.exceptions import ValidationError, PermissionDenied
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.auth.decorators import permission_required
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.urlresolvers import reverse
 from django.utils import timezone
@@ -23,14 +22,13 @@ from wagtail.wagtailcore.models import Page, PageRevision, get_navigation_menu_i
 
 from wagtail.wagtailadmin import messages
 
-@permission_required('wagtailadmin.access_admin')
+
 def explorer_nav(request):
     return render(request, 'wagtailadmin/shared/explorer_nav.html', {
         'nodes': get_navigation_menu_items(),
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def index(request, parent_page_id=None):
     if parent_page_id:
         parent_page = get_object_or_404(Page, id=parent_page_id)
@@ -67,7 +65,6 @@ def index(request, parent_page_id=None):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def add_subpage(request, parent_page_id):
     parent_page = get_object_or_404(Page, id=parent_page_id).specific
     if not parent_page.permissions_for_user(request.user).can_add_subpage():
@@ -89,7 +86,6 @@ def add_subpage(request, parent_page_id):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def content_type_use(request, content_type_app_name, content_type_model_name):
     try:
         content_type = ContentType.objects.get_by_natural_key(content_type_app_name, content_type_model_name)
@@ -123,7 +119,6 @@ def content_type_use(request, content_type_app_name, content_type_model_name):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def create(request, content_type_app_name, content_type_model_name, parent_page_id):
     parent_page = get_object_or_404(Page, id=parent_page_id).specific
     parent_page_perms = parent_page.permissions_for_user(request.user)
@@ -249,7 +244,6 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def edit(request, page_id):
     latest_revision = get_object_or_404(Page, id=page_id).get_latest_revision()
     page = get_object_or_404(Page, id=page_id).get_latest_revision_as_page()
@@ -383,7 +377,6 @@ def edit(request, page_id):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def delete(request, page_id):
     page = get_object_or_404(Page, id=page_id).specific
     if not page.permissions_for_user(request.user).can_delete():
@@ -408,13 +401,11 @@ def delete(request, page_id):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def view_draft(request, page_id):
     page = get_object_or_404(Page, id=page_id).get_latest_revision_as_page()
     return page.serve_preview(page.dummy_request(), page.default_preview_mode)
 
 
-@permission_required('wagtailadmin.access_admin')
 def preview_on_edit(request, page_id):
     # Receive the form submission that would typically be posted to the 'edit' view. If submission is valid,
     # return the rendered page; if not, re-render the edit form
@@ -444,7 +435,6 @@ def preview_on_edit(request, page_id):
         return response
 
 
-@permission_required('wagtailadmin.access_admin')
 def preview_on_create(request, content_type_app_name, content_type_model_name, parent_page_id):
     # Receive the form submission that would typically be posted to the 'create' view. If submission is valid,
     # return the rendered page; if not, re-render the edit form
@@ -520,7 +510,7 @@ def preview_loading(request):
     """
     return HttpResponse("<html><head><title></title></head><body></body></html>")
 
-@permission_required('wagtailadmin.access_admin')
+
 def unpublish(request, page_id):
     page = get_object_or_404(Page, id=page_id).specific
     if not page.permissions_for_user(request.user).can_unpublish():
@@ -538,7 +528,6 @@ def unpublish(request, page_id):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def move_choose_destination(request, page_to_move_id, viewed_page_id=None):
     page_to_move = get_object_or_404(Page, id=page_to_move_id)
     page_perms = page_to_move.permissions_for_user(request.user)
@@ -568,7 +557,6 @@ def move_choose_destination(request, page_to_move_id, viewed_page_id=None):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def move_confirm(request, page_to_move_id, destination_id):
     page_to_move = get_object_or_404(Page, id=page_to_move_id).specific
     destination = get_object_or_404(Page, id=destination_id)
@@ -590,7 +578,6 @@ def move_confirm(request, page_to_move_id, destination_id):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def set_page_position(request, page_to_move_id):
     page_to_move = get_object_or_404(Page, id=page_to_move_id)
     parent_page = page_to_move.get_parent()
@@ -630,7 +617,6 @@ def set_page_position(request, page_to_move_id):
     return HttpResponse('')
 
 
-@permission_required('wagtailadmin.access_admin')
 def copy(request, page_id):
     page = Page.objects.get(id=page_id)
 
@@ -703,7 +689,6 @@ def get_page_edit_handler(page_class):
     return PAGE_EDIT_HANDLERS[page_class]
 
 
-@permission_required('wagtailadmin.access_admin')
 @vary_on_headers('X-Requested-With')
 def search(request):
     pages = []
@@ -745,7 +730,6 @@ def search(request):
         })
 
 
-@permission_required('wagtailadmin.access_admin')
 def approve_moderation(request, revision_id):
     revision = get_object_or_404(PageRevision, id=revision_id)
     if not revision.page.permissions_for_user(request.user).can_publish():
@@ -763,7 +747,6 @@ def approve_moderation(request, revision_id):
     return redirect('wagtailadmin_home')
 
 
-@permission_required('wagtailadmin.access_admin')
 def reject_moderation(request, revision_id):
     revision = get_object_or_404(PageRevision, id=revision_id)
     if not revision.page.permissions_for_user(request.user).can_publish():
@@ -781,7 +764,6 @@ def reject_moderation(request, revision_id):
     return redirect('wagtailadmin_home')
 
 
-@permission_required('wagtailadmin.access_admin')
 @require_GET
 def preview_for_moderation(request, revision_id):
     revision = get_object_or_404(PageRevision, id=revision_id)
@@ -801,7 +783,6 @@ def preview_for_moderation(request, revision_id):
     return page.serve_preview(request, page.default_preview_mode)
 
 
-@permission_required('wagtailadmin.access_admin')
 @require_POST
 def lock(request, page_id):
     # Get the page
@@ -826,7 +807,6 @@ def lock(request, page_id):
         return redirect('wagtailadmin_explore', page.get_parent().id)
 
 
-@permission_required('wagtailadmin.access_admin')
 @require_POST
 def unlock(request, page_id):
     # Get the page

--- a/wagtail/wagtailadmin/views/tags.py
+++ b/wagtail/wagtailadmin/views/tags.py
@@ -3,10 +3,8 @@ import json
 from taggit.models import Tag
 
 from django.http import HttpResponse
-from django.contrib.auth.decorators import permission_required
 
 
-@permission_required('wagtailadmin.access_admin')
 def autocomplete(request):
     term = request.GET.get('term', None)
     if term:

--- a/wagtail/wagtailadmin/views/userbar.py
+++ b/wagtail/wagtailadmin/views/userbar.py
@@ -1,10 +1,12 @@
 from django.shortcuts import render
+from django.contrib.auth.decorators import permission_required
 
 from wagtail.wagtailadmin.userbar import EditPageItem, AddPageItem, ApproveModerationEditPageItem, RejectModerationEditPageItem
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import Page, PageRevision
 
 
+@permission_required('wagtailadmin.access_admin', raise_exception=True)
 def for_frontend(request, page_id):
     items = [
         EditPageItem(Page.objects.get(id=page_id)),
@@ -26,6 +28,7 @@ def for_frontend(request, page_id):
     })
 
 
+@permission_required('wagtailadmin.access_admin', raise_exception=True)
 def for_moderation(request, revision_id):
     items = [
         EditPageItem(PageRevision.objects.get(id=revision_id).page),

--- a/wagtail/wagtailadmin/views/userbar.py
+++ b/wagtail/wagtailadmin/views/userbar.py
@@ -1,12 +1,10 @@
 from django.shortcuts import render
-from django.contrib.auth.decorators import permission_required
 
 from wagtail.wagtailadmin.userbar import EditPageItem, AddPageItem, ApproveModerationEditPageItem, RejectModerationEditPageItem
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import Page, PageRevision
 
 
-@permission_required('wagtailadmin.access_admin', raise_exception=True)
 def for_frontend(request, page_id):
     items = [
         EditPageItem(Page.objects.get(id=page_id)),
@@ -28,7 +26,6 @@ def for_frontend(request, page_id):
     })
 
 
-@permission_required('wagtailadmin.access_admin', raise_exception=True)
 def for_moderation(request, revision_id):
     items = [
         EditPageItem(PageRevision.objects.get(id=revision_id).page),

--- a/wagtail/wagtaildocs/views/chooser.py
+++ b/wagtail/wagtaildocs/views/chooser.py
@@ -12,7 +12,6 @@ from wagtail.wagtaildocs.models import Document
 from wagtail.wagtaildocs.forms import DocumentForm
 
 
-@permission_required('wagtailadmin.access_admin')
 def chooser(request):
     if request.user.has_perm('wagtaildocs.add_document'):
         uploadform = DocumentForm()
@@ -77,7 +76,6 @@ def chooser(request):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def document_chosen(request, document_id):
     document = get_object_or_404(Document, id=document_id)
 

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -103,7 +103,6 @@ def add(request):
     })
 
 
-@permission_required('wagtailadmin.access_admin')  # more specific permission tests are applied within the view
 def edit(request, document_id):
     doc = get_object_or_404(Document, id=document_id)
 
@@ -140,7 +139,6 @@ def edit(request, document_id):
     })
 
 
-@permission_required('wagtailadmin.access_admin')  # more specific permission tests are applied within the view
 def delete(request, document_id):
     doc = get_object_or_404(Document, id=document_id)
 
@@ -157,7 +155,6 @@ def delete(request, document_id):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def usage(request, document_id):
     doc = get_object_or_404(Document, id=document_id)
 

--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -11,14 +11,12 @@ from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, render
-from django.contrib.auth.decorators import permission_required
 
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailforms.models import FormSubmission, get_forms_for_user
 from wagtail.wagtailforms.forms import SelectDateForm
 
 
-@permission_required('wagtailadmin.access_admin')
 def index(request):
     p = request.GET.get("p", 1)
 
@@ -38,7 +36,6 @@ def index(request):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def list_submissions(request, page_id):
     form_page = get_object_or_404(Page, id=page_id).specific
 

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -32,7 +32,6 @@ def get_image_json(image):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def chooser(request):
     Image = get_image_model()
 
@@ -100,7 +99,6 @@ def chooser(request):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def image_chosen(request, image_id):
     image = get_object_or_404(get_image_model(), id=image_id)
 
@@ -151,7 +149,6 @@ def chooser_upload(request):
     )
 
 
-@permission_required('wagtailadmin.access_admin')
 def chooser_select_format(request, image_id):
     image = get_object_or_404(get_image_model(), id=image_id)
 

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -78,7 +78,6 @@ def index(request):
         })
 
 
-@permission_required('wagtailadmin.access_admin')  # more specific permission tests are applied within the view
 def edit(request, image_id):
     Image = get_image_model()
     ImageForm = get_image_form(Image)
@@ -127,7 +126,6 @@ def edit(request, image_id):
     })
 
 
-@permission_required('wagtailadmin.access_admin')  # more specific permission tests are applied within the view
 def url_generator(request, image_id):
     image = get_object_or_404(get_image_model(), id=image_id)
 
@@ -150,7 +148,6 @@ def json_response(document, status=200):
     return HttpResponse(json.dumps(document), content_type='application/json', status=status)
 
 
-@permission_required('wagtailadmin.access_admin')
 def generate_url(request, image_id, filter_spec):
     # Get the image
     Image = get_image_model()
@@ -191,7 +188,6 @@ def generate_url(request, image_id, filter_spec):
     return json_response({'url': site_root_url + url, 'preview_url': preview_url}, status=200)
 
 
-@permission_required('wagtailadmin.access_admin')
 def preview(request, image_id, filter_spec):
     image = get_object_or_404(get_image_model(), id=image_id)
 
@@ -201,7 +197,6 @@ def preview(request, image_id, filter_spec):
         return HttpResponse("Invalid filter spec: " + filter_spec, content_type='text/plain', status=400)
 
 
-@permission_required('wagtailadmin.access_admin')  # more specific permission tests are applied within the view
 def delete(request, image_id):
     image = get_object_or_404(get_image_model(), id=image_id)
 
@@ -248,7 +243,6 @@ def add(request):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def usage(request, image_id):
     image = get_object_or_404(get_image_model(), id=image_id)
 

--- a/wagtail/wagtailimages/views/multiple.py
+++ b/wagtail/wagtailimages/views/multiple.py
@@ -101,7 +101,6 @@ def add(request):
 
 
 @require_POST
-@permission_required('wagtailadmin.access_admin')  # more specific permission tests are applied within the view
 def edit(request, image_id, callback=None):
     Image = get_image_model()
     ImageForm = get_image_edit_form(Image)
@@ -139,7 +138,6 @@ def edit(request, image_id, callback=None):
 
 
 @require_POST
-@permission_required('wagtailadmin.access_admin')  # more specific permission tests are applied within the view
 def delete(request, image_id):
     image = get_object_or_404(get_image_model(), id=image_id)
 

--- a/wagtail/wagtailsearch/views/editorspicks.py
+++ b/wagtail/wagtailsearch/views/editorspicks.py
@@ -1,5 +1,4 @@
 from django.shortcuts import render, redirect, get_object_or_404
-from django.contrib.auth.decorators import permission_required
 
 from django.core.urlresolvers import reverse
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
@@ -11,7 +10,6 @@ from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailadmin import messages
 
 
-@permission_required('wagtailadmin.access_admin')
 @vary_on_headers('X-Requested-With')
 def index(request):
     is_searching = False
@@ -70,7 +68,6 @@ def save_editorspicks(query, new_query, editors_pick_formset):
         return False
 
 
-@permission_required('wagtailadmin.access_admin')
 def add(request):
     if request.POST:
         # Get query
@@ -102,7 +99,6 @@ def add(request):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def edit(request, query_id):
     query = get_object_or_404(models.Query, id=query_id)
 
@@ -138,7 +134,6 @@ def edit(request, query_id):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def delete(request, query_id):
     query = get_object_or_404(models.Query, id=query_id)
 

--- a/wagtail/wagtailsearch/views/queries.py
+++ b/wagtail/wagtailsearch/views/queries.py
@@ -1,6 +1,5 @@
 from django.shortcuts import render
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.contrib.auth.decorators import permission_required
 
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 from wagtail.wagtailadmin.forms import SearchForm
@@ -9,7 +8,6 @@ from wagtail.wagtailsearch import models
 from wagtail.wagtailsearch.utils import normalise_query_string
 
 
-@permission_required('wagtailadmin.access_admin')
 def chooser(request, get_results=False):
     # Get most popular queries
     queries = models.Query.get_most_popular()

--- a/wagtail/wagtailsnippets/views/chooser.py
+++ b/wagtail/wagtailsnippets/views/chooser.py
@@ -3,14 +3,12 @@ import json
 from six import text_type
 
 from django.shortcuts import get_object_or_404
-from django.contrib.auth.decorators import permission_required
 
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 
 from wagtail.wagtailsnippets.views.snippets import get_content_type_from_url_params, get_snippet_type_name
 
 
-@permission_required('wagtailadmin.access_admin')
 def choose(request, content_type_app_name, content_type_model_name):
     content_type = get_content_type_from_url_params(content_type_app_name, content_type_model_name)
     model = content_type.model_class()
@@ -29,7 +27,6 @@ def choose(request, content_type_app_name, content_type_model_name):
     )
 
 
-@permission_required('wagtailadmin.access_admin')
 def chosen(request, content_type_app_name, content_type_model_name, id):
     content_type = get_content_type_from_url_params(content_type_app_name, content_type_model_name)
     model = content_type.model_class()

--- a/wagtail/wagtailsnippets/views/snippets.py
+++ b/wagtail/wagtailsnippets/views/snippets.py
@@ -3,7 +3,6 @@ from django.shortcuts import get_object_or_404, render, redirect
 from django.utils.encoding import force_text
 from django.utils.text import capfirst
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.auth.decorators import permission_required
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
@@ -70,7 +69,6 @@ def get_snippet_edit_handler(model):
 # == Views ==
 
 
-@permission_required('wagtailadmin.access_admin')
 def index(request):
     snippet_types = [
         (
@@ -86,7 +84,6 @@ def index(request):
     })
 
 
-@permission_required('wagtailadmin.access_admin')  # further permissions are enforced within the view
 def list(request, content_type_app_name, content_type_model_name):
     content_type = get_content_type_from_url_params(content_type_app_name, content_type_model_name)
     if not user_can_edit_snippet_type(request.user, content_type):
@@ -105,7 +102,6 @@ def list(request, content_type_app_name, content_type_model_name):
     })
 
 
-@permission_required('wagtailadmin.access_admin')  # further permissions are enforced within the view
 def create(request, content_type_app_name, content_type_model_name):
     content_type = get_content_type_from_url_params(content_type_app_name, content_type_model_name)
     if not user_can_edit_snippet_type(request.user, content_type):
@@ -149,7 +145,6 @@ def create(request, content_type_app_name, content_type_model_name):
     })
 
 
-@permission_required('wagtailadmin.access_admin')  # further permissions are enforced within the view
 def edit(request, content_type_app_name, content_type_model_name, id):
     content_type = get_content_type_from_url_params(content_type_app_name, content_type_model_name)
     if not user_can_edit_snippet_type(request.user, content_type):
@@ -194,7 +189,6 @@ def edit(request, content_type_app_name, content_type_model_name, id):
     })
 
 
-@permission_required('wagtailadmin.access_admin')  # further permissions are enforced within the view
 def delete(request, content_type_app_name, content_type_model_name, id):
     content_type = get_content_type_from_url_params(content_type_app_name, content_type_model_name)
     if not user_can_edit_snippet_type(request.user, content_type):
@@ -223,7 +217,6 @@ def delete(request, content_type_app_name, content_type_model_name, id):
     })
 
 
-@permission_required('wagtailadmin.access_admin')
 def usage(request, content_type_app_name, content_type_model_name, id):
     content_type = get_content_type_from_url_params(content_type_app_name, content_type_model_name)
     model = content_type.model_class()


### PR DESCRIPTION
This pull request applies the ``access_admin`` permission check automatically to all admin views. It addresses #731 and #900

This has the following advantages:
 - Eliminates the risk of forgetting to add the permission check which may lead to security holes
 - Allows us to specify the login_url on all views removing the need for the user to set their global ``LOGIN_URL`` setting to wagtails login view
 - Introduces a proper, non hacky fix to replace: https://github.com/kaedroho/wagtail/commit/45a10979c67dc35c7e64222192b8c0c9496993e5 (the old fix caused django to always reverse djangos login view to wagtails login view which is incredably annoying if you have a site that has a frontend login view)

I've squeezed a couple of extra changes into this PR:
 - Set the default value of ``next`` in ``login.html`` to the dashboard. There's no longer a need to set the ``LOGIN_REDIRECT_URL`` setting to wagtails dashboard
 - Fix the namespacing of the password reset urls