### PR TITLE
[streamfield] Search

### DIFF
--- a/wagtail/wagtailcore/blocks.py
+++ b/wagtail/wagtailcore/blocks.py
@@ -361,7 +361,7 @@ class CharBlock(FieldBlock):
         super(CharBlock, self).__init__(**kwargs)
 
     def get_searchable_content(self, value):
-        return [value]
+        return [force_text(value)]
 
 
 class URLBlock(FieldBlock):
@@ -380,7 +380,7 @@ class RichTextBlock(FieldBlock):
         return mark_safe('<div class="rich-text">' + expand_db_html(value) + '</div>')
 
     def get_searchable_content(self, value):
-        return [value]
+        return [force_text(value)]
 
 
 class RawHTMLBlock(FieldBlock):

--- a/wagtail/wagtailcore/blocks.py
+++ b/wagtail/wagtailcore/blocks.py
@@ -353,9 +353,6 @@ class FieldBlock(Block):
     def clean(self, value):
         return self.field.clean(value)
 
-    def get_searchable_content(self, value):
-        return [value]
-
 
 class CharBlock(FieldBlock):
     def __init__(self, required=True, help_text=None, max_length=None, min_length=None, **kwargs):
@@ -363,10 +360,15 @@ class CharBlock(FieldBlock):
         self.field = forms.CharField(required=required, help_text=help_text, max_length=max_length, min_length=min_length)
         super(CharBlock, self).__init__(**kwargs)
 
+    def get_searchable_content(self, value):
+        return [value]
+
+
 class URLBlock(FieldBlock):
     def __init__(self, required=True, help_text=None, max_length=None, min_length=None, **kwargs):
         self.field = forms.URLField(required=required, help_text=help_text, max_length=max_length, min_length=min_length)
         super(URLBlock, self).__init__(**kwargs)
+
 
 class RichTextBlock(FieldBlock):
     @cached_property
@@ -376,6 +378,10 @@ class RichTextBlock(FieldBlock):
 
     def render_basic(self, value):
         return mark_safe('<div class="rich-text">' + expand_db_html(value) + '</div>')
+
+    def get_searchable_content(self, value):
+        return [value]
+
 
 class RawHTMLBlock(FieldBlock):
     def __init__(self, required=True, help_text=None, max_length=None, min_length=None, **kwargs):

--- a/wagtail/wagtailcore/fields.py
+++ b/wagtail/wagtailcore/fields.py
@@ -82,3 +82,6 @@ class StreamField(with_metaclass(models.SubfieldBase, models.Field)):
     def value_to_string(self, obj):
         value = self._get_val_from_obj(obj)
         return self.get_prep_value(value)
+
+    def get_searchable_content(self, value):
+        return self.stream_block.get_searchable_content(value)

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -292,7 +292,7 @@ class TestStructBlock(unittest.TestCase):
             'link': 'http://www.wagtail.io',
         })
 
-        self.assertEqual(content, ["Wagtail site", "http://www.wagtail.io"])
+        self.assertEqual(content, ["Wagtail site"])
 
 
 class TestListBlock(unittest.TestCase):
@@ -447,7 +447,7 @@ class TestListBlock(unittest.TestCase):
             },
         ])
 
-        self.assertEqual(content, ["Wagtail", "http://www.wagtail.io", "Django", "http://www.djangoproject.com"])
+        self.assertEqual(content, ["Wagtail", "Django"])
 
 
 class TestStreamBlock(unittest.TestCase):

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -35,6 +35,12 @@ class TestFieldBlock(unittest.TestCase):
 
         self.assertIn('This field is required.', html)
 
