### PR TITLE
Clean up drone settings a bit more from #1021

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,7 @@
 image: kaedroho/django-base
 env:
- - RUNNING_IN_DRONE=yes
+ - DATABASE_HOST=postgres
+ - ELASTICSEARCH_URL=http://elasticsearch:9200/
 script:
  - pip3.4 install mock python-dateutil pytz elasticsearch
  - python3.4 setup.py install

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -16,11 +16,10 @@ DATABASES = {
         'TEST_NAME': os.environ.get('DATABASE_NAME', 'test_wagtaildemo'),
         'USER': os.environ.get('DATABASE_USER', 'postgres'),
         'PASSWORD': os.environ.get('DATABASE_PASS', None),
+        'HOST': os.environ.get('DATABASE_HOST', None),
+        'PORT': os.environ.get('DATABASE_PORT', None),
     }
 }
-
-if os.environ.get('RUNNING_IN_DRONE', False) == 'yes':
-    DATABASES['default']['HOST'] = 'postgres'
 
 
 SECRET_KEY = 'not needed'
@@ -127,8 +126,8 @@ try:
     }
 
     # Check if we're running in Drone
-    if os.environ.get('RUNNING_IN_DRONE', False) == 'yes':
-        WAGTAILSEARCH_BACKENDS['elasticsearch']['URLS'] = ['http://elasticsearch:9200/']
+    if 'ELASTICSEARCH_URL' in os.environ:
+        WAGTAILSEARCH_BACKENDS['elasticsearch']['URLS'] = [os.environ['ELASTICSEARCH_URL']]
 
 except ImportError:
     pass

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -125,7 +125,6 @@ try:
         'max_retries': 1,
     }
 
-    # Check if we're running in Drone
     if 'ELASTICSEARCH_URL' in os.environ:
         WAGTAILSEARCH_BACKENDS['elasticsearch']['URLS'] = [os.environ['ELASTICSEARCH_URL']]
 


### PR DESCRIPTION
No idea if I'm doing the right thing here, but let's see what happens when I submit...

f2f57fba7377d51a2485f3205cfbb2e63d446446 doesn't do the job for me, because: 1) I need to be able to pass in `DATABASE_HOST` / `DATABASE_PORT` variables for #1020, and 2) it seems a bit ugly for tests/settings.py to be checking for Drone specifically - the Drone config should be passing in the settings it needs instead. Here's my attempt at an improved version.