### PR TITLE
Better tests for edit handlers, part 2

### DIFF
--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -420,7 +420,7 @@ class TestInlinePanel(TestCase):
         EventPageForm = SpeakerInlinePanel.get_form_class(EventPage)
 
         # SpeakerInlinePanel should instruct the form class to include a 'speakers' formset
-        self.assertEqual(['speakers'], EventPageForm.formsets.keys())
+        self.assertEqual(['speakers'], list(EventPageForm.formsets.keys()))
 
         event_page = EventPage.objects.get(slug='christmas')
 
@@ -457,7 +457,7 @@ class TestInlinePanel(TestCase):
         EventPageForm = SpeakerInlinePanel.get_form_class(EventPage)
 
         # SpeakerInlinePanel should instruct the form class to include a 'speakers' formset
-        self.assertEqual(['speakers'], EventPageForm.formsets.keys())
+        self.assertEqual(['speakers'], list(EventPageForm.formsets.keys()))
 
         event_page = EventPage.objects.get(slug='christmas')
 

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -434,6 +434,15 @@ class TestInlinePanel(TestCase):
         self.assertIn('<label for="id_speakers-0-image">Image:</label>', result)
         self.assertIn('value="Choose an image"', result)
 
+        # rendered panel must also contain hidden fields for id, DELETE and ORDER
+        self.assertIn('<input id="id_speakers-0-id" name="speakers-0-id" type="hidden"', result)
+        self.assertIn('<input id="id_speakers-0-DELETE" name="speakers-0-DELETE" type="hidden"', result)
+        self.assertIn('<input id="id_speakers-0-ORDER" name="speakers-0-ORDER" type="hidden"', result)
+
+        # rendered panel must contain maintenance form for the formset
+        self.assertIn('<input id="id_speakers-TOTAL_FORMS" name="speakers-TOTAL_FORMS" type="hidden"', result)
+
+        # render_js_init must provide the JS initializer
         self.assertIn('var panel = InlinePanel({', panel.render_js_init())
 
     def test_render_with_panel_overrides(self):
@@ -467,4 +476,13 @@ class TestInlinePanel(TestCase):
         self.assertIn('<label for="id_speakers-0-image">Image:</label>', result)
         self.assertIn('value="Choose an image"', result)
 
+        # rendered panel must also contain hidden fields for id, DELETE and ORDER
+        self.assertIn('<input id="id_speakers-0-id" name="speakers-0-id" type="hidden"', result)
+        self.assertIn('<input id="id_speakers-0-DELETE" name="speakers-0-DELETE" type="hidden"', result)
+        self.assertIn('<input id="id_speakers-0-ORDER" name="speakers-0-ORDER" type="hidden"', result)
+
+        # rendered panel must contain maintenance form for the formset
+        self.assertIn('<input id="id_speakers-TOTAL_FORMS" name="speakers-TOTAL_FORMS" type="hidden"', result)
+
+        # render_js_init must provide the JS initializer
         self.assertIn('var panel = InlinePanel({', panel.render_js_init())


### PR DESCRIPTION
The sequel to #933. Tests for PageChooserPanel and InlinePanel have now been updated to test behaviour on real models, and all remaining mock objects have been eliminated.