### PR TITLE
Ensure that deletions always happen on the base Page model, to work around treebeard bug

### DIFF
--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -212,6 +212,9 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         self.assertIsInstance(page, SimplePage)
         self.assertFalse(page.live)
 
+        # treebeard should report no consistency problems with the tree
+        self.assertFalse(any(Page.find_problems()), 'treebeard found consistency problems')
+
     def test_create_simplepage_scheduled(self):
         go_live_at = timezone.now() + timedelta(days=1)
         expire_at = timezone.now() + timedelta(days=2)
@@ -299,6 +302,9 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         self.assertTrue(signal_fired[0])
         self.assertEqual(signal_page[0], page)
         self.assertEqual(signal_page[0], signal_page[0].specific)
+
+        # treebeard should report no consistency problems with the tree
+        self.assertFalse(any(Page.find_problems()), 'treebeard found consistency problems')
 
     def test_create_simplepage_post_publish_scheduled(self):
         go_live_at = timezone.now() + timedelta(days=1)
@@ -908,6 +914,9 @@ class TestPageDelete(TestCase, WagtailTestUtils):
         # Should be redirected to explorer page
         self.assertRedirects(response, reverse('wagtailadmin_explore', args=(self.root_page.id, )))
 
+        # treebeard should report no consistency problems with the tree
+        self.assertFalse(any(Page.find_problems()), 'treebeard found consistency problems')
+
         # Check that the page is gone
         self.assertEqual(Page.objects.filter(path__startswith=self.root_page.path, slug='hello-world').count(), 0)
 
@@ -936,6 +945,9 @@ class TestPageDelete(TestCase, WagtailTestUtils):
         # Should be redirected to explorer page
         self.assertRedirects(response, reverse('wagtailadmin_explore', args=(self.root_page.id, )))
 
+        # treebeard should report no consistency problems with the tree
+        self.assertFalse(any(Page.find_problems()), 'treebeard found consistency problems')
+
         # Check that the page is gone
         self.assertEqual(Page.objects.filter(path__startswith=self.root_page.path, slug='hello-world').count(), 0)
 
@@ -954,6 +966,9 @@ class TestPageDelete(TestCase, WagtailTestUtils):
 
         # Should be redirected to explorer page
         self.assertRedirects(response, reverse('wagtailadmin_explore', args=(self.root_page.id, )))
+
+        # treebeard should report no consistency problems with the tree
+        self.assertFalse(any(Page.find_problems()), 'treebeard found consistency problems')
 
         # Check that the page is gone
         self.assertFalse(StandardIndex.objects.filter(id=self.child_index.id).exists())
@@ -1155,6 +1170,9 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         # Check that the children were not copied
         self.assertEqual(page_copy.get_children().count(), 0)
 
