### PR TITLE
Added pagination to snippets.

### DIFF
--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/chooser/choose.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/chooser/choose.html
@@ -4,9 +4,10 @@
 
 <div class="nice-padding">
     {% if items %}
-    	{% include "wagtailsnippets/snippets/list.html" with choosing=1 %}
+    	{% include "wagtailsnippets/chooser/list.html" with choosing=1 %}
     {% else %}
     	{% url 'wagtailsnippets_create' content_type.app_label content_type.model as wagtailsnippets_create_snippet_url %}
     	<p>{% blocktrans %}You haven't created any {{ snippet_type_name }} snippets. Why not <a href="{{ wagtailsnippets_create_snippet_url }}" target="_blank">create one now{% endblocktrans %}</p>
     {% endif %}
+
 </div>

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/chooser/choose.js
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/chooser/choose.js
@@ -1,6 +1,39 @@
 function(modal) {
-    $('a.snippet-choice', modal.body).click(function() {
-        modal.loadUrl(this.href);
+
+    var listingUrl = $('#snippet-chooser-list', modal.body).data('url');
+    console.log(listingUrl);
+
+    function ajaxifyLinks (context) {
+        $('a.snippet-choice', modal.body).click(function() {
+            modal.loadUrl(this.href);
+            return false;
+        });
+
+        $('.pagination a', context).click(function() {
+            var page = this.getAttribute("data-page");
+            setPage(page);
+            return false;
+        });
+    }
+
+    function setPage(page) {
+
+        $.ajax({
+            url: listingUrl,
+            data: {p: page},
+            dataType: "html",
+            success: function(data, status, xhr) {
+                var response = eval('(' + data + ')');
+                $(modal.body).html(response.html);
+                if (response.onload) {
+                    response.onload(self);
+                }
+                ajaxifyLinks($('#snippet-chooser-list'));
+            }
+        });
         return false;
-    });
+    }
+
+    ajaxifyLinks(modal.body);
+
 }

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/chooser/list.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/chooser/list.html
@@ -1,5 +1,8 @@
 {% load i18n %}
-<table class="listing">
+
+{% url "wagtailsnippets_choose" content_type.app_label content_type.model as linkurl %}
+
+<table class="listing" id="snippet-chooser-list" data-url="{{ linkurl }}">
     <col />
     <col  />
     <col width="16%" />
@@ -23,5 +26,4 @@
     </tbody>
 </table>
 
-
-{% include "wagtailadmin/shared/pagination_nav.html" with items=items is_ajax=is_ajax linkurl=linkurl %}
+{% include "wagtailadmin/shared/pagination_nav.html" with items=items is_ajax=1 %}

--- a/wagtail/wagtailsnippets/views/chooser.py
+++ b/wagtail/wagtailsnippets/views/chooser.py
@@ -1,4 +1,5 @@
 import json
+from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 
 from six import text_type
 
@@ -16,13 +17,23 @@ def choose(request, content_type_app_name, content_type_model_name):
 
     items = model.objects.all()
 
+    p = request.GET.get("p", 1)
+    paginator = Paginator(items, 25)
+
+    try:
+        paginated_items = paginator.page(p)
+    except PageNotAnInteger:
+        paginated_items = paginator.page(1)
+    except EmptyPage:
+        paginated_items = paginator.page(paginator.num_pages)
+
     return render_modal_workflow(
         request,
         'wagtailsnippets/chooser/choose.html', 'wagtailsnippets/chooser/choose.js',
         {
             'content_type': content_type,
             'snippet_type_name': snippet_type_name,
-            'items': items,
+            'items': paginated_items,
         }
     )
 

--- a/wagtail/wagtailsnippets/views/snippets.py
+++ b/wagtail/wagtailsnippets/views/snippets.py
@@ -94,11 +94,22 @@ def list(request, content_type_app_name, content_type_model_name):
 
     items = model.objects.all()
 
+    # Pagination
+    p = request.GET.get('p', 1)
+    paginator = Paginator(items, 20)
+
+    try:
+        paginated_items = paginator.page(p)
+    except PageNotAnInteger:
+        paginated_items = paginator.page(1)
+    except EmptyPage:
+        paginated_items = paginator.page(paginator.num_pages)
+
     return render(request, 'wagtailsnippets/snippets/type_index.html', {
         'content_type': content_type,
         'snippet_type_name': snippet_type_name,
         'snippet_type_name_plural': snippet_type_name_plural,
-        'items': items,
+        'items': paginated_items,
     })
 
 


### PR DESCRIPTION
Now paginating snippets and snippet choosers.

Major change is the chooser has its own listing template rather than reusing the snippet listing, similar to images chooser. The reuse of snippets listing I felt required too much template logic, so I pulled it out into its own listing.

For pagination I would personally use CBVs in this situation but I notice that there isn't any, so I refrained from doing so. 