### PR TITLE
Use unicode literals in models. Fixes #1006

### DIFF
--- a/wagtail/contrib/wagtailroutablepage/models.py
+++ b/wagtail/contrib/wagtailroutablepage/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from six import string_types
 
 from django.http import Http404

--- a/wagtail/project_template/core/models.py
+++ b/wagtail/project_template/core/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.db import models
 
 from wagtail.wagtailcore.models import Page

--- a/wagtail/tests/models.py
+++ b/wagtail/tests/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.db import models
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin, BaseUserManager

--- a/wagtail/wagtailadmin/models.py
+++ b/wagtail/wagtailadmin/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.db import models
 
 # Create your models here.

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1119,7 +1119,7 @@ class PageRevision(models.Model):
             page.has_unpublished_changes = not self.is_latest_revision()
             # If page goes live clear the approved_go_live_at of all revisions
             page.revisions.update(approved_go_live_at=None)
-        page.expired = False # When a page is published it can't be expired
+        page.expired = False  # When a page is published it can't be expired
         page.save()
         self.submitted_for_moderation = False
         page.revisions.update(submitted_for_moderation=False)

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 import warnings
 import json
@@ -5,8 +7,6 @@ import json
 import six
 from six import StringIO
 from six.moves.urllib.parse import urlparse
-
-from __future__ import unicode_literals
 
 from modelcluster.models import ClusterableModel, get_all_child_relations
 

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -6,6 +6,8 @@ import six
 from six import StringIO
 from six.moves.urllib.parse import urlparse
 
+from __future__ import unicode_literals
+
 from modelcluster.models import ClusterableModel, get_all_child_relations
 
 from django.db import models, connection, transaction

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -1,5 +1,7 @@
 import os.path
 
+from __future__ import unicode_literals
+
 from taggit.managers import TaggableManager
 
 from django.db import models

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -1,6 +1,6 @@
-import os.path
-
 from __future__ import unicode_literals
+
+import os.path
 
 from taggit.managers import TaggableManager
 

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -10,7 +10,7 @@ from django.dispatch.dispatcher import receiver
 from django.dispatch import Signal
 from django.core.urlresolvers import reverse
 from django.conf import settings
-from django.utils.translation import ugettext_lazy  as _
+from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import python_2_unicode_compatible
 
 from wagtail.wagtailadmin.taggable import TagSearchable
@@ -21,7 +21,7 @@ from wagtail.wagtailsearch import index
 @python_2_unicode_compatible
 class Document(models.Model, TagSearchable):
     title = models.CharField(max_length=255, verbose_name=_('Title'))
-    file = models.FileField(upload_to='documents' , verbose_name=_('File'))
+    file = models.FileField(upload_to='documents', verbose_name=_('File'))
     created_at = models.DateTimeField(auto_now_add=True)
     uploaded_by_user = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True, editable=False)
 

--- a/wagtail/wagtailembeds/models.py
+++ b/wagtail/wagtailembeds/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -1,6 +1,8 @@
 import json
 import re
 
+from __future__ import unicode_literals
+
 from six import text_type
 
 from unidecode import unidecode

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -1,7 +1,7 @@
+from __future__ import unicode_literals
+
 import json
 import re
-
-from __future__ import unicode_literals
 
 from six import text_type
 

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -17,7 +17,7 @@ from django.dispatch.dispatcher import receiver
 from django.utils.safestring import mark_safe
 from django.utils.html import escape, format_html_join
 from django.conf import settings
-from django.utils.translation import ugettext_lazy  as _
+from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
 from django.core.urlresolvers import reverse
@@ -55,7 +55,7 @@ def get_upload_to(instance, filename):
 
 @python_2_unicode_compatible
 class AbstractImage(models.Model, TagSearchable):
