### PR TITLE
Globally set cache headers for admin interface

### DIFF
--- a/wagtail/wagtailadmin/tests/tests.py
+++ b/wagtail/wagtailadmin/tests/tests.py
@@ -28,6 +28,14 @@ class TestHome(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtailadmin_home') + '?hide-kittens=true')
         self.assertNotContains(response, '<a href="http://www.tomroyal.com/teaandkittens/" class="icon icon-kitten" data-fluffy="yes">Kittens!</a>')
 
+    def test_never_cache_header(self):
+        # This tests that wagtailadmins global cache settings have been applied correctly
+        response = self.client.get(reverse('wagtailadmin_home'))
+
+        self.assertIn('private', response['Cache-Control'])
+        self.assertIn('no-cache', response['Cache-Control'])
+        self.assertIn('no-store', response['Cache-Control'])
+
 
 class TestEditorHooks(TestCase, WagtailTestUtils):
     def setUp(self):

--- a/wagtail/wagtailadmin/tests/tests.py
+++ b/wagtail/wagtailadmin/tests/tests.py
@@ -35,6 +35,7 @@ class TestHome(TestCase, WagtailTestUtils):
         self.assertIn('private', response['Cache-Control'])
         self.assertIn('no-cache', response['Cache-Control'])
         self.assertIn('no-store', response['Cache-Control'])
+        self.assertIn('max-age=0', response['Cache-Control'])
 
 
 class TestEditorHooks(TestCase, WagtailTestUtils):

--- a/wagtail/wagtailadmin/urls.py
+++ b/wagtail/wagtailadmin/urls.py
@@ -121,5 +121,5 @@ urlpatterns += [
 
 # Decorate all views with cache settings to prevent caching
 urlpatterns = decorate_urlpatterns(urlpatterns,
-    cache_control(private=True, no_cache=True, no_store=True)
+    cache_control(private=True, no_cache=True, no_store=True, max_age=0)
 )

--- a/wagtail/wagtailadmin/urls.py
+++ b/wagtail/wagtailadmin/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import url
 from django.contrib.auth.decorators import permission_required
+from django.views.decorators.cache import cache_control
 
 from wagtail.wagtailadmin.forms import PasswordResetForm
 from wagtail.wagtailadmin.views import account, chooser, home, pages, tags, userbar, page_privacy
@@ -117,3 +118,8 @@ urlpatterns += [
         }, name='wagtailadmin_password_reset_complete'
     ),
 ]
+
+# Decorate all views with cache settings to prevent caching
+urlpatterns = decorate_urlpatterns(urlpatterns,
+    cache_control(private=True, no_cache=True, no_store=True)
+)


### PR DESCRIPTION
This PR adds some cache-control headers to the responses of all admin views. It allows Varnish/Squid/CDN to run on vanilla settings infront of a wagtail site. It partly addresses #911