### PR TITLE
Add third-party tutorials page to docs

### DIFF
--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -11,3 +11,4 @@ How to
     multilingual_sites
     custom_branding
     contributing
+    third_party_tutorials

--- a/docs/howto/third_party_tutorials.rst
+++ b/docs/howto/third_party_tutorials.rst
@@ -1,0 +1,28 @@
+Third-party tutorials
+---------------------
+
+.. warning::
+
+    The following list is a collection of tutorials and development notes from third-party developers.
+    Some of the older links may not apply to the latest Wagtail versions.
+
+* `Working With Wagtail: Menus <http://www.tivix.com/blog/working-with-wagtail-menus/>`_ (22 January 2015)
+* `Upgrading Wagtail to use Django 1.7 locally using vagrant <https://jossingram.wordpress.com/2014/12/10/upgrading-wagtail-to-use-django-1-7-locally-using-vagrant/>`_ (10 December 2014)
+* `Wagtail redirect page. Can link to page, URL and document <https://gist.github.com/alej0varas/e7e334643ceab6e65744>`_ (24 September 2014)
+* `Outputing JSON for a model with properties and db fields in Wagtail/Django <https://jossingram.wordpress.com/2014/09/24/outputing-json-for-a-model-with-properties-and-db-fields-in-wagtaildjango/>`_ (24 September 2014)
+* `Bi-lingual website using Wagtail CMS <https://jossingram.wordpress.com/2014/09/17/bi-lingual-website-using-wagtail-cms/>`_ (17 September 2015)
+* `Wagtail CMS – Lesser known features <https://jossingram.wordpress.com/2014/09/12/wagtail-cms-lesser-known-features/>`_ (12 September 2014)
+* `Wagtail notes: stateful on/off hallo.js plugins <http://www.coactivate.org/projects/ejucovy/blog/2014/08/09/wagtail-notes-stateful-onoff-hallojs-plugins/>`_ (9 August 2014)
+* `Add some blockquote buttons to Wagtail CMS’ WYSIWYG Editor <https://jossingram.wordpress.com/2014/07/24/add-some-blockquote-buttons-to-wagtail-cms-wysiwyg-editor/>`_ (24 July 2014)
+* `Adding Bread Crumbs to the front end in Wagtail CMS <https://jossingram.wordpress.com/2014/07/01/adding-bread-crumbs-to-the-front-end-in-wagtail-cms/>`_ (1 July 2014)
+* `Extending hallo.js using Wagtail hooks <https://gist.github.com/jeffrey-hearn/502d0914fa4a930f08ac>`_ (9 July 2014)
+* `Wagtail notes: custom tabs per page type <http://www.coactivate.org/projects/ejucovy/blog/2014/05/10/wagtail-notes-custom-tabs-per-page-type/>`_ (10 May 2014)
+* `Wagtail notes: managing redirects as pages <http://www.coactivate.org/projects/ejucovy/blog/2014/05/10/wagtail-notes-managing-redirects-as-pages/>`_ (10 May 2014)
+* `Wagtail notes: dynamic templates per page <http://www.coactivate.org/projects/ejucovy/blog/2014/05/10/wagtail-notes-dynamic-templates-per-page/>`_ (10 May 2014)
+* `Wagtail notes: type-constrained PageChooserPanel <http://www.coactivate.org/projects/ejucovy/blog/2014/05/09/wagtail-notes-type-constrained-pagechooserpanel/>`_ (9 May 2014)
+* `How to Run the Wagtail CMS on Gondor <https://gondor.io/blog/2014/02/14/how-run-wagtail-cms-gondor/>`_ (14 February 2014)
+* `The first Wagtail tutorial <http://spapas.github.io/2014/02/13/wagtail-tutorial/>`_ (13 February 2014)
+
+.. tip::
+
+    We are working on a collection of Wagtail tutorials and best practices. Please tweet `@WagtailCMS <https://twitter.com/WagtailCMS>`_ or `contact us directly <mailto:hello@wagtail.io>`_ to share your Wagtail HOWTOs, development notes or site launches.


### PR DESCRIPTION
This is a first attempt to a collection of tutorials, how-to and developer notes from around the web.

As [suggested](https://groups.google.com/forum/#!searchin/wagtail/wagtail$20planet/wagtail/j97y2orXVp4/xX6ws_FEhBEJ) on the Groups, it would be great to start something like Planet Wagtail. But for now, a separate docs page can suffice.