### PR TITLE
Remove built dependencies

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -41,16 +41,8 @@ This provides everything you need to create a new Wagtail project from scratch, 
 
 You will need Python's `pip <http://pip.readthedocs.org/en/latest/installing.html>`__ package manager. We also recommend `virtualenvwrapper <http://virtualenvwrapper.readthedocs.org/en/latest/>`_ so that you can manage multiple independent Python environments for different projects - although this is not strictly necessary if you intend to do all your development under Vagrant.
 
-Wagtail is based on the Django web framework and various other Python libraries. Most of these are pure Python and will install automatically using ``pip``, but there are a few native-code components that require further attention:
 
- * libsass-python (for compiling SASS stylesheets) - requires a C++ compiler and the Python development headers.
- * Pillow (for image processing) - additionally requires libjpeg and zlib.
-
-On Debian or Ubuntu, these can be installed with the command::
-
-    sudo apt-get install python-dev python-pip g++ libjpeg62-dev zlib1g-dev
-
-With these dependencies installed, Wagtail can then be installed with the command::
+Wagtail can be installed with the command::
 
     pip install wagtail
 

--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,9 @@ PY3 = sys.version_info[0] == 3
 install_requires = [
     "Django>=1.7.0,<1.8",
     "django-compressor>=1.4",
-    "django-libsass>=0.2",
     "django-modelcluster>=0.5",
     "django-taggit==0.12.2",
     "django-treebeard==3.0",
-    "Pillow>=2.6.1",
     "beautifulsoup4>=4.3.2",
     "html5lib==0.999",
     "Unidecode>=0.04.14",

--- a/wagtail/project_template/requirements.txt
+++ b/wagtail/project_template/requirements.txt
@@ -1,6 +1,8 @@
 # Minimal requirements
 Django>=1.7,<1.8
 wagtail==0.8.4
+django-libsass>=0.2
+Pillow>=2.6.1
 
 # Recommended components (require additional setup):
 # psycopg2==2.5.2


### PR DESCRIPTION
This commit removes libsass and Pillow from the setup.py dependency list. This greatly improves install performance and also means that the basic Wagtail installation is pure-python (so no build tools need to be on the end users host machine).

None of these dependencies are directly called from within Wagtail so the start project command continues to work correctly.