### PR TITLE
Fix Error serving documents with Django Cache Middleware enabled [#983]

### DIFF
--- a/wagtail/wagtaildocs/views/serve.py
+++ b/wagtail/wagtaildocs/views/serve.py
@@ -1,6 +1,6 @@
 from django.shortcuts import get_object_or_404
-from django.core.servers.basehttp import FileWrapper
 from django.http import HttpResponse
+from wsgiref.util import FileWrapper
 
 from wagtail.wagtaildocs.models import Document, document_served
 

--- a/wagtail/wagtaildocs/views/serve.py
+++ b/wagtail/wagtaildocs/views/serve.py
@@ -1,6 +1,6 @@
 from django.shortcuts import get_object_or_404
-from django.http import HttpResponse
 from wsgiref.util import FileWrapper
+from django.http import StreamingHttpResponse
 
 from wagtail.wagtaildocs.models import Document, document_served
 
@@ -8,7 +8,7 @@ from wagtail.wagtaildocs.models import Document, document_served
 def serve(request, document_id, document_filename):
     doc = get_object_or_404(Document, id=document_id)
     wrapper = FileWrapper(doc.file)
-    response = HttpResponse(wrapper, content_type='application/octet-stream')
+    response = StreamingHttpResponse(wrapper, content_type='application/octet-stream')
 
     # TODO: strip out weird characters like semicolons from the filename
     # (there doesn't seem to be an official way of escaping them)


### PR DESCRIPTION
Changes to fix #983:

- changed the import to `from wsgiref.util import FileWrapper`
- updated the view to return a `StreamingHttpResponse`