### PR TITLE
Stop missing panels from displaying as stray unlabelled fields - fixes #338 and #922

### DIFF
--- a/wagtail/tests/models.py
+++ b/wagtail/tests/models.py
@@ -495,6 +495,11 @@ class TaggedPageTag(TaggedItemBase):
 class TaggedPage(Page):
     tags = ClusterTaggableManager(through=TaggedPageTag, blank=True)
 
+TaggedPage.content_panels = [
+    FieldPanel('title', classname="full title"),
+    FieldPanel('tags'),
+]
+
 
 class PageChooserModel(models.Model):
     page = models.ForeignKey('wagtailcore.Page', help_text='help text')

--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -223,12 +223,30 @@ class EditHandler(object):
         # by default, assume that the subclass provides a catch-all render() method
         return self.render()
 
+    def render_missing_fields(self):
+        """
+        Helper function: render all of the fields that are defined on the form but not "claimed" by
+        any panels via required_fields. These fields are most likely to be hidden fields introduced
+        by the forms framework itself, such as ORDER / DELETE fields on formset members.
+
+        (If they aren't actually hidden fields, then they will appear as ugly unstyled / label-less fields
+        outside of the panel furniture. But there's not much we can do about that.)
+        """
+        rendered_fields = self.required_fields()
+        missing_fields_html = [
+            text_type(self.form[field_name])
+            for field_name in self.form.fields
+            if field_name not in rendered_fields
+        ]
+
+        return mark_safe(''.join(missing_fields_html))
+
     def render_form_content(self):
         """
         Render this as an 'object', ensuring that all fields necessary for a valid form
         submission are included
         """
-        return mark_safe(self.render_as_object())
+        return mark_safe(self.render_as_object() + self.render_missing_fields())
 
 
 class BaseCompositeEditHandler(EditHandler):

--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -225,8 +225,8 @@ class EditHandler(object):
 
     def render_form_content(self):
         """
-        Render this as an 'object', along with any unaccounted-for fields to make this
-        a valid submittable form
+        Render this as an 'object', ensuring that all fields necessary for a valid form
+        submission are included
         """
         return mark_safe(self.render_as_object())
 

--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -538,16 +538,11 @@ class BaseInlinePanel(EditHandler):
     def required_formsets(cls):
         child_edit_handler_class = cls.get_child_edit_handler_class()
         return {
-            cls.relation_name: {'fields': child_edit_handler_class.required_fields()}
+            cls.relation_name: {
+                'fields': child_edit_handler_class.required_fields(),
+                'widgets': child_edit_handler_class.widget_overrides(),
+            }
         }
-
-    @classmethod
-    def widget_overrides(cls):
-        overrides = cls.get_child_edit_handler_class().widget_overrides()
-        if overrides:
-            return {cls.relation_name: overrides}
-        else:
-            return {}
 
     def __init__(self, instance=None, form=None):
         super(BaseInlinePanel, self).__init__(instance=instance, form=form)

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -171,18 +171,9 @@ class TestTabbedInterface(TestCase):
         # this result should not include fields that are not covered by the panel definition
         self.assertNotIn('signup_link', result)
 
-    def test_rendered_fields(self):
-        EventPageForm = self.EventPageTabbedInterface.get_form_class(EventPage)
-        event = EventPage(title='Abergavenny sheepdog trials')
-        form = EventPageForm(instance=event)
-
-        tabbed_interface = self.EventPageTabbedInterface(
-            instance=event,
-            form=form
-        )
-
-        # rendered_fields should report the set of form fields rendered recursively as part of TabbedInterface
-        result = set(tabbed_interface.rendered_fields())
+    def test_required_fields(self):
+        # required_fields should report the set of form fields to be rendered recursively by children of TabbedInterface
+        result = set(self.EventPageTabbedInterface.required_fields())
         self.assertEqual(result, set(['title', 'date_from', 'date_to']))
 
     def test_render_form_content(self):
@@ -198,9 +189,9 @@ class TestTabbedInterface(TestCase):
         result = tabbed_interface.render_form_content()
         # rendered output should contain field content as above
         self.assertIn('Abergavenny sheepdog trials</textarea>', result)
-        # rendered output should also contain all other fields that are in the form but not represented
+        # rendered output should NOT include fields that are in the model but not represented
         # in the panel definition
-        self.assertIn('signup_link', result)
+        self.assertNotIn('signup_link', result)
 
 
 class TestObjectList(TestCase):
