### PR TITLE
Raise missing files error

### DIFF
--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
@@ -36,7 +36,7 @@
             <dl>
                 {% if document.file %}
                     <dt>{% trans "Filesize" %}</dt>
-                    <dd>{{ document.file.size|filesizeformat }}</dd>
+                    <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
                 {% endif %}
             </dl>
         </div>

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -47,7 +47,7 @@ class TestDocumentPermissions(TestCase):
         self.assertFalse(self.document.is_editable_by_user(self.user))
 
 
-## ===== ADMIN VIEWS =====
+# ===== ADMIN VIEWS =====
 
 
 class TestDocumentIndexView(TestCase, WagtailTestUtils):
@@ -173,6 +173,21 @@ class TestDocumentEditView(TestCase, WagtailTestUtils):
 
         # Document title should be changed
         self.assertEqual(models.Document.objects.get(id=self.document.id).title, "Test document changed!")
+
+    def test_with_missing_source_file(self):
+        # Build a fake file
+        fake_file = ContentFile(b("An ephemeral document"))
+        fake_file.name = 'to-be-deleted.txt'
+
+        # Create a new document to delete the source for
+        document = models.Document.objects.create(title="Test missing source document", file=fake_file)
+        document.file.delete(False)
+
+        response = self.client.get(reverse('wagtaildocs_edit_document', args=(document.id,)), {})
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtaildocs/documents/edit.html')
+
+        self.assertContains(response, 'File not found')
 
 
 class TestDocumentDeleteView(TestCase, WagtailTestUtils):
@@ -530,7 +545,7 @@ class TestServeView(TestCase):
     def test_response_code(self):
         self.assertEqual(self.get().status_code, 200)
 
-    @unittest.expectedFailure # Filename has a random string appended to it
+    @unittest.expectedFailure  # Filename has a random string appended to it
     def test_content_disposition_header(self):
         self.assertEqual(self.get()['Content-Disposition'], 'attachment; filename=example.doc')
 

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -133,12 +133,17 @@ def edit(request, document_id):
     else:
         form = DocumentForm(instance=doc)
 
-    # Get file size
-    try:
-        filesize = doc.file.size
-    except OSError:
-        # File doesn't exist
-        filesize = None
+    filesize = None
+
+    # Get file size when there is a file associated with the Document object
+    if doc.file:
+        try:
+            filesize = doc.file.size
+        except OSError:
+            # File doesn't exist
+            pass
+
+    if not filesize:
         messages.error(request, _("The file could not be found. Please change the source or delete the document"), buttons=[
             messages.button(reverse('wagtaildocs_delete_document', args=(doc.id,)), _('Delete'))
         ])

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -133,8 +133,15 @@ def edit(request, document_id):
     else:
         form = DocumentForm(instance=doc)
 
+    # Get file size
+    try:
+        filesize = doc.file.size
+    except OSError:
+        # File doesn't exist
+        filesize = None
     return render(request, "wagtaildocs/documents/edit.html", {
         'document': doc,
+        'filesize': filesize,
         'form': form
     })
 

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -139,6 +139,10 @@ def edit(request, document_id):
     except OSError:
         # File doesn't exist
         filesize = None
+        messages.error(request, _("The file could not be found. Please change the source or delete the document"), buttons=[
+            messages.button(reverse('wagtaildocs_delete_document', args=(doc.id,)), _('Delete'))
+        ])
+
     return render(request, "wagtaildocs/documents/edit.html", {
         'document': doc,
         'filesize': filesize,

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -125,6 +125,9 @@ def edit(request, image_id):
     except OSError:
         # File doesn't exist
         filesize = None
+        messages.error(request, _("The source image file could not be found. Please change the source or delete the image.").format(image.title), buttons=[
+            messages.button(reverse('wagtailimages_delete_image', args=(image.id,)), _('Delete'))
+        ])
 
     return render(request, "wagtailimages/images/edit.html", {
         'image': image,


### PR DESCRIPTION
This PR builds on #1013 and

* Catches `OSerror` for missing document source files in edit view
* Raises an error notification banner for documents/images with missing source files