### PR TITLE
Added admin_form_fields to Image model

### DIFF
--- a/wagtail/tests/migrations/0009_customimagewithadminformfields_customimagewithoutadminformfields.py
+++ b/wagtail/tests/migrations/0009_customimagewithadminformfields_customimagewithoutadminformfields.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import wagtail.wagtailadmin.taggable
+from django.conf import settings
+import taggit.managers
+import wagtail.wagtailimages.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taggit', '0001_initial'),
+        ('tests', '0008_registerdecorator'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CustomImageWithAdminFormFields',
+            fields=[
+                ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
+                ('title', models.CharField(verbose_name='Title', max_length=255)),
+                ('file', models.ImageField(verbose_name='File', height_field='height', upload_to=wagtail.wagtailimages.models.get_upload_to, width_field='width')),
+                ('width', models.IntegerField(editable=False)),
+                ('height', models.IntegerField(editable=False)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('focal_point_x', models.PositiveIntegerField(blank=True, null=True)),
+                ('focal_point_y', models.PositiveIntegerField(blank=True, null=True)),
+                ('focal_point_width', models.PositiveIntegerField(blank=True, null=True)),
+                ('focal_point_height', models.PositiveIntegerField(blank=True, null=True)),
+                ('caption', models.CharField(max_length=255)),
+                ('not_editable_field', models.CharField(max_length=255)),
+                ('tags', taggit.managers.TaggableManager(verbose_name='Tags', help_text=None, through='taggit.TaggedItem', blank=True, to='taggit.Tag')),
+                ('uploaded_by_user', models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True, blank=True, editable=False)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=(models.Model, wagtail.wagtailadmin.taggable.TagSearchable),
+        ),
+        migrations.CreateModel(
+            name='CustomImageWithoutAdminFormFields',
+            fields=[
+                ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
+                ('title', models.CharField(verbose_name='Title', max_length=255)),
+                ('file', models.ImageField(verbose_name='File', height_field='height', upload_to=wagtail.wagtailimages.models.get_upload_to, width_field='width')),
+                ('width', models.IntegerField(editable=False)),
+                ('height', models.IntegerField(editable=False)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('focal_point_x', models.PositiveIntegerField(blank=True, null=True)),
+                ('focal_point_y', models.PositiveIntegerField(blank=True, null=True)),
+                ('focal_point_width', models.PositiveIntegerField(blank=True, null=True)),
+                ('focal_point_height', models.PositiveIntegerField(blank=True, null=True)),
+                ('caption', models.CharField(max_length=255)),
+                ('not_editable_field', models.CharField(max_length=255)),
+                ('tags', taggit.managers.TaggableManager(verbose_name='Tags', help_text=None, through='taggit.TaggedItem', blank=True, to='taggit.Tag')),
+                ('uploaded_by_user', models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True, blank=True, editable=False)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=(models.Model, wagtail.wagtailadmin.taggable.TagSearchable),
+        ),
+    ]

--- a/wagtail/tests/models.py
+++ b/wagtail/tests/models.py
@@ -20,6 +20,7 @@ from wagtail.wagtailsnippets.models import register_snippet
 from wagtail.wagtailsnippets.edit_handlers import SnippetChooserPanel
 from wagtail.wagtailsearch import index
 from wagtail.contrib.wagtailroutablepage.models import RoutablePage
+from wagtail.wagtailimages.models import AbstractImage, Image
 
 
 EVENT_AUDIENCE_CHOICES = (
@@ -522,3 +523,17 @@ register_snippet(RegisterFunction)
 @register_snippet
 class RegisterDecorator(models.Model):
     pass
+
+
+class CustomImageWithoutAdminFormFields(AbstractImage):
+    caption = models.CharField(max_length=255)
+    not_editable_field = models.CharField(max_length=255)
+
+
+class CustomImageWithAdminFormFields(AbstractImage):
+    caption = models.CharField(max_length=255)
+    not_editable_field = models.CharField(max_length=255)
+
+    admin_form_fields = Image.admin_form_fields + (
+        'caption',
+    )

--- a/wagtail/wagtailimages/forms.py
+++ b/wagtail/wagtailimages/forms.py
@@ -19,6 +19,7 @@ def formfield_for_dbfield(db_field, **kwargs):
 def get_image_form(model):
     return modelform_factory(
         model,
+        fields=model.admin_form_fields,
         formfield_callback=formfield_for_dbfield,
         # set the 'file' widget to a FileInput rather than the default ClearableFileInput
         # so that when editing, we don't get the 'currently: ...' banner which is

--- a/wagtail/wagtailimages/forms.py
+++ b/wagtail/wagtailimages/forms.py
@@ -1,7 +1,10 @@
+import warnings
+
 from django import forms
 from django.forms.models import modelform_factory
 from django.utils.translation import ugettext as _
 
+from wagtail.utils.deprecation import RemovedInWagtail11Warning
 from wagtail.wagtailimages.formats import get_image_formats
 from wagtail.wagtailimages.fields import WagtailImageField
 
@@ -17,9 +20,20 @@ def formfield_for_dbfield(db_field, **kwargs):
 
 
 def get_image_form(model):
+    if hasattr(model, 'admin_form_fields'):
+        fields = model.admin_form_fields
+    else:
+        fields = '__all__'
+
+        warnings.warn(
+            "Custom image models without an 'admin_form_fields' attribute are now deprecated. "
+            "Add admin_form_fields = (tuple of field names) to {classname}".format(
+                classname=model.__name__
+            ), RemovedInWagtail11Warning, stacklevel=2)
+
     return modelform_factory(
         model,
-        fields=model.admin_form_fields,
+        fields=fields,
         formfield_callback=formfield_for_dbfield,
         # set the 'file' widget to a FileInput rather than the default ClearableFileInput
         # so that when editing, we don't get the 'currently: ...' banner which is

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -67,16 +67,6 @@ class AbstractImage(models.Model, TagSearchable):
     focal_point_width = models.PositiveIntegerField(null=True, blank=True)
     focal_point_height = models.PositiveIntegerField(null=True, blank=True)
 
-    admin_form_fields = (
-        'title',
-        'file',
-        'tags',
-        'focal_point_x',
-        'focal_point_y',
-        'focal_point_width',
-        'focal_point_height',
-    )
-
     def get_usage(self):
         return get_object_usage(self)
 
@@ -235,7 +225,15 @@ class AbstractImage(models.Model, TagSearchable):
 
 
 class Image(AbstractImage):
-    pass
+    admin_form_fields = (
+        'title',
+        'file',
+        'tags',
+        'focal_point_x',
+        'focal_point_y',
+        'focal_point_width',
+        'focal_point_height',
+    )
 
 
 # Do smartcropping calculations when user saves an image without a focal point

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -67,6 +67,16 @@ class AbstractImage(models.Model, TagSearchable):
     focal_point_width = models.PositiveIntegerField(null=True, blank=True)
     focal_point_height = models.PositiveIntegerField(null=True, blank=True)
 
+    admin_form_fields = (
+        'title',
+        'file',
+        'tags',
+        'focal_point_x',
+        'focal_point_y',
+        'focal_point_width',
+        'focal_point_height',
+    )
+
     def get_usage(self):
         return get_object_usage(self)
 

--- a/wagtail/wagtailimages/tests/tests.py
+++ b/wagtail/wagtailimages/tests/tests.py
@@ -306,19 +306,19 @@ class TestGetImageForm(TestCase, WagtailTestUtils):
         ])
 
     def test_file_field(self):
-        form = get_image_form(Image)
+        form = get_image_form(WagtailImage)
 
         self.assertIsInstance(form.base_fields['file'], WagtailImageField)
         self.assertIsInstance(form.base_fields['file'].widget, forms.FileInput)
 
     def test_tags_field(self):
-        form = get_image_form(Image)
+        form = get_image_form(WagtailImage)
 
         self.assertIsInstance(form.base_fields['tags'], TagField)
         self.assertIsInstance(form.base_fields['tags'].widget, TagWidget)
 
     def test_focal_point_fields(self):
-        form = get_image_form(Image)
+        form = get_image_form(WagtailImage)
 
         self.assertIsInstance(form.base_fields['focal_point_x'], forms.IntegerField)
         self.assertIsInstance(form.base_fields['focal_point_y'], forms.IntegerField)


### PR DESCRIPTION
In Django 1.7, creating forms from a model without specifying a list of fields is deprecated.

This commit makes the get_image_form function look for a field called admin_form_fields on the Image model (which is set to a tuple of field names) and uses it for building the form.