### PR TITLE
Fixed precision of "fill" operation resizing. Fixes #968

### DIFF
--- a/wagtail/wagtailimages/image_operations.py
+++ b/wagtail/wagtailimages/image_operations.py
@@ -158,22 +158,16 @@ class FillOperation(Operation):
         # Crop!
         willow.crop(int(left), int(top), int(right), int(bottom))
 
-        # Resize the final image
+        # Get scale for resizing
+        # The scale should be the same for both the horizontal and
+        # vertical axes
         aftercrop_width, aftercrop_height = willow.get_size()
-        horz_scale = self.width / aftercrop_width
-        vert_scale = self.height / aftercrop_height
+        scale = self.width / aftercrop_width
 
-        if aftercrop_width <= self.width or aftercrop_height <= self.height:
-            return
-
-        if horz_scale > vert_scale:
-            width = self.width
-            height = int(aftercrop_height * horz_scale)
-        else:
-            width = int(aftercrop_width * vert_scale)
-            height = self.height
-
-        willow.resize(width, height)
+        # Only resize if the image is too big
+        if scale < 1.0:
+            # Resize!
+            willow.resize(self.width, self.height)
 
     def get_vary(self, image):
         focal_point = image.get_focal_point()

--- a/wagtail/wagtailimages/tests/test_image_operations.py
+++ b/wagtail/wagtailimages/tests/test_image_operations.py
@@ -151,6 +151,13 @@ class TestFillOperation(ImageOperationTestCase):
             ('resize', (800, 600), {}),
         ]),
 
+        # Basic usage with an oddly-sized original image
+        # This checks for a rounding precision issue (#968)
+        ('fill-200x200', Image(width=539, height=720), [
+            ('crop', (0, 90, 539, 629), {}),
+            ('resize', (200, 200), {}),
+        ]),
+
         # Closeness shouldn't have any effect when used without a focal point
         ('fill-800x600-c100', Image(width=1000, height=1000), [
             ('crop', (0, 125, 1000, 875), {}),


### PR DESCRIPTION
This also removes some unnecessary calculations from the "fill" filter.