+        # treebeard should report no consistency problems with the tree
+        self.assertFalse(any(Page.find_problems()), 'treebeard found consistency problems')
+
     def test_page_copy_post_copy_subpages(self):
         post_data = {
             'new_title': "Hello world 2",
@@ -1195,6 +1213,9 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         self.assertNotEqual(unpublished_child_copy, None)
         self.assertFalse(unpublished_child_copy.live)
         self.assertTrue(unpublished_child_copy.has_unpublished_changes)
+
+        # treebeard should report no consistency problems with the tree
+        self.assertFalse(any(Page.find_problems()), 'treebeard found consistency problems')
 
     def test_page_copy_post_copy_subpages_publish_copies(self):
         post_data = {
@@ -1237,6 +1258,9 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         self.assertFalse(unpublished_child_copy.live)
         self.assertTrue(unpublished_child_copy.has_unpublished_changes)
 
+        # treebeard should report no consistency problems with the tree
+        self.assertFalse(any(Page.find_problems()), 'treebeard found consistency problems')
+
     def test_page_copy_post_new_parent(self):
         post_data = {
             'new_title': "Hello world 2",
@@ -1252,6 +1276,9 @@ class TestPageCopy(TestCase, WagtailTestUtils):
 
         # Check that the page was copied to the correct place
         self.assertTrue(Page.objects.filter(slug='hello-world-2').first().get_parent(), self.test_child_page)
+
+        # treebeard should report no consistency problems with the tree
+        self.assertFalse(any(Page.find_problems()), 'treebeard found consistency problems')
 
     def test_page_copy_post_existing_slug_within_same_parent_page(self):
         # This tests the existing slug checking on page copy when not changing the parent page
@@ -1367,6 +1394,9 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         unpublished_child_copy = page_copy.get_children().filter(slug='unpublished-child-page').first()
         self.assertNotEqual(unpublished_child_copy, None)
         self.assertFalse(unpublished_child_copy.live)
+
+        # treebeard should report no consistency problems with the tree
+        self.assertFalse(any(Page.find_problems()), 'treebeard found consistency problems')
 
 
 class TestPageUnpublish(TestCase, WagtailTestUtils):

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -892,8 +892,7 @@ class TestPageDelete(TestCase, WagtailTestUtils):
         page_unpublished.connect(page_unpublished_handler)
 
         # Post
-        post_data = {'hello': 'world'} # For some reason, this test doesn't work without a bit of POST data
-        response = self.client.post(reverse('wagtailadmin_pages_delete', args=(self.child_page.id, )), post_data)
+        response = self.client.post(reverse('wagtailadmin_pages_delete', args=(self.child_page.id, )))
 
         # Should be redirected to explorer page
         self.assertRedirects(response, reverse('wagtailadmin_explore', args=(self.root_page.id, )))
@@ -921,8 +920,7 @@ class TestPageDelete(TestCase, WagtailTestUtils):
         page_unpublished.connect(page_unpublished_handler)
 
         # Post
-        post_data = {'hello': 'world'} # For some reason, this test doesn't work without a bit of POST data
-        response = self.client.post(reverse('wagtailadmin_pages_delete', args=(self.child_page.id, )), post_data)
+        response = self.client.post(reverse('wagtailadmin_pages_delete', args=(self.child_page.id, )))
 
         # Should be redirected to explorer page
         self.assertRedirects(response, reverse('wagtailadmin_explore', args=(self.root_page.id, )))

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -410,7 +410,7 @@ def delete(request, page_id):
     if not page.permissions_for_user(request.user).can_delete():
         raise PermissionDenied
 
-    if request.POST:
+    if request.method == 'POST':
         parent_id = page.get_parent().id
         page.delete()
 

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -406,7 +406,7 @@ def edit(request, page_id):
 
 
 def delete(request, page_id):
-    page = get_object_or_404(Page, id=page_id).specific
+    page = get_object_or_404(Page, id=page_id)
     if not page.permissions_for_user(request.user).can_delete():
         raise PermissionDenied
 

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -364,6 +364,17 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
 
         return result
 
+    def delete(self, *args, **kwargs):
+        # Ensure that deletion always happens on an instance of Page, not a specific subclass. This
+        # works around a bug in treebeard <= 3.0 where calling SpecificPage.delete() fails to delete
+        # child pages that are not instances of SpecificPage
+        if type(self) is Page:
+            # this is a Page instance, so carry on as we were
+            return super(Page, self).delete(*args, **kwargs)
+        else:
+            # retrieve an actual Page instance and delete that instead of self
+            return Page.objects.get(id=self.id).delete(*args, **kwargs)
+
     @classmethod
     def check(cls, **kwargs):
         errors = super(Page, cls).check(**kwargs)


### PR DESCRIPTION
Alternative fix for #1034 that doesn't require dropping any existing Wagtail functionality. Essentially this is partially reverting #737 so that deletions happen on Page rather than SpecificPage, along with a whole lot of supporting code/tests to confirm that this doesn't cause any significant regressions, and some extra logic at the model level to guard against calling SpecificPage.delete().

There is one regression - custom delete() methods on subclasses of Page will no longer be called - but this was never documented, and we'd never be able to ensure that this happens for deletions performed within treebeard anyhow (because treebeard has no knowledge of how to obtain an instance of SpecificPage).