### PR TITLE
Use BASE_URL in password reset email if available - fixes #841

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/email.txt
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/email.txt
@@ -1,3 +1,3 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}{% base_url_setting as base_url %}
 {% trans "Please follow the link below to reset your password" %}
-{{ protocol }}://{{ domain }}{% url 'wagtailadmin_password_reset_confirm' uidb64=uid token=token %}
+{% if base_url %}{{ base_url }}{% else %}{{ protocol }}://{{ domain }}{% endif %}{% url 'wagtailadmin_password_reset_confirm' uidb64=uid token=token %}

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -134,6 +134,11 @@ def usage_count_enabled():
     return getattr(settings, 'WAGTAIL_USAGE_COUNT_ENABLED', False)
 
 
+@register.assignment_tag
+def base_url_setting():
+    return getattr(settings, 'BASE_URL', None)
+
+
 class EscapeScriptNode(template.Node):
     TAG_NAME = 'escapescript'
     SCRIPT_RE = re.compile(r'<(-*)/script>')

--- a/wagtail/wagtailadmin/tests/test_password_reset.py
+++ b/wagtail/wagtailadmin/tests/test_password_reset.py
@@ -1,0 +1,33 @@
+from django.test import TestCase, override_settings
+from django.core import mail
+
+from wagtail.tests.utils import WagtailTestUtils
+from wagtail.wagtailcore.models import Site
+
+
+class TestUserPasswordReset(TestCase, WagtailTestUtils):
+    fixtures = ['test.json']
+
+    # need to clear urlresolver caches before/after tests, because we override ROOT_URLCONF
+    # in some tests here
+    def setUp(self):
+        from django.core.urlresolvers import clear_url_caches
+        clear_url_caches()
+
+    def tearDown(self):
+        from django.core.urlresolvers import clear_url_caches
+        clear_url_caches()
+
+    @override_settings(ROOT_URLCONF="wagtail.wagtailadmin.urls")
+    def test_email_found_default_url(self):
+        response = self.client.post('/password_reset/', {'email': 'siteeditor@example.com'})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("testserver", mail.outbox[0].body)
+
+    @override_settings(ROOT_URLCONF="wagtail.wagtailadmin.urls", BASE_URL='http://mysite.com')
+    def test_email_found_base_url(self):
+        response = self.client.post('/password_reset/', {'email': 'siteeditor@example.com'})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("mysite.com", mail.outbox[0].body)


### PR DESCRIPTION
A simpler fix for #841 which doesn't require re-plumbing the PasswordResetForm logic - here we just pass BASE_URL in to the template via a custom tag instead.