### PR TITLE
Remove build dependencies. Fixes #985 and #958

### DIFF
--- a/docs/getting_started/creating_your_project.rst
+++ b/docs/getting_started/creating_your_project.rst
@@ -20,7 +20,7 @@ Running it
 Firstly, open up a command line shell in your new projects directory.
 
 
-* **1. Create a virtual environment**
+1. **Create a virtual environment**
 
   This is only required when you first run your project. This creates a folder to install extra Python modules into.
 
@@ -41,8 +41,7 @@ Firstly, open up a command line shell in your new projects directory.
       pip install virtualenv
       virtualenv venv
 
-
-* **2. Activate the virtual environment**
+2. **Activate the virtual environment**
 
   **Linux/Mac OSX:** :code:`source venv/bin/activate`
 
@@ -50,25 +49,21 @@ Firstly, open up a command line shell in your new projects directory.
 
   https://docs.python.org/3/library/venv.html
 
-
-* **3. Install PIP requirements**
+3. **Install PIP requirements**
 
   :code:`pip install -r requirements.txt`
 
-
-* **4. Create the database**
+4. **Create the database**
 
   By default, this would create an SQLite database file within the project directory.
 
   :code:`python manage.py migrate`
 
-
-* **5. Create an admin user**
+5. **Create an admin user**
 
   :code:`python manage.py createsuperuser`
 
-
-* **6. Run the development server**
+6. **Run the development server**
 
   :code:`python manage.py runserver`
 

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -6,10 +6,50 @@ Installation
 Before you start
 ================
 
-A basic Wagtail setup can be installed on your machine with only a few prerequisites - see `A basic Wagtail installation`_. However, there are various optional components that will improve the performance and feature set of Wagtail, and our recommended software stack includes the PostgreSQL database, ElasticSearch (for free-text searching), the OpenCV library (for image feature detection), and Redis (as a cache and message queue backend). This would be a lot to install in one go, and for this reason, we provide a virtual machine image, for use with `Vagrant <http://www.vagrantup.com/>`__, with all of these components ready installed.
+You can get basic Wagtail setup installed on your machine with only a few prerequisites. See the full  `Dependencies`_ list below.
 
-Whether you just want to try out the demo site, or you're ready to dive in and create a Wagtail site with all bells and whistles enabled, we strongly recommend the Vagrant approach. Nevertheless, if you're the sort of person who balks at the idea of downloading a whole operating system just to run a web app, we've got you covered too. Start from `A basic Wagtail installation`_ below.
+There are various optional components that will improve the performance and feature set of Wagtail. Our recommended software stack includes the PostgreSQL database, ElasticSearch (for free-text searching), the OpenCV library (for image feature detection), and Redis (as a cache and message queue backend). This would be a lot to install in one go. For this reason we provide a virtual machine image to use with `Vagrant <http://www.vagrantup.com/>`__, with all of these components ready installed.
 
+Whether you just want to try out the demo site, or you're ready to dive in and create a Wagtail site with all bells and whistles enabled, we strongly recommend the Vagrant approach. Nevertheless, if you're the sort of person who balks at the idea of downloading a whole operating system just to run a web app, we've got you covered too. Start from `Install Python`_.
+
+
+Dependencies
+============
+
+The basic Wagtail installation is pure Python. No build tools are required on the host machine.
+If you are installing Wagtail differently (e.g. from the Git repo), make you meet the following dependencies:
+
+Required
+--------
+
+ * Django>=1.7.0,<1.8
+ * django-compressor>=1.4
+ * django-modelcluster>=0.5
+ * django-taggit==0.12.2
+ * django-treebeard==3.0
+ * beautifulsoup4>=4.3.2
+ * html5lib==0.999
+ * Unidecode>=0.04.14
+ * six>=1.7.0
+ * requests>=2.0.0
+ * Willow==0.1
+
+.. warning::
+
+    The administrative interface requires django-libsass and Pillow. The project template bundled with Wagtail includes them (see :doc:`creating_your_project`). You must add the above libraries if you are adding Wagtail to an existing project, unless you will be using it
+    in a purely framework fashion without visiting wagtailadmin or hooking it up to the urlconf.
+
+ * django-libsass>=0.2
+ * Pillow>=2.6.1
+
+Both django-libsass and Pillow have native-code components that require further attention:
+
+ * libsass-python (for compiling SASS stylesheets) - requires a C++ compiler and the Python development headers.
+ * Pillow (for image processing) - additionally requires libjpeg and zlib.
+
+On Debian or Ubuntu, these can be installed with the command::
+
+    sudo apt-get install python-dev python-pip g++ libjpeg62-dev zlib1g-dev
 
 Install Python
 ==============

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -16,10 +16,16 @@ Whether you just want to try out the demo site, or you're ready to dive in and c
 Dependencies
 ============
 