+    def test_charfield_searchable_content(self):
+        block = blocks.CharBlock()
+        content = block.get_searchable_content("Hello world!")
+
+        self.assertEqual(content, ["Hello world!"])
+
     def test_choicefield_render(self):
         class ChoiceBlock(blocks.FieldBlock):
             field = forms.ChoiceField(choices=(
@@ -61,6 +67,19 @@ class TestFieldBlock(unittest.TestCase):
         self.assertIn('<select id="" name="" placeholder="">', html)
         self.assertIn('<option value="choice-1">Choice 1</option>', html)
         self.assertIn('<option value="choice-2" selected="selected">Choice 2</option>', html)
+
+    @unittest.expectedFailure # Returning "choice-1" instead of "Choice 1"
+    def test_choicefield_searchable_content(self):
+        class ChoiceBlock(blocks.FieldBlock):
+            field = forms.ChoiceField(choices=(
+                ('choice-1', "Choice 1"),
+                ('choice-2', "Choice 2"),
+            ))
+
+        block = ChoiceBlock()
+        content = block.get_searchable_content("choice-1")
+
+        self.assertEqual(content, ["Choice 1"])
 
 
 class TestMeta(unittest.TestCase):
@@ -262,6 +281,19 @@ class TestStructBlock(unittest.TestCase):
         block = LinkBlock()
         self.assertIn('<script type="text/x-html-template">hello world</script>', block.all_html_declarations())
 
+    def test_searchable_content(self):
+        class LinkBlock(blocks.StructBlock):
+            title = blocks.CharBlock()
+            link = blocks.URLBlock()
+
+        block = LinkBlock()
+        content = block.get_searchable_content({
+            'title': "Wagtail site",
+            'link': 'http://www.wagtail.io',
+        })
+
+        self.assertEqual(content, ["Wagtail site", "http://www.wagtail.io"])
+
 
 class TestListBlock(unittest.TestCase):
     def test_initialise_with_class(self):
@@ -397,6 +429,25 @@ class TestListBlock(unittest.TestCase):
 
         block = blocks.ListBlock(CharBlockWithDeclarations())
         self.assertIn('<script type="text/x-html-template">hello world</script>', block.all_html_declarations())
+
+    def test_searchable_content(self):
+        class LinkBlock(blocks.StructBlock):
+            title = blocks.CharBlock()
+            link = blocks.URLBlock()
+
+        block = blocks.ListBlock(LinkBlock())
+        content = block.get_searchable_content([
+            {
+                'title': "Wagtail",
+                'link': 'http://www.wagtail.io',
+            },
+            {
+                'title': "Django",
+                'link': 'http://www.djangoproject.com',
+            },
+        ])
+
+        self.assertEqual(content, ["Wagtail", "http://www.wagtail.io", "Django", "http://www.djangoproject.com"])
 
 
 class TestStreamBlock(unittest.TestCase):
@@ -646,3 +697,32 @@ class TestStreamBlock(unittest.TestCase):
 
         block_value = block.value_from_datadict(post_data, {}, 'article')
         self.assertEqual(block_value[2].value, "heading 2")
+
+    def test_searchable_content(self):
+        class ArticleBlock(blocks.StreamBlock):
+            heading = blocks.CharBlock()
+            paragraph = blocks.CharBlock()
+
+        block = ArticleBlock()
+        value = block.to_python([
+            {
+                'type': 'heading',
+                'value': "My title",
+            },
+            {
+                'type': 'paragraph',
+                'value': 'My first paragraph',
+            },
+            {
+                'type': 'paragraph',
+                'value': 'My second paragraph',
+            },
+        ])
+
+        content = block.get_searchable_content(value)
+
+        self.assertEqual(content, [
+             "My title",
+             "My first paragraph",
+             "My second paragraph",
+        ])

--- a/wagtail/wagtailsearch/index.py
+++ b/wagtail/wagtailsearch/index.py
@@ -116,7 +116,10 @@ class BaseField(object):
     def get_value(self, obj):
         try:
             field = self.get_field(obj.__class__)
-            return field._get_val_from_obj(obj)
+            value = field._get_val_from_obj(obj)
+            if hasattr(field, 'get_searchable_content'):
+                value = field.get_searchable_content(value)
+            return value
         except models.fields.FieldDoesNotExist:
             value = getattr(obj, self.field_name, None)
             if hasattr(value, '__call__'):


### PR DESCRIPTION
This PR adds a new method to streamfield blocks to allow them to return a list of strings to add to the search index.

It also tweaks ``SearchField`` to make it use the ``get_searchable_content`` method if it is defined on the field.