### PR TITLE
Don't normalise query strings on search. Fixes #937

### DIFF
--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -7,7 +7,6 @@ from django.db.models.sql.where import SubqueryConstraint, WhereNode
 from django.core.exceptions import ImproperlyConfigured
 
 from wagtail.wagtailsearch.index import class_is_indexed
-from wagtail.wagtailsearch.utils import normalise_query_string
 
 
 class FilterError(Exception):
@@ -212,10 +211,6 @@ class BaseSearch(object):
         # Model must be a class that is in the index
         if not class_is_indexed(model):
             return []
-
-        # Normalise query string
-        if query_string is not None:
-            query_string = normalise_query_string(query_string)
 
         # Check that theres still a query string after the clean up
         if query_string == "":

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -135,7 +135,6 @@ class TestElasticSearchBackend(BackendTests, TestCase):
         # Even though they both start with the letter "H". This should not be considered a match
         self.assertEqual(len(results), 0)
 
-    @unittest.expectedFailure
     def test_search_with_hyphen(self):
         """
         This tests that punctuation characters are treated the same

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -135,6 +135,35 @@ class TestElasticSearchBackend(BackendTests, TestCase):
         # Even though they both start with the letter "H". This should not be considered a match
         self.assertEqual(len(results), 0)
 
+    @unittest.expectedFailure
+    def test_search_with_hyphen(self):
+        """
+        This tests that punctuation characters are treated the same
+        way in both indexing and querying.
+
+        See: https://github.com/torchbox/wagtail/issues/937
+        """
+        # Reset the index
+        self.backend.reset_index()
+        self.backend.add_type(models.SearchTest)
+        self.backend.add_type(models.SearchTestChild)
+
+        # Add some test data
+        obj = models.SearchTest()
+        obj.title = "Hello-World"
+        obj.live = True
+        obj.save()
+        self.backend.add(obj)
+
+        # Refresh the index
+        self.backend.refresh_index()
+
+        # Test search for "Hello-World"
+        results = self.backend.search("Hello-World", models.SearchTest.objects.all())
+
+        # Should find the result
+        self.assertEqual(len(results), 1)
+
 
 class TestElasticSearchQuery(TestCase):
     def assertDictEqual(self, a, b):


### PR DESCRIPTION
We were previously doing this as punctuation characters were being treated as commands in Elasticsearch. This is no longer the case and this behaviour is causing issues (#937).