### PR TITLE
Fix retrieval of latest page revision on mysql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,18 @@ matrix:
   include:
    - env: TOXENV=py27-dj17-postgres
    - env: TOXENV=py27-dj17-sqlite
+   - env: TOXENV=py27-dj17-mysql
    - env: TOXENV=py33-dj17-postgres
    - env: TOXENV=py34-dj17-postgres
    - env: TOXENV=py34-dj17-sqlite
    - env: TOXENV=py27-dj18-postgres
+#   - env: TOXENV=py27-dj18-mysql
 #   - env: TOXENV=py27-dj18-sqlite
 #  - env: TOXENV=py33-dj18-postgres
    - env: TOXENV=py34-dj18-postgres
    - env: TOXENV=py34-dj18-sqlite
   allow_failures:
+   - env: TOXENV=py27-dj17-mysql
    - env: TOXENV=py27-dj18-postgres
    - env: TOXENV=py34-dj18-postgres
    - env: TOXENV=py34-dj18-sqlite

--- a/tox.ini
+++ b/tox.ini
@@ -42,23 +42,18 @@ usedevelop = True
 envlist =
     py27-dj17-postgres,
     py27-dj17-sqlite,
+    py27-dj17-mysql,
     py33-dj17-postgres,
     py33-dj17-sqlite,
     py34-dj17-postgres,
     py34-dj17-sqlite,
     py27-dj18-postgres,
     py27-dj18-sqlite,
+    py27-dj18-mysql,
     py33-dj18-postgres,
     py33-dj18-sqlite,
     py34-dj18-postgres,
     py34-dj18-sqlite
-
-
-# mysql not currently supported
-# (wagtail.wagtailimages.tests.TestImageEditView currently fails with a
-# foreign key constraint error)
-# py26-dj16-mysql
-# py27-dj16-mysql
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -90,6 +90,7 @@ setenv =
     DATABASE_ENGINE=django.db.backends.mysql
     DATABASE_USER=wagtail
     DATABASE_HOST=localhost
+    DATABASE_USER=root
 
 [testenv:py33-dj17-postgres]
 basepython=python3.3
@@ -160,6 +161,7 @@ setenv =
     DATABASE_ENGINE=django.db.backends.mysql
     DATABASE_USER=wagtail
     DATABASE_HOST=localhost
+    DATABASE_USER=root
 
 [testenv:py33-dj18-postgres]
 basepython=python3.3

--- a/tox.ini
+++ b/tox.ini
@@ -89,6 +89,7 @@ deps =
 setenv =
     DATABASE_ENGINE=django.db.backends.mysql
     DATABASE_USER=wagtail
+    DATABASE_HOST=localhost
 
 [testenv:py33-dj17-postgres]
 basepython=python3.3
@@ -158,6 +159,7 @@ deps =
 setenv =
     DATABASE_ENGINE=django.db.backends.mysql
     DATABASE_USER=wagtail
+    DATABASE_HOST=localhost
 
 [testenv:py33-dj18-postgres]
 basepython=python3.3

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -481,7 +481,7 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         return revision
 
     def get_latest_revision(self):
-        return self.revisions.order_by('-created_at').first()
+        return self.revisions.order_by('-created_at', '-id').first()
 
     def get_latest_revision_as_page(self):
         latest_revision = self.get_latest_revision()
@@ -1097,7 +1097,7 @@ class PageRevision(models.Model):
             # special case: a revision without an ID is presumed to be newly-created and is thus
             # newer than any revision that might exist in the database
             return True
-        latest_revision = PageRevision.objects.filter(page_id=self.page_id).order_by('-created_at').first()
+        latest_revision = PageRevision.objects.filter(page_id=self.page_id).order_by('-created_at', '-id').first()
         return (latest_revision == self)
 
     def publish(self):


### PR DESCRIPTION
Fixes one of the issues currently breaking tests on mysql (https://github.com/torchbox/wagtail/issues/541#issuecomment-75411431) and adds MySQL + Django 1.7 + Python 2.7 to our Travis setup as an `allow_failures` case so that we can keep track of progress towards full MySQL support.