-    title = models.CharField(max_length=255, verbose_name=_('Title') )
+    title = models.CharField(max_length=255, verbose_name=_('Title'))
     file = models.ImageField(verbose_name=_('File'), upload_to=get_upload_to, width_field='width', height_field='height')
     width = models.IntegerField(editable=False)
     height = models.IntegerField(editable=False)
@@ -184,7 +184,7 @@ class AbstractImage(models.Model, TagSearchable):
             input_filename_without_extension, input_extension = os.path.splitext(input_filename)
 
             output_extension = '.'.join([vary_key, filter.spec]) + input_extension
-            output_filename_without_extension = input_filename_without_extension[:(59-len(output_extension))] # Truncate filename to prevent it going over 60 chars
+            output_filename_without_extension = input_filename_without_extension[:(59 - len(output_extension))]  # Truncate filename to prevent it going over 60 chars
             output_filename = output_filename_without_extension + '.' + output_extension
 
             rendition, created = self.renditions.get_or_create(
@@ -325,7 +325,7 @@ class Filter(models.Model):
         if not vary_string:
             return ''
 
-        return  hashlib.sha1(vary_string.encode('utf-8')).hexdigest()[:8]
+        return hashlib.sha1(vary_string.encode('utf-8')).hexdigest()[:8]
 
     _registered_operations = None
 
@@ -383,4 +383,3 @@ class Rendition(AbstractRendition):
 def rendition_delete(sender, instance, **kwargs):
     # Pass false so FileField doesn't save the model.
     instance.file.delete(False)
-

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -1,8 +1,8 @@
+from __future__ import unicode_literals
+
 import os.path
 import hashlib
 import re
-
-from __future__ import unicode_literals
 
 from six import BytesIO, text_type
 

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -2,6 +2,8 @@ import os.path
 import hashlib
 import re
 
+from __future__ import unicode_literals
+
 from six import BytesIO, text_type
 
 from taggit.managers import TaggableManager

--- a/wagtail/wagtailredirects/models.py
+++ b/wagtail/wagtailredirects/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 

--- a/wagtail/wagtailredirects/models.py
+++ b/wagtail/wagtailredirects/models.py
@@ -11,7 +11,7 @@ from six.moves.urllib.parse import urlparse
 class Redirect(models.Model):
     old_path = models.CharField(verbose_name=_("Redirect from"), max_length=255, unique=True, db_index=True)
     site = models.ForeignKey('wagtailcore.Site', null=True, blank=True, related_name='redirects', db_index=True, editable=False)
-    is_permanent = models.BooleanField(verbose_name=_("Permanent"), default=True, help_text=_("Recommended. Permanent redirects ensure search engines forget the old page (the 'Redirect from') and index the new page instead.") )
+    is_permanent = models.BooleanField(verbose_name=_("Permanent"), default=True, help_text=_("Recommended. Permanent redirects ensure search engines forget the old page (the 'Redirect from') and index the new page instead."))
     redirect_page = models.ForeignKey('wagtailcore.Page', verbose_name=_("Redirect to a page"), null=True, blank=True)
     redirect_link = models.URLField(verbose_name=_("Redirect to any URL"), blank=True)
 

--- a/wagtail/wagtailsearch/models.py
+++ b/wagtail/wagtailsearch/models.py
@@ -1,5 +1,7 @@
 import datetime
 
+from __future__ import unicode_literals
+
 from django.db import models
 from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible

--- a/wagtail/wagtailsearch/models.py
+++ b/wagtail/wagtailsearch/models.py
@@ -1,6 +1,6 @@
-import datetime
-
 from __future__ import unicode_literals
+
+import datetime
 
 from django.db import models
 from django.utils import timezone

--- a/wagtail/wagtailsnippets/models.py
+++ b/wagtail/wagtailsnippets/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 

--- a/wagtail/wagtailusers/models.py
+++ b/wagtail/wagtailusers/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.db import models
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _


### PR DESCRIPTION
Adds `from __future__ import unicode_literals` to model files to prevent bytestrings creeping into migrations.