### PR TITLE
Removed filters cache on {% image %} tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,19 @@ matrix:
    - env: TOXENV=py33-dj17-postgres
    - env: TOXENV=py34-dj17-postgres
    - env: TOXENV=py34-dj17-sqlite
+   - env: TOXENV=py34-dj17-mysql
    - env: TOXENV=py27-dj18-postgres
 #   - env: TOXENV=py27-dj18-mysql
 #   - env: TOXENV=py27-dj18-sqlite
 #  - env: TOXENV=py33-dj18-postgres
    - env: TOXENV=py34-dj18-postgres
    - env: TOXENV=py34-dj18-sqlite
+   - env: TOXENV=py34-dj18-mysql
   allow_failures:
-   - env: TOXENV=py27-dj17-mysql
    - env: TOXENV=py27-dj18-postgres
    - env: TOXENV=py34-dj18-postgres
    - env: TOXENV=py34-dj18-sqlite
+   - env: TOXENV=py34-dj18-mysql
 
 # Services
 services:

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ envlist =
     py33-dj17-postgres,
     py33-dj17-sqlite,
     py34-dj17-postgres,
+    py34-dj17-mysql,
     py34-dj17-sqlite,
     py27-dj18-postgres,
     py27-dj18-sqlite,
@@ -51,6 +52,7 @@ envlist =
     py33-dj18-sqlite,
     py34-dj18-postgres,
     py34-dj18-sqlite
+    py34-dj18-mysql,
 
 
 [testenv]
@@ -82,7 +84,7 @@ deps =
     {[deps]base}
     {[deps]py2}
     {[deps]dj17}
-    MySQL-python==1.2.5
+    mysqlclient==1.3.6
 setenv =
     DATABASE_ENGINE=django.db.backends.mysql
     DATABASE_USER=wagtail
@@ -127,6 +129,19 @@ deps =
 setenv =
     DATABASE_ENGINE=django.db.backends.sqlite3
 
+[testenv:py34-dj17-mysql]
+basepython=python3.4
+deps =
+    {[deps]base}
+    {[deps]py3}
+    {[deps]dj17}
+    mysqlclient==1.3.6
+setenv =
+    DATABASE_ENGINE=django.db.backends.mysql
+    DATABASE_USER=wagtail
+    DATABASE_HOST=localhost
+    DATABASE_USER=root
+
 
 [testenv:py27-dj18-postgres]
 basepython=python2.7
@@ -153,7 +168,7 @@ deps =
     {[deps]base}
     {[deps]py2}
     {[deps]dj18}
-    MySQL-python==1.2.5
+    mysqlclient==1.3.6
 setenv =
     DATABASE_ENGINE=django.db.backends.mysql
     DATABASE_USER=wagtail
@@ -197,3 +212,16 @@ deps =
     {[deps]dj18}
 setenv =
     DATABASE_ENGINE=django.db.backends.sqlite3
+
+[testenv:py34-dj18-mysql]
+basepython=python3.4
+deps =
+    {[deps]base}
+    {[deps]py3}
+    {[deps]dj18}
+    mysqlclient==1.3.6
+setenv =
+    DATABASE_ENGINE=django.db.backends.mysql
+    DATABASE_USER=wagtail
+    DATABASE_HOST=localhost
+    DATABASE_USER=root

--- a/wagtail/wagtailcore/management/commands/fixtree.py
+++ b/wagtail/wagtailcore/management/commands/fixtree.py
@@ -20,6 +20,11 @@ class Command(BaseCommand):
     )
     option_list = BaseCommand.option_list + base_options
 
+    def numberlist_to_string(self, numberlist):
+        # Converts a list of numbers into a string
+        # Doesn't put "L" after longs
+        return '[' + ', '.join(map(str, numberlist)) + ']'
+
     def handle(self, **options):
         any_problems_fixed = False
 
@@ -34,9 +39,9 @@ class Command(BaseCommand):
         (bad_alpha, bad_path, orphans, bad_depth, bad_numchild) = Page.find_problems()
 
         if bad_depth:
-            self.stdout.write("Incorrect depth value found for pages: %r" % bad_depth)
+            self.stdout.write("Incorrect depth value found for pages: %s" % self.numberlist_to_string(bad_depth))
         if bad_numchild:
-            self.stdout.write("Incorrect numchild value found for pages: %r" % bad_numchild)
+            self.stdout.write("Incorrect numchild value found for pages: %s" % self.numberlist_to_string(bad_numchild))
 
         if bad_depth or bad_numchild:
             Page.fix_tree(destructive=False)
@@ -89,15 +94,15 @@ class Command(BaseCommand):
         if any((bad_alpha, bad_path, orphans, bad_depth, bad_numchild)):
             self.stdout.write("Remaining problems (cannot fix automatically):")
             if bad_alpha:
-                self.stdout.write("Invalid characters found in path for pages: %r" % bad_alpha)
+                self.stdout.write("Invalid characters found in path for pages: %s" % self.numberlist_to_string(bad_alpha))
             if bad_path:
-                self.stdout.write("Invalid path length found for pages: %r" % bad_path)
+                self.stdout.write("Invalid path length found for pages: %s" % self.numberlist_to_string(bad_path))
             if orphans:
-                self.stdout.write("Orphaned pages found: %r" % orphans)
+                self.stdout.write("Orphaned pages found: %s" % self.numberlist_to_string(orphans))
             if bad_depth:
-                self.stdout.write("Incorrect depth value found for pages: %r" % bad_depth)
+                self.stdout.write("Incorrect depth value found for pages: %s" % self.numberlist_to_string(bad_depth))
             if bad_numchild:
-                self.stdout.write("Incorrect numchild value found for pages: %r" % bad_numchild)
+                self.stdout.write("Incorrect numchild value found for pages: %s" % self.numberlist_to_string(bad_numchild))
 
         elif any_problems_fixed:
             self.stdout.write("All problems fixed.")


### PR DESCRIPTION
Keeping filter objects globally seems to upset mysql. Also, performing querys in the ``__init__`` method of a template node causes queries to be made even if the template isn't being fully rendered (eg. compressing static files)

This may hit performance slightly as it removes a bit of caching.

Fixes #541
Fixes #865