### PR TITLE
Ignore middleware responses when building dummy request

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -859,10 +859,10 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         # Apply middleware to the request - see http://www.mellowmorning.com/2011/04/18/mock-django-request-for-testing/
         handler = BaseHandler()
         handler.load_middleware()
+        # call each middleware in turn and throw away any responses that they might return
         for middleware_method in handler._request_middleware:
-            if middleware_method(request):
-                raise Exception("Couldn't create request mock object - "
-                                "request middleware returned a response")
+            middleware_method(request)
+
         return request
 
     DEFAULT_PREVIEW_MODES = [('', 'Default')]


### PR DESCRIPTION
Ref: https://groups.google.com/d/msg/wagtail/hTFw1jKCHm4/E99gQ3wqWhwJ

If a site developer is using a middleware that returns a response on plain vanilla HTTP requests (e.g. to enforce HTTPS or basic auth), preview fails with the error "Couldn't create request mock object - request middleware returned a response". When I wrote (well, pasted) that code, it wasn't clear why this scenario would ever occur, or what the appropriate behaviour should be, so throwing an error seemed like the logical thing to do.

It's now clear that this does occur in the wild, and in every conceivable case, the best thing to do is to throw away the response and continue regardless. So that's what this patch does.

For testing this behaviour before and after, I've set up a branch of wagtaildemo which adds a cheap-and-cheerful basic auth middleware (with username=user, password=pass): https://github.com/gasman/wagtaildemo/tree/basic-auth