### PR TITLE
Admin Template Branding Blocks

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/home.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/home.html
@@ -19,7 +19,7 @@
                 </div>
             {% endif %}
             <div class="col9">
-                <h1>{% blocktrans %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}</h1> 
+                <h1>{% block admin_branding_home %}{% blocktrans %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>
                 <h2>{{ user.get_full_name|default:user.get_username }}</h2>
             </div>
         </div>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/login.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/login.html
@@ -23,9 +23,9 @@
         <form action="{% url 'wagtailadmin_login' %}" method="post" autocomplete="off">
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ next }}" />
-            <h1>{% trans "Sign in to Wagtail" %}</h1>
+            <h1>{% block admin_branding_login %}{% trans "Sign in to Wagtail" %}{% endblock %}</h1>
 
-          
+
             <ul class="fields">
                 <li class="full">
                     <div class="field iconfield">


### PR DESCRIPTION
    We commonly need to override the admin and home/dashboard branding
    for our users. While this can be done relatively easily by copying
    the wagtailadmin/home.html and wagtailadmin/login.html templates
    it would be a bit easier with smaller blocks especially for future Wagtail 
   upgrades.

    - Adds 'admin_branding_home' block to home.html
    - Adds 'block admin_branding_login' block to login.html