### PR TITLE
Add a default BASE_URL setting to the project template

### DIFF
--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -30,7 +30,7 @@ ALLOWED_HOSTS = []
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
-BASE_URL = 'http://localhost:8000'
+BASE_URL = 'http://example.com'
 
 
 # Application definition

--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -28,6 +28,11 @@ TEMPLATE_DEBUG = True
 ALLOWED_HOSTS = []
 
 
+# Base URL to use when referring to full URLs within the Wagtail admin backend -
+# e.g. in notification emails. Don't include '/admin' or a trailing slash
+BASE_URL = 'http://localhost:8000'
+
+
 # Application definition
 
 INSTALLED_APPS = (


### PR DESCRIPTION
A quick follow-up to #997 (and #826) - now that we're using `BASE_URL` in one more place, it's important to make sure people actually set it, so it ought to be in our project template.

I was a bit torn over whether it should be 'http://example.com' or 'http://localhost:8000' in the default file - 'http://localhost:8000' stands a chance of being the actual correct value (except that local sites probably won't have email enabled, and as of 0.8.x we've still got the whole 8000 vs 8111 thing anyhow), but I figured that 'http://example.com' was the better choice as it screams "CHANGE ME", and is easier to find in the codebase if you see it showing up in your emails (and doesn't give the false impression that it's linked to the Site record within the admin). Shout now (i.e. in the next hour) if you have any objections!