### PR TITLE
Send instance in correct kwarg in document_served signal

### DIFF
--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -550,7 +550,8 @@ class TestServeView(TestCase):
         self.get()
 
         self.assertEqual(mock_handler.call_count, 1)
-        self.assertEqual(mock_handler.mock_calls[0][2]['sender'], self.document)
+        self.assertEqual(mock_handler.mock_calls[0][2]['sender'], models.Document)
+        self.assertEqual(mock_handler.mock_calls[0][2]['instance'], self.document)
 
     def test_with_nonexistent_document(self):
         response = self.client.get(reverse('wagtaildocs_serve', args=(1000, 'blahblahblah', )))

--- a/wagtail/wagtaildocs/views/serve.py
+++ b/wagtail/wagtaildocs/views/serve.py
@@ -16,6 +16,6 @@ def serve(request, document_id, document_filename):
     response['Content-Length'] = doc.file.size
 
     # Send document_served signal
-    document_served.send(sender=doc, request=request)
+    document_served.send(sender=Document, instance=doc, request=request)
 
     return response


### PR DESCRIPTION
Was previously using "sender" which should be set to the document class