@@ -308,15 +299,8 @@ class TestFieldPanel(TestCase):
         # there should be no errors on this field
         self.assertNotIn('<p class="error-message">', result)
 
-    def test_rendered_fields(self):
-        form = self.EventPageForm(
-            {'title': 'Pontypridd sheepdog trials', 'date_from': '2014-07-20', 'date_to': '2014-07-22'},
-            instance=self.event)
-        field_panel = self.EndDatePanel(
-            instance=self.event,
-            form=form
-        )
-        result = field_panel.rendered_fields()
+    def test_required_fields(self):
+        result = self.EndDatePanel.required_fields()
         self.assertEqual(result, ['date_to'])
 
     def test_error_message_is_rendered(self):

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -453,9 +453,8 @@ class TestInlinePanel(TestCase):
         self.assertIn('<label for="id_speakers-0-first_name">Name:</label>', result)
         self.assertNotIn('<label for="id_speakers-0-last_name">Surname:</label>', result)
 
-        # surname field is still rendered as a 'stray' label-less field: see #338.
-        # (Temporarily adding a test for this, so that we can verify that it fails when #338 is fixed...)
-        self.assertIn('<input id="id_speakers-0-last_name"', result)
+        # test for #338: surname field should not be rendered as a 'stray' label-less field
+        self.assertNotIn('<input id="id_speakers-0-last_name"', result)
 
         self.assertIn('<label for="id_speakers-0-image">Image:</label>', result)
         self.assertIn('value="Choose an image"', result)

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -414,6 +414,7 @@ class TestInlinePanel(TestCase):
         result = panel.render_as_field()
 
         self.assertIn('<label for="id_speakers-0-first_name">Name:</label>', result)
+        self.assertIn('value="Father"', result)
         self.assertIn('<label for="id_speakers-0-last_name">Surname:</label>', result)
         self.assertIn('<label for="id_speakers-0-image">Image:</label>', result)
         self.assertIn('value="Choose an image"', result)
@@ -435,7 +436,7 @@ class TestInlinePanel(TestCase):
         where one is specified
         """
         SpeakerInlinePanel = InlinePanel(EventPage, 'speakers', label="Speakers", panels=[
-            FieldPanel('first_name'),
+            FieldPanel('first_name', widget=forms.Textarea),
             ImageChooserPanel('image'),
         ])
         EventPageForm = SpeakerInlinePanel.get_form_class(EventPage)
@@ -450,7 +451,9 @@ class TestInlinePanel(TestCase):
 
         result = panel.render_as_field()
 
+        # rendered panel should contain first_name rendered as a text area, but no last_name field
         self.assertIn('<label for="id_speakers-0-first_name">Name:</label>', result)
+        self.assertIn('Father</textarea>', result)
         self.assertNotIn('<label for="id_speakers-0-last_name">Surname:</label>', result)
 
         # test for #338: surname field should not be rendered as a 'stray' label-less field


### PR DESCRIPTION
Up to now, the procedure for rendering the page edit form (and any sub-forms for inline children) has been:

* construct a ModelForm consisting of all the fields of the page model (i.e. the thing that Django 1.8 is trying to stop us doing)
* construct a tree of EditHandler instances that have a reference back to the form
* tell the EditHandlers to render their corresponding form fields, and check `rendered_fields` to find out what they've rendered
* render all fields that haven't been claimed by the EditHandlers, as an indiscriminate unstyled blob

The final step was intended to mop up any hidden fields that were inserted by the forms framework, such as the 'id', 'DELETE' and 'ORDER' fields supplied by InlineFormSet. However, any legitimate non-hidden fields that were missing a corresponding FieldPanel - intentionally or not - would end up in that set too, and appear as stray unlabelled fields at the bottom of the form.

This PR changes the procedure so that EditHandler classes define a *class* method `required_fields` to declare up-front which fields they WILL render, as opposed to the instance method `rendered_fields` to declare which fields they *have* rendered. This means that we can construct a ModelForm that only includes the relevant fields.

This fix depends on django-modelcluster 0.5, which adds the ability to specify an explicit field list on child formsets of ClusterForm.

While this is a bug fix, I suggest that it should remain a Wagtail 0.9 addition and not be backported to 0.8, as it's a functional change to Wagtail and builds upon other EditHandler refactoring work such as #598.

@thenewguy: I believe this fix should allow you to eliminate the monkeypatch described in https://github.com/torchbox/wagtail/issues/338#issuecomment-49309105. The 'slug' field will now be omitted from the form entirely, which is functionally equivalent to (and more robust than) the field doing a round-trip on the form as a non-editable hidden field.