### PR TITLE
Fix password reset URL in emails [fixes #841]

### DIFF
--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -154,8 +154,10 @@ class PasswordResetForm(PasswordResetForm):
             }
 
             base_url = getattr(settings, 'BASE_URL', False)
-            if base_url:
-                context.update({'base_url': base_url})
+            if not base_url:
+                base_url = '%s://%s' % (protocol, domain)
+
+            context.update({'base_url': base_url})
 
             from pprint import pprint
             pprint(context)

--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -161,10 +161,6 @@ class PasswordResetForm(PasswordResetForm):
 
             context.update({'base_url': base_url})
 
-            from pprint import pprint
-            pprint(context)
-            pprint(email_template_name)
-
             self.send_mail(subject_template_name, email_template_name,
                            context, from_email, user.email,
                            html_email_template_name=html_email_template_name)

--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -143,6 +143,8 @@ class PasswordResetForm(PasswordResetForm):
                 domain = current_site.domain
             else:
                 site_name = domain = domain_override
+
+            protocol = 'https' if use_https else 'http'
             context = {
                 'email': user.email,
                 'domain': domain,
@@ -150,7 +152,7 @@ class PasswordResetForm(PasswordResetForm):
                 'uid': urlsafe_base64_encode(force_bytes(user.pk)),
                 'user': user,
                 'token': token_generator.make_token(user),
-                'protocol': 'https' if use_https else 'http',
+                'protocol': protocol,
             }
 
             base_url = getattr(settings, 'BASE_URL', False)

--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/email.txt
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/email.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 {% trans "Please follow the link below to reset your password" %}
-{% if base_url %}{{ base_url }}{% else %}{{ protocol }}://{{ domain }}{% endif %}{% url 'wagtailadmin_password_reset_confirm' uidb64=uid token=token %}
+{{ base_url }}{% url 'wagtailadmin_password_reset_confirm' uidb64=uid token=token %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/email.txt
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/email.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 {% trans "Please follow the link below to reset your password" %}
-{{ protocol }}://{{ domain }}{% url 'wagtailadmin_password_reset_confirm' uidb64=uid token=token %}
+{% if base_url %}{{ base_url }}{% else %}{{ protocol }}://{{ domain }}{% endif %}{% url 'wagtailadmin_password_reset_confirm' uidb64=uid token=token %}

--- a/wagtail/wagtailadmin/tests/test_password_reset.py
+++ b/wagtail/wagtailadmin/tests/test_password_reset.py
@@ -1,0 +1,33 @@
+from django.test import TestCase, override_settings
+from django.core import mail
+
+from wagtail.tests.utils import WagtailTestUtils
+from wagtail.wagtailcore.models import Site
+
+
+class TestUserPasswordReset(TestCase, WagtailTestUtils):
+    fixtures = ['test.json']
+
+    # need to clear urlresolver caches before/after tests, because we override ROOT_URLCONF
+    # in some tests here
+    def setUp(self):
+        from django.core.urlresolvers import clear_url_caches
+        clear_url_caches()
+
+    def tearDown(self):
+        from django.core.urlresolvers import clear_url_caches
+        clear_url_caches()
+
+    @override_settings(ROOT_URLCONF="wagtail.wagtailadmin.urls")
+    def test_email_found_default_url(self):
+        response = self.client.post('/password_reset/', {'email': 'siteeditor@example.com'})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("testserver", mail.outbox[0].body)
+
+    @override_settings(ROOT_URLCONF="wagtail.wagtailadmin.urls", BASE_URL='http://mysite.com')
+    def test_email_found_base_url(self):
+        response = self.client.post('/password_reset/', {'email': 'siteeditor@example.com'})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("mysite.com", mail.outbox[0].body)


### PR DESCRIPTION
Hi,

This is my attempt to fix #841.

Unfortunately it is not possible to inject the unified URL in the password reset view as the `extra_context` dict is passed only to the password reset form (see [django/contrib/auth/views](https://github.com/django/django/blob/1.7.1/django/contrib/auth/views.py#L134-L174))

Instead, overriding the `save()` method on `PasswordResetForm` (modelled on the latest [Django master](https://github.com/django/django/blob/master/django/contrib/auth/forms.py))

Any feedback and suggestion are welcome.
