### PR TITLE
Add scrutinizer-ci settings

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,16 @@
+tools:
+    external_code_coverage:
+        timeout: 600    # Timeout in seconds.
+        runs: 6 # Wait for 6 code coverage submisisons. Corresponds to the Travis build matrix
+
+checks:
+    python:
+        code_rating: true
+        duplicate_code: true
+
+filter:
+    excluded_paths:
+        - '*/test/*'
+        - '*/south_migrations/*'
+        - '*/migrations/*'
+        - 'wagtail/vendor/*'

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,7 @@
 tools:
     external_code_coverage:
         timeout: 600    # Timeout in seconds.
-        runs: 6 # Wait for 6 code coverage submisisons. Corresponds to the Travis build matrix
+        runs: 5 # Wait for 6 code coverage submisisons. Corresponds to the Travis build matrix
 
 checks:
     python:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,16 +1,43 @@
-tools:
-    external_code_coverage:
-        timeout: 1200    # Timeout in seconds.
-        runs: 5 # Wait for 6 code coverage submisisons. Corresponds to the Travis build matrix
-
 checks:
     python:
-        code_rating: true
         duplicate_code: true
-
+        code_rating: true
+tools:
+    external_code_coverage:
+        timeout: 1200
+        enabled: true
+        runs: 5
+        filter:
+            excluded_paths:
+                - '*/test/*'
+                - '*/south_migrations/*'
+                - '*/migrations/*'
+                - 'wagtail/vendor/*'
+            paths: {  }
+    python_analyzer:
+        enabled: true
+        config:
+            metrics: true
+            duplication_detector:
+                enabled: true
+                min_mass: 25
+        file_extensions:
+            - .py
+        filter:
+            excluded_paths:
+                - '*/test/*'
+                - '*/south_migrations/*'
+                - '*/migrations/*'
+                - 'wagtail/vendor/*'
+            paths: {  }
 filter:
     excluded_paths:
         - '*/test/*'
         - '*/south_migrations/*'
         - '*/migrations/*'
         - 'wagtail/vendor/*'
+    paths: {  }
+build_failure_conditions: {  }
+_force_disabled: {  }
+application:
+    type: none

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 tools:
     external_code_coverage:
-        timeout: 600    # Timeout in seconds.
+        timeout: 1200    # Timeout in seconds.
         runs: 5 # Wait for 6 code coverage submisisons. Corresponds to the Travis build matrix
 
 checks:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,7 +6,7 @@ tools:
     external_code_coverage:
         timeout: 1200
         enabled: true
-        runs: 5
+        runs: 2
         filter:
             excluded_paths:
                 - '*/test/*'

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -38,6 +38,5 @@ filter:
         - 'wagtail/vendor/*'
     paths: {  }
 build_failure_conditions: {  }
-_force_disabled: {  }
 application:
     type: none

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,8 @@ script:
   tox
 
 after_success:
-  coveralls
-
-after_script:
-  ocular --data-file ".coverage" --config-file ".coveragerc"
+  - coveralls
+  - ocular
 
 # Who to notify about build results
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ services:
 
 # Package installation
 install:
-  - pip install tox coveralls
+  - pip install tox coveralls scrutinizer-ocular
 
 # Pre-test configuration
 before_script:
@@ -42,6 +42,9 @@ script:
 
 after_success:
   coveralls
+
+after_script:
+  ocular --data-file ".coverage" --config-file ".coveragerc"
 
 # Who to notify about build results
 notifications:


### PR DESCRIPTION
Configured to get code coverage data from Travis CI builds.
More configuration details at https://scrutinizer-ci.com/docs/guides/python/automated-code-reviews and https://scrutinizer-ci.com/docs/tools/external-code-coverage