### PR TITLE
Prevent deleting pages that have children

### DIFF
--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -933,6 +933,23 @@ class TestPageDelete(TestCase, WagtailTestUtils):
         # Check that the page_unpublished signal was not fired
         self.assertFalse(signal_fired[0])
 
+    def test_page_delete_with_children(self):
+        # Add a grandchild page
+        grandchild_page = SimplePage()
+        grandchild_page.title = "Hello world!"
+        grandchild_page.slug = "hello-world"
+        self.child_page.add_child(instance=grandchild_page)
+
+        # Post
+        post_data = {'hello': 'world'} # For some reason, this test doesn't work without a bit of POST data
+        response = self.client.post(reverse('wagtailadmin_pages_delete', args=(self.child_page.id, )), post_data)
+
+        # Check that the user was given a 403 error
+        self.assertEqual(response.status_code, 403)
+
+        # Check that the pages still exist
+        self.assertEqual(Page.objects.filter(path__startswith=self.root_page.path, slug='hello-world').count(), 2)
+
 
 class TestPageSearch(TestCase, WagtailTestUtils):
     def setUp(self):

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1272,7 +1272,7 @@ class PagePermissionTester(object):
             return False
         return self.user.is_superuser or ('edit' in self.permissions) or ('add' in self.permissions and self.page.owner_id == self.user.id)
 
-    def can_delete(self):
+    def can_move(self):
         if not self.user.is_active:
             return False
         if self.page_is_root:  # root node is not a page and can never be deleted, even by superusers
@@ -1296,6 +1296,9 @@ class PagePermissionTester(object):
 
         else:
             return False
+
+    def can_delete(self):
+        return self.can_move() and self.page.is_leaf()
 
     def can_unpublish(self):
         if not self.user.is_active:
@@ -1339,14 +1342,6 @@ class PagePermissionTester(object):
         (and the use-cases for a non-admin needing to do it are fairly obscure...)
         """
         return self.can_publish_subpage()
-
-    def can_move(self):
-        """
-        Moving a page should be logically equivalent to deleting and re-adding it (and all its children).
-        As such, the permission test for 'can this be moved at all?' should be the same as for deletion.
-        (Further constraints will then apply on where it can be moved *to*.)
-        """
-        return self.can_delete()
 
     def can_move_to(self, destination):
         # reject the logically impossible cases first

--- a/wagtail/wagtailcore/tests/test_page_permissions.py
+++ b/wagtail/wagtailcore/tests/test_page_permissions.py
@@ -143,8 +143,9 @@ class TestPagePermission(TestCase):
         self.assertTrue(homepage_perms.can_edit())
         self.assertFalse(root_perms.can_edit())  # root is not a real editable page, even to superusers
 
-        self.assertTrue(homepage_perms.can_delete())
+        self.assertFalse(homepage_perms.can_delete()) # Cannot delete page with children
         self.assertFalse(root_perms.can_delete())
+        self.assertTrue(unpub_perms.can_delete())
 
         self.assertTrue(homepage_perms.can_publish())
         self.assertFalse(root_perms.can_publish())


### PR DESCRIPTION
This is a quick fix for an issue we discovered yesterday. Wagtail 0.8+ has a bug where it will not delete child pages if they are not the same type of the page being deleted. This causes orphaned pages to be created which can cause crashes if a new page is created in the same position of an orphaned page.

Most of the solutions to this bug would require a fair bit of work and after discussing with @zerolab and @tomdyson, we think the best thing to do for now is to prevent users from deleting pages with children.