+Barebones
+---------
+
 The basic Wagtail installation is pure Python. No build tools are required on the host machine.
+For the full list of absolutely required libraries, see `setup.py <https://github.com/torchbox/wagtail/blob/master/setup.py>`__.
+
 If you are installing Wagtail differently (e.g. from the Git repository), you must run ``python setup.py install`` from the repository root. The above command will install all Wagtail dependencies.
 
-For the full list of absolutely required libraries, see `setup.py <https://github.com/torchbox/wagtail/blob/master/setup.py>`__.
+Administration UI
+-----------------
 
 .. warning::
 

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -17,22 +17,9 @@ Dependencies
 ============
 
 The basic Wagtail installation is pure Python. No build tools are required on the host machine.
-If you are installing Wagtail differently (e.g. from the Git repo), make you meet the following dependencies:
+If you are installing Wagtail differently (e.g. from the Git repository), you must run ``python setup.py install`` from the repository root. The above command will install all Wagtail dependencies.
 
-Required
---------
-
- * Django>=1.7.0,<1.8
- * django-compressor>=1.4
- * django-modelcluster>=0.5
- * django-taggit==0.12.2
- * django-treebeard==3.0
- * beautifulsoup4>=4.3.2
- * html5lib==0.999
- * Unidecode>=0.04.14
- * six>=1.7.0
- * requests>=2.0.0
- * Willow==0.1
+For the full list of absolutely required libraries, see `setup.py <https://github.com/torchbox/wagtail/blob/master/setup.py>`__.
 
 .. warning::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,30 +7,21 @@ Below are some useful links to help you get started with Wagtail.
 
 
 * **First steps**
-
-  :doc:`getting_started/trying_wagtail`
-
-  :doc:`getting_started/installation`
-
-  :doc:`getting_started/creating_your_project`
+  * :doc:`getting_started/trying_wagtail`
+  * :doc:`getting_started/installation`
+  * :doc:`getting_started/creating_your_project`
 
 
 * **Creating your Wagtail site**
-
-  :doc:`core_components/pages/creating_pages`
-
-  :doc:`Writing templates <core_components/pages/writing_templates>`
-
-  :doc:`core_components/images/index`
-
-  :doc:`core_components/search/index`
-
-  :doc:`howto/third_party_tutorials`
+  * :doc:`core_components/pages/creating_pages`
+  * :doc:`Writing templates <core_components/pages/writing_templates>`
+  * :doc:`core_components/images/index`
+  * :doc:`core_components/search/index`
+  * :doc:`howto/third_party_tutorials`
 
 
 * **Using Wagtail**
-
-  :doc:`Editors guide <editor_manual/index>`
+  * :doc:`Editors guide <editor_manual/index>`
 
 
 Index

--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,9 @@ PY3 = sys.version_info[0] == 3
 install_requires = [
     "Django>=1.7.0,<1.8",
     "django-compressor>=1.4",
-    "django-libsass>=0.2",
     "django-modelcluster>=0.5",
     "django-taggit==0.12.2",
     "django-treebeard==3.0",
-    "Pillow>=2.6.1",
     "beautifulsoup4>=4.3.2",
     "html5lib==0.999",
     "Unidecode>=0.04.14",

--- a/wagtail/project_template/requirements.txt
+++ b/wagtail/project_template/requirements.txt
@@ -1,6 +1,8 @@
 # Minimal requirements
 Django>=1.7,<1.8
 wagtail==0.8.5
+django-libsass>=0.2
+Pillow>=2.6.1
 
 # Recommended components (require additional setup):
 # psycopg2==2.5.2


### PR DESCRIPTION
This PR builds on top of #985. It adds a "Dependecies" section to the "Installation" page, making it explcit that django-libsass and Pillow must be added to requirements. 