### PR TITLE
Refactor edit handler classes so that they can have a persistent reference to their corresponding model

### DIFF
--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -7,9 +7,8 @@ from django import forms
 from wagtail.wagtailadmin.edit_handlers import (
     get_form_for_model,
     extract_panel_definitions_from_model_class,
-    BaseFieldPanel,
     FieldPanel,
-    BaseRichTextFieldPanel,
+    RichTextFieldPanel,
     TabbedInterface,
     ObjectList,
     PageChooserPanel,
@@ -17,7 +16,7 @@ from wagtail.wagtailadmin.edit_handlers import (
 )
 
 from wagtail.wagtailadmin.widgets import AdminPageChooser, AdminDateInput
-from wagtail.wagtailimages.edit_handlers import BaseImageChooserPanel, ImageChooserPanel
+from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 from wagtail.wagtailcore.models import Page, Site
 from wagtail.tests.models import PageChooserModel, EventPage, EventPageSpeaker
 
@@ -91,7 +90,7 @@ class TestExtractPanelDefinitionsFromModelClass(TestCase):
         result = extract_panel_definitions_from_model_class(EventPageSpeaker)
         self.assertEqual(len(result), 4)
         #print repr(result)
-        self.assertTrue(any([issubclass(panel, BaseImageChooserPanel) for panel in result]))
+        self.assertTrue(any([isinstance(panel, ImageChooserPanel) for panel in result]))
 
     def test_exclude(self):
         panels = extract_panel_definitions_from_model_class(Site, exclude=['hostname'])
@@ -103,19 +102,19 @@ class TestExtractPanelDefinitionsFromModelClass(TestCase):
         panels = extract_panel_definitions_from_model_class(EventPage)
 
         self.assertTrue(any([
-            issubclass(panel, BaseFieldPanel) and panel.field_name == 'date_from'
+            isinstance(panel, FieldPanel) and panel.field_name == 'date_from'
             for panel in panels
         ]))
 
         # returned panel types should respect modelfield.get_panel() - used on RichTextField
         self.assertTrue(any([
-            issubclass(panel, BaseRichTextFieldPanel) and panel.field_name == 'body'
+            isinstance(panel, RichTextFieldPanel) and panel.field_name == 'body'
             for panel in panels
         ]))
 
         # treebeard fields should be excluded
         self.assertFalse(any([
-            issubclass(panel, BaseFieldPanel) and panel.field_name == 'path'
+            panel.field_name == 'path'
             for panel in panels
         ]))
 
@@ -132,7 +131,7 @@ class TestTabbedInterface(TestCase):
             ObjectList([
                 InlinePanel(EventPage, 'speakers', label="Speakers"),
             ], heading='Speakers'),
-        ])
+        ]).bind_to_model(EventPage)
 
     def test_get_form_class(self):
         EventPageForm = self.EventPageTabbedInterface.get_form_class(EventPage)
@@ -211,7 +210,7 @@ class TestObjectList(TestCase):
             FieldPanel('date_from'),
             FieldPanel('date_to'),
             InlinePanel(EventPage, 'speakers', label="Speakers"),
-        ], heading='Event details', classname="shiny")
+        ], heading='Event details', classname="shiny").bind_to_model(EventPage)
 
     def test_get_form_class(self):
         EventPageForm = self.EventPageObjectList.get_form_class(EventPage)
@@ -254,7 +253,7 @@ class TestFieldPanel(TestCase):
         self.event = EventPage(title='Abergavenny sheepdog trials',
             date_from=date(2014, 7, 20), date_to=date(2014, 7, 21))
 
