### PR TITLE
Image vary_key related changes

### DIFF
--- a/wagtail/wagtailimages/image_operations.py
+++ b/wagtail/wagtailimages/image_operations.py
@@ -38,6 +38,8 @@ class DoNothingOperation(Operation):
 
 
 class FillOperation(Operation):
+    vary_fields = ('focal_point_width', 'focal_point_height', 'focal_point_x', 'focal_point_y')
+
     def construct(self, size, *extra):
         # Get width and height
         width_str, height_str = size.split('x')
@@ -174,21 +176,6 @@ class FillOperation(Operation):
             height = self.height
 
         willow.resize(width, height)
-
-    def get_vary(self, image):
-        focal_point = image.get_focal_point()
-
-        if focal_point is not None:
-            focal_point_key = "%(x)d-%(y)d-%(width)dx%(height)d" % {
-                'x': int(focal_point.centroid_x),
-                'y': int(focal_point.centroid_y),
-                'width': int(focal_point.width),
-                'height': int(focal_point.height),
-            }
-        else:
-            focal_point_key = ''
-
-        return [focal_point_key]
 
 
 class MinMaxOperation(Operation):

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -302,8 +302,10 @@ class Filter(models.Model):
         vary = []
 
         for operation in self.operations:
-            if hasattr(operation, 'get_vary'):
-                vary.extend(operation.get_vary(image))
+            for field in getattr(operation, 'vary_fields', []):
+                value = getattr(image, field)
+                if value is not None:
+                    vary.append(str(value))
 
         return vary
 

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -303,9 +303,8 @@ class Filter(models.Model):
 
         for operation in self.operations:
             for field in getattr(operation, 'vary_fields', []):
-                value = getattr(image, field)
-                if value is not None:
-                    vary.append(str(value))
+                value = getattr(image, field, '')
+                vary.append(str(value))
 
         return vary
 

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -311,10 +311,12 @@ class Filter(models.Model):
 
     def get_vary_key(self, image):
         vary_string = '-'.join(self.get_vary(image))
-        vary_key = hashlib.sha1(vary_string.encode('utf-8')).hexdigest()
 
-        return vary_key[:8]
+        # Return blank string if there are no vary fields
+        if not vary_string:
+            return ''
 
+        return  hashlib.sha1(vary_string.encode('utf-8')).hexdigest()[:8]
 
     _registered_operations = None
 

--- a/wagtail/wagtailimages/tests/test_image_operations.py
+++ b/wagtail/wagtailimages/tests/test_image_operations.py
@@ -347,4 +347,4 @@ class TestVaryKey(unittest.TestCase):
         fil = Filter(spec='fill-100x100')
         vary_key = fil.get_vary_key(image)
 
-        self.assertEqual(vary_key, 'fa9841ef')
+        self.assertEqual(vary_key, '0bbe3b2f')

--- a/wagtail/wagtailimages/tests/test_image_operations.py
+++ b/wagtail/wagtailimages/tests/test_image_operations.py
@@ -333,7 +333,7 @@ class TestVaryKey(unittest.TestCase):
         fil = Filter(spec='fill-100x100')
         vary_key = fil.get_vary_key(image)
 
-        self.assertEqual(vary_key, '')
+        self.assertEqual(vary_key, '2e16d0ba')
 
     def test_vary_key_fill_filter_with_focal_point(self):
         image = Image(

--- a/wagtail/wagtailimages/tests/test_image_operations.py
+++ b/wagtail/wagtailimages/tests/test_image_operations.py
@@ -326,14 +326,14 @@ class TestVaryKey(unittest.TestCase):
         fil = Filter(spec='max-100x100')
         vary_key = fil.get_vary_key(image)
 
-        self.assertEqual(vary_key, 'da39a3ee')
+        self.assertEqual(vary_key, '')
 
     def test_vary_key_fill_filter(self):
         image = Image(width=1000, height=1000)
         fil = Filter(spec='fill-100x100')
         vary_key = fil.get_vary_key(image)
 
-        self.assertEqual(vary_key, 'da39a3ee')
+        self.assertEqual(vary_key, '')
 
     def test_vary_key_fill_filter_with_focal_point(self):
         image = Image(

--- a/wagtail/wagtailimages/tests/test_image_operations.py
+++ b/wagtail/wagtailimages/tests/test_image_operations.py
@@ -2,7 +2,7 @@ import unittest
 
 from wagtail.wagtailimages import image_operations
 from wagtail.wagtailimages.exceptions import InvalidFilterSpecError
-from wagtail.wagtailimages.models import Image
+from wagtail.wagtailimages.models import Image, Filter
 
 
 class WillowOperationRecorder(object):
@@ -318,3 +318,33 @@ class TestWidthHeightOperation(ImageOperationTestCase):
     ]
 
 TestWidthHeightOperation.setup_test_methods()
+
+
+class TestVaryKey(unittest.TestCase):
+    def test_vary_key(self):
+        image = Image(width=1000, height=1000)
+        fil = Filter(spec='max-100x100')
+        vary_key = fil.get_vary_key(image)
+
+        self.assertEqual(vary_key, 'da39a3ee')
+
+    def test_vary_key_fill_filter(self):
+        image = Image(width=1000, height=1000)
+        fil = Filter(spec='fill-100x100')
+        vary_key = fil.get_vary_key(image)
+
+        self.assertEqual(vary_key, 'da39a3ee')
+
+    def test_vary_key_fill_filter_with_focal_point(self):
+        image = Image(
+            width=1000,
+            height=1000,
+            focal_point_width=100,
+            focal_point_height=100,
+            focal_point_x=500,
+            focal_point_y=500,
+        )
+        fil = Filter(spec='fill-100x100')
+        vary_key = fil.get_vary_key(image)
+
+        self.assertEqual(vary_key, 'fa9841ef')


### PR DESCRIPTION
This includes a couple of fixes to ``vary_key`` generation.
 - Replaced ``get_vary`` method with ``vary_fields``
 - Operations which do not have any ``vary_fields`` will produce a blank vary key (this fixes an issue where all your renditions would be regenerated on upgrade to 0.9. This doesn't apply to the ``fill`` filter though).