### PR TITLE
Make admin date/time pickers and their JS code consistently use times without seconds

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,6 +34,7 @@ Changelog
  * The Page model now records the date/time that a page was first published, as the field `first_published_at`
  * Increased the maximum length of a page slug from 50 to 255 characters
  * Plain text fields in the page editor now use auto-expanding text areas
+ * Date / time pickers now consistently use times without seconds, to prevent Javascript behaviour glitches when focusing / unfocusing fields
 
 
 0.8.6 (10.03.2015)

--- a/docs/releases/0.9.rst
+++ b/docs/releases/0.9.rst
@@ -63,6 +63,7 @@ Admin
  * Removed the need to add permission check on admin views (now automated)
  * Reversing ``django.contrib.auth.admin.login`` will no longer lead to Wagtails login view (making it easier to have front end views)
  * Added cache-control headers to all admin views. This allows Varnish/Squid/CDN to run on vanilla settings in front of a Wagtail site
+ * Date / time pickers now consistently use times without seconds, to prevent Javascript behaviour glitches when focusing / unfocusing fields
 
 
 Project template

--- a/wagtail/wagtailadmin/static/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static/wagtailadmin/js/page-editor.js
@@ -104,7 +104,7 @@ function initDateTimeChooser(id) {
     if (window.dateTimePickerTranslations) {
         $('#' + id).datetimepicker({
             closeOnDateSelect: true,
-            format: 'Y-m-d H:i:s',
+            format: 'Y-m-d H:i',
             scrollInput:false,
             i18n: {
                 lang: window.dateTimePickerTranslations
@@ -113,7 +113,7 @@ function initDateTimeChooser(id) {
         });
     } else {
         $('#' + id).datetimepicker({
-            format: 'Y-m-d H:i:s',
+            format: 'Y-m-d H:i',
         });
     }
 }

--- a/wagtail/wagtailadmin/widgets.py
+++ b/wagtail/wagtailadmin/widgets.py
@@ -28,16 +28,28 @@ class AdminAutoHeightTextInput(WidgetWithScript, widgets.Textarea):
         return '$("#{0}").autosize();'.format(id_)
 
 class AdminDateInput(WidgetWithScript, widgets.DateInput):
+    # Set a default date format to match the one that our JS date picker expects -
+    # it can still be overridden explicitly, but this way it won't be affected by
+    # the DATE_INPUT_FORMATS setting
+    def __init__(self, attrs=None, format='%Y-%m-%d'):
+        super(AdminDateInput, self).__init__(attrs=attrs, format=format)
+
     def render_js_init(self, id_, name, value):
         return 'initDateChooser({0});'.format(json.dumps(id_))
 
 
 class AdminTimeInput(WidgetWithScript, widgets.TimeInput):
+    def __init__(self, attrs=None, format='%H:%M'):
+        super(AdminTimeInput, self).__init__(attrs=attrs, format=format)
+
     def render_js_init(self, id_, name, value):
         return 'initTimeChooser({0});'.format(json.dumps(id_))
 
 
 class AdminDateTimeInput(WidgetWithScript, widgets.DateTimeInput):
+    def __init__(self, attrs=None, format='%Y-%m-%d %H:%M'):
+        super(AdminDateTimeInput, self).__init__(attrs=attrs, format=format)
+
     def render_js_init(self, id_, name, value):
         return 'initDateTimeChooser({0});'.format(json.dumps(id_))
 

--- a/wagtail/wagtailcore/migrations/0011_update_golive_expire_help_text.py
+++ b/wagtail/wagtailcore/migrations/0011_update_golive_expire_help_text.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0010_change_page_owner_to_null_on_delete'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='page',
+            name='expire_at',
+            field=models.DateTimeField(help_text='Please add a date-time in the form YYYY-MM-DD hh:mm.', null=True, verbose_name='Expiry date/time', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='page',
+            name='go_live_at',
+            field=models.DateTimeField(help_text='Please add a date-time in the form YYYY-MM-DD hh:mm.', null=True, verbose_name='Go live date/time', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/wagtail/wagtailcore/migrations/0013_update_golive_expire_help_text.py
+++ b/wagtail/wagtailcore/migrations/0013_update_golive_expire_help_text.py
@@ -7,7 +7,7 @@ from django.db import models, migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('wagtailcore', '0010_change_page_owner_to_null_on_delete'),
+        ('wagtailcore', '0012_extend_page_slug_field'),
     ]
 
     operations = [

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -278,8 +278,8 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
     show_in_menus = models.BooleanField(default=False, help_text=_("Whether a link to this page will appear in automatically generated menus"))
     search_description = models.TextField(blank=True)
 
-    go_live_at = models.DateTimeField(verbose_name=_("Go live date/time"), help_text=_("Please add a date-time in the form YYYY-MM-DD hh:mm:ss."), blank=True, null=True)
-    expire_at = models.DateTimeField(verbose_name=_("Expiry date/time"), help_text=_("Please add a date-time in the form YYYY-MM-DD hh:mm:ss."), blank=True, null=True)
+    go_live_at = models.DateTimeField(verbose_name=_("Go live date/time"), help_text=_("Please add a date-time in the form YYYY-MM-DD hh:mm."), blank=True, null=True)
+    expire_at = models.DateTimeField(verbose_name=_("Expiry date/time"), help_text=_("Please add a date-time in the form YYYY-MM-DD hh:mm."), blank=True, null=True)
     expired = models.BooleanField(default=False, editable=False)
 
     locked = models.BooleanField(default=False, editable=False)


### PR DESCRIPTION
AdminTimeInput currently suffers from the same bug that was described (and fixed) for AdminDateTimeInput in #479: the JS time picker does not recognise the hh:mm:ss format that the Django form widget produces, and replaces it with the current time on blur instead.

We could fix this in the same way as #479, and update the JS code to use hh:mm:ss as its preferred format, but this isn't particularly desirable: time inputs are typically used on event pages, and most events don't run to a resolution of one second :-) (Neither does our go-live/expiry cron job, for that matter... so it doesn't really make sense for AdminDateTimeInput either.)

This PR therefore reverses the fix made in #479, and instead specifies an explicit format within AdminDateInput / AdminTimeInput / AdminDateTimeInput so that they match the no-seconds format that the JQuery UI widgets expect by default. This has the additional benefit that it's no longer dependent on the DATE_INPUT_FORMATS / TIME_INPUT_FORMATS / DATETIME_INPUT_FORMATS settings, so the JS behaviour won't break as a result of a site owner setting a non-standard value there.