-        self.EndDatePanel = FieldPanel('date_to', classname='full-width')
+        self.EndDatePanel = FieldPanel('date_to', classname='full-width').bind_to_model(EventPage)
 
     def test_render_as_object(self):
         form = self.EventPageForm(
@@ -343,7 +342,7 @@ class TestPageChooserPanel(TestCase):
         model = PageChooserModel  # a model with a foreign key to Page which we want to render as a page chooser
 
         # a PageChooserPanel class that works on PageChooserModel's 'page' field
-        self.MyPageChooserPanel = PageChooserPanel('page', 'tests.EventPage')
+        self.MyPageChooserPanel = PageChooserPanel('page', 'tests.EventPage').bind_to_model(PageChooserModel)
 
         # build a form class containing the fields that MyPageChooserPanel wants
         self.PageChooserForm = self.MyPageChooserPanel.get_form_class(PageChooserModel)
@@ -388,14 +387,14 @@ class TestPageChooserPanel(TestCase):
         result = PageChooserPanel(
             'barbecue',
             'wagtailcore.site'
-        ).target_content_type()
+        ).bind_to_model(PageChooserModel).target_content_type()
         self.assertEqual(result.name, 'site')
 
     def test_target_content_type_malformed_type(self):
         result = PageChooserPanel(
             'barbecue',
             'snowman'
-        )
+        ).bind_to_model(PageChooserModel)
         self.assertRaises(ImproperlyConfigured,
                           result.target_content_type)
 
@@ -403,7 +402,7 @@ class TestPageChooserPanel(TestCase):
         result = PageChooserPanel(
             'barbecue',
             'snowman.lorry'
-        )
+        ).bind_to_model(PageChooserModel)
         self.assertRaises(ImproperlyConfigured,
                           result.target_content_type)
 
