### PR TITLE
Using absolute imports for wagtailadmin scss.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Changelog
  * Added validation to prevent pages being crated with only whitespace characters in their title fields (Frank Wiles)
  * Page model fields without a FieldPanel are no longer displayed in the form
  * No longer need to specify the base model on InlinePanel definitions
+ * The project template Vagrantfile now listens on port 8000
 
 
 0.8.5 (xx.xx.20xx)

--- a/docs/releases/0.9.rst
+++ b/docs/releases/0.9.rst
@@ -31,6 +31,7 @@ Minor features
  * Added validation to prevent pages being created with only whitespace characters in their title fields
  * Page model fields without a FieldPanel are no longer displayed in the form
  * No longer need to specify the base model on InlinePanel definitions
+ * The project template Vagrantfile now listens on port 8000
 
 
 Bug fixes

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/core.scss
@@ -1,23 +1,23 @@
-@import "variables.scss";
-@import "mixins.scss";
-@import "grid.scss";
+@import "wagtailadmin/scss/variables.scss";
+@import "wagtailadmin/scss/mixins.scss";
+@import "wagtailadmin/scss/grid.scss";
 
-@import "components/explorer.scss";
-@import "components/icons.scss";
-@import "components/typography.scss";
-@import "components/tabs.scss";
-@import "components/dropdowns.scss";
-@import "components/modals.scss";
-@import "components/forms.scss";
-@import "components/listing.scss";
-@import "components/messages.scss";
-@import "components/formatters.scss";
-@import "components/header.scss";
-@import "components/progressbar.scss";
-@import "components/datetimepicker.scss";
-@import "components/main-nav.scss";
+@import "wagtailadmin/scss/components/explorer.scss";
+@import "wagtailadmin/scss/components/icons.scss";
+@import "wagtailadmin/scss/components/typography.scss";
+@import "wagtailadmin/scss/components/tabs.scss";
+@import "wagtailadmin/scss/components/dropdowns.scss";
+@import "wagtailadmin/scss/components/modals.scss";
+@import "wagtailadmin/scss/components/forms.scss";
+@import "wagtailadmin/scss/components/listing.scss";
+@import "wagtailadmin/scss/components/messages.scss";
+@import "wagtailadmin/scss/components/formatters.scss";
+@import "wagtailadmin/scss/components/header.scss";
+@import "wagtailadmin/scss/components/progressbar.scss";
+@import "wagtailadmin/scss/components/datetimepicker.scss";
+@import "wagtailadmin/scss/components/main-nav.scss";
 
-@import "fonts.scss";
+@import "wagtailadmin/scss/fonts.scss";
 
 html{
     background:$color-grey-4;

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/layouts/home.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/layouts/home.scss
@@ -1,6 +1,6 @@
-@import "../variables.scss";
-@import "../mixins.scss";
-@import "../grid.scss";
+@import "wagtailadmin/scss/variables.scss";
+@import "wagtailadmin/scss/mixins.scss";
+@import "wagtailadmin/scss/grid.scss";
 
 h1{
     font-weight:300;

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/layouts/login.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/layouts/login.scss
@@ -1,6 +1,6 @@
-@import "../variables.scss";
-@import "../mixins.scss";
-@import "../grid.scss";
+@import "wagtailadmin/scss/variables.scss";
+@import "wagtailadmin/scss/mixins.scss";
+@import "wagtailadmin/scss/grid.scss";
 
 // overrides default nice padding defined in variables.scss
 $desktop-nice-padding: 100px;

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/layouts/page-editor.scss
@@ -1,6 +1,6 @@
-@import "../variables.scss";
-@import "../mixins.scss";
-@import "../grid.scss";
+@import "wagtailadmin/scss/variables.scss";
+@import "wagtailadmin/scss/mixins.scss";
+@import "wagtailadmin/scss/grid.scss";
 
 .page-editor .content-wrapper{
     margin-bottom:10em;

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/layouts/preview.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/layouts/preview.scss
@@ -1,5 +1,5 @@
-@import "../variables.scss";
-@import "../mixins.scss";
+@import "wagtailadmin/scss/variables.scss";
+@import "wagtailadmin/scss/mixins.scss";
 
 /* This font is just a single spinner glyph */
 @font-face {

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/panels/rich-text.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/panels/rich-text.scss
@@ -1,5 +1,5 @@
-@import "../variables.scss";
-@import "../mixins.scss";
+@import "wagtailadmin/scss/variables.scss";
+@import "wagtailadmin/scss/mixins.scss";
 
 .hallotoolbar{
     position:absolute;

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/userbar.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/userbar.scss
@@ -1,9 +1,9 @@
-@import "variables.scss";
-@import "mixins.scss";
+@import "wagtailadmin/scss/variables.scss";
+@import "wagtailadmin/scss/mixins.scss";
 
-@import "components/icons.scss";
+@import "wagtailadmin/scss/components/icons.scss";
 
-@import "fonts.scss";
+@import "wagtailadmin/scss/fonts.scss";
 
 html, body{
     background-color:transparent;


### PR DESCRIPTION
This is to facilitate overriding of default styles via staticfiles.

I wanted to change some variables in the admin scss. I was unable achieve this without doing nasty things with copy-pasting all of wagtailadmin static. This change allows me to just override `static/wagtailadmin/scss/variables.scss`.