### PR TITLE
Added Drone config

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,8 @@
+image: kaedroho/django-base
+script:
+ - pip3.4 install mock python-dateutil pytz elasticsearch
+ - python3.4 setup.py install
+ - python3.4 runtests.py
+services:
+ - postgres
+ - dockerfile/elasticsearch

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -16,6 +16,8 @@ DATABASES = {
         'TEST_NAME': os.environ.get('DATABASE_NAME', 'test_wagtaildemo'),
         'USER': os.environ.get('DATABASE_USER', 'postgres'),
         'PASSWORD': os.environ.get('DATABASE_PASS', None),
+        'HOST': os.environ.get('POSTGRES_PORT_5432_TCP_ADDR', None),
+        'PORT': os.environ.get('POSTGRES_PORT_5432_TCP_PORT', None),
     }
 }
 
@@ -121,6 +123,13 @@ try:
         'TIMEOUT': 10,
         'max_retries': 1,
     }
+
+    # Check if we're running in Drone
+    if 'ELASTICSEARCH_PORT_9200_TCP_PORT' in os.environ:
+        ip = os.environ.get('ELASTICSEARCH_PORT_9200_TCP_ADDR')
+        port = os.environ.get('ELASTICSEARCH_PORT_9200_TCP_PORT')
+
+        WAGTAILSEARCH_BACKENDS['elasticsearch']['URLS'] = ['http://%s:%s/' % (ip, port)]
 except ImportError:
     pass
 


### PR DESCRIPTION
This PR adds the necessary configuration to make wagtail run on Drone (https://github.com/drone/drone).

Drone is a CI system built on Docker. It has the following advantages over Travis CI:
 - Self hosted, no fair usage limits
 - Uses my ``django-base`` Docker image which has ``libsass``, ``psycopg`` and ``Pillow`` preinstalled. This should give much faster build speeds.
  - This also means that the test suite runs in the exact same environment that a production wagtail site based on that image would.
 - You can use any docker image in the docker hub as a service (30000+ and updated frequently)
 - Like Travis, it integrates with github (including pull requests)

The tests settings did need a bit of tweaking as Postgres and Elasticsearch run in different containers.

It currently only tests Python 3.4 on postgres (this is due to my own personal time limitations, I'll hopefully have it all up and running soon if theres enough interest)

See it in action here:
http://drone.kaed.uk/github.com/kaedroho/wagtail
http://drone.kaed.uk/github.com/kaedroho/wagtail/drone/1dff53f8cc04aee0c68f3c12dd4e2b8152e453e6