### PR TITLE
Better tests for edit_handlers

### DIFF
--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -137,10 +137,6 @@ def extract_panel_definitions_from_model_class(model, exclude=None):
     return panels
 
 
-def set_page_edit_handler(page_class, handlers):
-    page_class.handlers = handlers
-
-
 class EditHandler(object):
     """
     Abstract class providing sensible default behaviours for objects implementing

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -171,6 +171,9 @@ class TestTabbedInterface(TestCase):
         # result should contain rendered content from descendants
         self.assertIn('Abergavenny sheepdog trials</textarea>', result)
 
+        # this result should not include fields that are not covered by the panel definition
+        self.assertNotIn('signup_link', result)
+
     def test_rendered_fields(self):
         EventPageForm = self.EventPageTabbedInterface.get_form_class(EventPage)
         event = EventPage(title='Abergavenny sheepdog trials')
@@ -184,6 +187,23 @@ class TestTabbedInterface(TestCase):
         # rendered_fields should report the set of form fields rendered recursively as part of TabbedInterface
         result = set(tabbed_interface.rendered_fields())
         self.assertEqual(result, set(['title', 'date_from', 'date_to']))
+
+    def test_render_form_content(self):
+        EventPageForm = self.EventPageTabbedInterface.get_form_class(EventPage)
+        event = EventPage(title='Abergavenny sheepdog trials')
+        form = EventPageForm(instance=event)
+
+        tabbed_interface = self.EventPageTabbedInterface(
+            instance=event,
+            form=form
+        )
+
+        result = tabbed_interface.render_form_content()
+        # rendered output should contain field content as above
+        self.assertIn('Abergavenny sheepdog trials</textarea>', result)
+        # rendered output should also contain all other fields that are in the form but not represented
+        # in the panel definition
+        self.assertIn('signup_link', result)
 
 
 class TestObjectList(TestCase):


### PR DESCRIPTION
This PR provides improved unit tests for wagtail.wagtailadmin.edit_handlers. The existing tests rely on mock objects and dummy parameters that are not at all representative of real-world use of the module, and end up testing the implementation internals rather than the overall functionality of the module (which is understandable, since there's no documentation for what the module is meant to do...)

These tests are a prerequisite for several issues that require refactoring of edit_handlers, including StreamField (#823) and removing stray form fields (#338).

The tests for PageChooserPanel and InlinePanel are still to be updated - these will follow in a separate PR. 