@@ -416,7 +415,7 @@ class TestInlinePanel(TestCase):
         Check that the inline panel renders the panels set on the model
         when no 'panels' parameter is passed in the InlinePanel definition
         """
-        SpeakerInlinePanel = InlinePanel(EventPage, 'speakers', label="Speakers")
+        SpeakerInlinePanel = InlinePanel(EventPage, 'speakers', label="Speakers").bind_to_model(EventPage)
         EventPageForm = SpeakerInlinePanel.get_form_class(EventPage)
 
         # SpeakerInlinePanel should instruct the form class to include a 'speakers' formset
@@ -453,7 +452,7 @@ class TestInlinePanel(TestCase):
         SpeakerInlinePanel = InlinePanel(EventPage, 'speakers', label="Speakers", panels=[
             FieldPanel('first_name'),
             ImageChooserPanel('image'),
-        ])
+        ]).bind_to_model(EventPage)
         EventPageForm = SpeakerInlinePanel.get_form_class(EventPage)
 
         # SpeakerInlinePanel should instruct the form class to include a 'speakers' formset

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -712,7 +712,7 @@ def get_page_edit_handler(page_class):
             ObjectList(page_class.content_panels, heading='Content'),
             ObjectList(page_class.promote_panels, heading='Promote'),
             ObjectList(page_class.settings_panels, heading='Settings', classname="settings")
-        ])
+        ]).bind_to_model(page_class)
 
     return PAGE_EDIT_HANDLERS[page_class]
 

--- a/wagtail/wagtaildocs/edit_handlers.py
+++ b/wagtail/wagtaildocs/edit_handlers.py
@@ -13,7 +13,12 @@ class BaseDocumentChooserPanel(BaseChooserPanel):
         return {cls.field_name: AdminDocumentChooser}
 
 
-def DocumentChooserPanel(field_name):
-    return type(str('_DocumentChooserPanel'), (BaseDocumentChooserPanel,), {
-        'field_name': field_name,
-    })
+class DocumentChooserPanel(object):
+    def __init__(self, field_name):
+        self.field_name = field_name
+
+    def bind_to_model(self, model):
+        return type(str('_DocumentChooserPanel'), (BaseDocumentChooserPanel,), {
+            'model': model,
+            'field_name': self.field_name,
+        })

--- a/wagtail/wagtailimages/edit_handlers.py
+++ b/wagtail/wagtailimages/edit_handlers.py
@@ -13,7 +13,12 @@ class BaseImageChooserPanel(BaseChooserPanel):
         return {cls.field_name: AdminImageChooser}
 
 
-def ImageChooserPanel(field_name):
-    return type(str('_ImageChooserPanel'), (BaseImageChooserPanel,), {
-        'field_name': field_name,
-    })
+class ImageChooserPanel(object):
+    def __init__(self, field_name):
+        self.field_name = field_name
+
+    def bind_to_model(self, model):
+        return type(str('_ImageChooserPanel'), (BaseImageChooserPanel,), {
+            'model': model,
+            'field_name': self.field_name,
+        })

--- a/wagtail/wagtailredirects/views.py
+++ b/wagtail/wagtailredirects/views.py
@@ -12,7 +12,7 @@ from wagtail.wagtailadmin import messages
 from wagtail.wagtailredirects import models
 
 
-REDIRECT_EDIT_HANDLER = ObjectList(models.Redirect.content_panels)
+REDIRECT_EDIT_HANDLER = ObjectList(models.Redirect.content_panels).bind_to_model(models.Redirect)
 
 
 @permission_required('wagtailredirects.change_redirect')

--- a/wagtail/wagtailsnippets/edit_handlers.py
+++ b/wagtail/wagtailsnippets/edit_handlers.py
@@ -39,9 +39,15 @@ class BaseSnippetChooserPanel(BaseChooserPanel):
         }))
 
 
-def SnippetChooserPanel(field_name, snippet_type):
-    return type(str('_SnippetChooserPanel'), (BaseSnippetChooserPanel,), {
-        'field_name': field_name,
-        'snippet_type_name': force_text(snippet_type._meta.verbose_name),
-        'snippet_type': snippet_type,
-    })
+class SnippetChooserPanel(object):
+    def __init__(self, field_name, snippet_type):
+        self.field_name = field_name
+        self.snippet_type = snippet_type
+
+    def bind_to_model(self, model):
+        return type(str('_SnippetChooserPanel'), (BaseSnippetChooserPanel,), {
+            'model': model,
+            'field_name': self.field_name,
+            'snippet_type_name': force_text(self.snippet_type._meta.verbose_name),
+            'snippet_type': self.snippet_type,
+        })

--- a/wagtail/wagtailsnippets/views/snippets.py
+++ b/wagtail/wagtailsnippets/views/snippets.py
@@ -59,7 +59,7 @@ SNIPPET_EDIT_HANDLERS = {}
 def get_snippet_edit_handler(model):
     if model not in SNIPPET_EDIT_HANDLERS:
         panels = extract_panel_definitions_from_model_class(model)
-        edit_handler = ObjectList(panels)
+        edit_handler = ObjectList(panels).bind_to_model(model)
 
         SNIPPET_EDIT_HANDLERS[model] = edit_handler
 


### PR DESCRIPTION
Previously, TabbedInterface, ObjectList, FieldPanel et al were factory functions that yield a class that has no knowledge of their corresponding models. With this update, they are now classes in their own right, meaning that when we place them in a content_panels definition, we end up with a list of 'panel definition' objects rather than a list of EditHandler classes. These panel definition objects can be 'traded in' for a proper EditHandler class by calling bind_to_model(model) - this means that our EditHandler classes are now aware of the model they are attached to.

Since bind_to_model(model) returns a fresh class each time it is called, the panel definition objects can be shared between models with no issues - so we can still make use of common definitions like wagtaildemo's LinkFields.panels.

This is a key step towards StreamField (where the model field and the edit handler both need to share the bit of configuration that defines the set of available child blocks), and opens up the possibility of further improvements to the EditHandler mechanism:

* InlinePanel no longer needs to redundantly specify the parent model as its first parameter
* PageChooserPanel and SnippetChooserPanel can inspect the foreign key to find out what model they're linking to, rather than requiring it to be specified as a parameter (#509)
* The API can probably be simplified considerably: for a start, EditHandler.get_form_class no longer needs to be passed the model as a parameter. Ultimately it might be possible for EditHandler to wrap the form handling completely, and avoid the need for the back-and-forth interaction between forms and EditHandlers that we have now.