### PR TITLE
Page privacy groups

### DIFF
--- a/wagtail/tests/fixtures/test.json
+++ b/wagtail/tests/fixtures/test.json
@@ -344,7 +344,54 @@
         "cost": "free"
     }
 },
-
+{
+    "pk": 13,
+    "model": "wagtailcore.page",
+    "fields": {
+        "title": "Secret plans to group",
+        "numchild": 1,
+        "show_in_menus": true,
+        "live": true,
+        "depth": 3,
+        "content_type": ["tests", "simplepage"],
+        "path": "000100010006",
+        "url_path": "/home/secret-plans-to-group/",
+        "slug": "secret-plans-to-group"
+    }
+},
+{
+    "pk": 13,
+    "model": "tests.simplepage",
+    "fields": {
+        "content": "<p>muahahahaha groups</p>"
+    }
+},
+{
+    "pk": 14,
+    "model": "wagtailcore.page",
+    "fields": {
+        "title": "Steal underpants from group",
+        "numchild": 0,
+        "show_in_menus": true,
+        "live": true,
+        "depth": 4,
+        "content_type": ["tests", "eventpage"],
+        "path": "0001000100060001",
+        "url_path": "/home/secret-plans-to-group/steal-underpants-from-group/",
+        "slug": "steal-underpants-from-group"
+    }
+},
+{
+    "pk": 14,
+    "model": "tests.eventpage",
+    "fields": {
+        "date_from": "2015-07-04",
+        "audience": "private",
+        "location": "Marks and Spencer Group",
+        "body": "<p>meet in the menswear department at noon as a group</p>",
+        "cost": "free"
+    }
+},
 {
     "pk": 1,
     "model": "wagtailcore.site",
@@ -403,6 +450,13 @@
         "permissions": [
             ["access_admin", "wagtailadmin", "admin"]
         ]
+    }
+},
+{
+    "pk": 7,
+    "model": "auth.group",
+    "fields": {
+        "name": "Public site private page group"
     }
 },
 {
@@ -566,6 +620,56 @@
         "email": "admin_only_user@example.com"
     }
 },
+{
+    "pk": 7,
+    "model": "tests.customuser",
+    "fields": {
+        "username": "page_privacy_user_without_group",
+        "first_name": "",
+        "last_name": "",
+        "is_active": true,
+        "is_superuser": false,
+        "is_staff": false,
+        "user_permissions": [],
+        "password": "md5$seasalt$1ae1784477dc1642829e80f2a29d16cd",
+        "email": "page_privacy_user_without_group@example.com"
+    }
+},
+{
+    "pk": 8,
+    "model": "tests.customuser",
+    "fields": {
+        "username": "page_privacy_user_with_group",
+        "first_name": "",
+        "last_name": "",
+        "is_active": true,
+        "is_superuser": false,
+        "is_staff": false,
+        "groups": [
+            ["Public site private page group"]
+        ],
+        "user_permissions": [],
+        "password": "md5$seasalt$1ae1784477dc1642829e80f2a29d16cd",
+        "email": "page_privacy_user_with_group@example.com"
+    }
+},
+{
+    "pk": 9,
+    "model": "tests.customuser",
+    "fields": {
+        "username": "superuser_group_privacy_test",
+        "first_name": "",
+        "last_name": "",
+        "is_active": true,
+        "is_superuser": true,
+        "is_staff": true,
+        "groups": [
+        ],
+        "user_permissions": [],
+        "password": "md5$seasalt$1ae1784477dc1642829e80f2a29d16cd",
+        "email": "superuser_group_privacy_test@example.com"
+    }
+},
 
 {
     "pk": 1,
@@ -625,6 +729,14 @@
     "fields": {
         "page": 11,
         "password": "swordfish"
+    }
+},
+{
+    "pk": 2,
+    "model": "wagtailcore.pageviewrestriction",
+    "fields": {
+        "page": 13,
+        "groups": [7]
     }
 },
 {

--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -179,7 +179,7 @@ class PageViewRestrictionForm(forms.Form):
         ('none', ugettext_lazy("Public")),
         ('password', ugettext_lazy("Private, accessible with the following password")),
         ('group', ugettext_lazy("Private, accessible to Users in the following Groups")),
-    ], widget=forms.Select)
+    ])
     password = forms.CharField(required=False)
     groups = forms.ModelMultipleChoiceField(queryset=Group.objects.order_by('name'),
                                             widget=forms.CheckboxSelectMultiple,

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/components/forms.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/components/forms.scss
@@ -613,6 +613,12 @@ li.focused > .help{
     }
 }
 
+.model_multiple_choice_field .input.left ul li{
+  float: left;
+  white-space: nowrap;
+  padding-right: 1.5em;
+}
+
 .fields > li,
 .field-col{
     @include clearfix();

--- a/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy.html
@@ -9,6 +9,7 @@
         <ul class="fields">
             {% include "wagtailadmin/shared/field_as_li.html" with field=form.restriction_type %}
             {% include "wagtailadmin/shared/field_as_li.html" with field=form.password li_classes="password-field" %}
+            {% include "wagtailadmin/shared/field_as_li.html" with field=form.groups li_classes="groups-field" input_classes="left" %}
         </ul>
         <input type="submit" value="Save" />
     </form>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy.js
@@ -11,23 +11,22 @@ function(modal) {
     var groupsRow = $("li.groups-field", modal.body);
     function refreshFormFields() {
         var restrictType = restrictionTypePasswordField.val();
-        if (restrictType != "none") {
-            if (restrictType == "password") {
-                passwordField.removeAttr('disabled');
-                passwordRow.show();
-                groupFields.attr('disabled', true);
-                groupsRow.hide();
-            } else if(restrictType == "group") {
-                passwordField.attr('disabled', true);
-                passwordRow.hide();
-                groupFields.removeAttr('disabled');
-                groupsRow.show();
-            }
-        } else {
+
+        if (restrictType == "none") {
             passwordField.attr('disabled', true);
             passwordRow.hide();
             groupFields.attr('disabled', true);
             groupsRow.hide();
+        }else if (restrictType == "password"){
+            passwordField.removeAttr('disabled');
+            passwordRow.show();
+            groupFields.attr('disabled', true);
+            groupsRow.hide();
+        }else if (restrictType == "group"){
+            passwordField.attr('disabled', true);
+            passwordRow.hide();
+            groupFields.removeAttr('disabled');
+            groupsRow.show();
         }
     }
     refreshFormFields();

--- a/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy.js
@@ -4,16 +4,33 @@ function(modal) {
         return false;
     });
 
-    var restrictionTypePasswordField = $("input[name='restriction_type'][value='password']", modal.body);
+    var restrictionTypePasswordField = $("#id_restriction_type", modal.body);
+    var passwordRow = $("li.password-field", modal.body);
     var passwordField = $("#id_password", modal.body);
+    var groupFields = $("#id_groups input[name='groups']", modal.body);
+    var groupsRow = $("li.groups-field", modal.body);
     function refreshFormFields() {
-        if (restrictionTypePasswordField.is(':checked')) {
-            passwordField.removeAttr('disabled');
+        var restrictType = restrictionTypePasswordField.val();
+        if (restrictType != "none") {
+            if (restrictType == "password") {
+                passwordField.removeAttr('disabled');
+                passwordRow.show();
+                groupFields.attr('disabled', true);
+                groupsRow.hide();
+            } else if(restrictType == "group") {
+                passwordField.attr('disabled', true);
+                passwordRow.hide();
+                groupFields.removeAttr('disabled');
+                groupsRow.show();
+            }
         } else {
             passwordField.attr('disabled', true);
+            passwordRow.hide();
+            groupFields.attr('disabled', true);
+            groupsRow.hide();
         }
     }
     refreshFormFields();
 
-    $("input[name='restriction_type']", modal.body).change(refreshFormFields);
+    restrictionTypePasswordField.change(refreshFormFields);
 }

--- a/wagtail/wagtailadmin/views/page_privacy.py
+++ b/wagtail/wagtailadmin/views/page_privacy.py
@@ -68,10 +68,13 @@ def set_privacy(request, page_id):
                 # If there are groups assigned, use that restriction type.
                 restriction_type = groups and 'group' or 'password'
 
+                if restriction_type == 'group':
+                    restriction.password = ''
+
                 form = PageViewRestrictionForm(initial={
                     'restriction_type': restriction_type,
                     'password': restriction.password,
-                    'groups': [g for g in groups]
+                    'groups': groups
                 })
             else:
                 # no current view restrictions on this page

--- a/wagtail/wagtailcore/migrations/0011_auto_20150312_1507.py
+++ b/wagtail/wagtailcore/migrations/0011_auto_20150312_1507.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0001_initial'),
+        ('wagtailcore', '0010_change_page_owner_to_null_on_delete'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='pageviewrestriction',
+            name='groups',
+            field=models.ManyToManyField(to='auth.Group'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='pageviewrestriction',
+            name='password',
+            field=models.CharField(max_length=255, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1391,4 +1391,5 @@ class PagePermissionTester(object):
 
 class PageViewRestriction(models.Model):
     page = models.ForeignKey('Page', related_name='view_restrictions')
-    password = models.CharField(max_length=255)
+    password = models.CharField(max_length=255, blank=True)
+    groups = models.ManyToManyField(Group)

--- a/wagtail/wagtailcore/templates/registration/login.html
+++ b/wagtail/wagtailcore/templates/registration/login.html
@@ -4,6 +4,11 @@
         <title>Password required</title>
     </head>
     <body>
+    <!--
+     It is expected that you will use your own login template. This one
+     is only here for convenience and testing. Follow Django Auth
+     recommendations for your login template.
+    -->
     {% if form.errors %}
     <p>Your username and password didn't match. Please try again.</p>
     {% endif %}

--- a/wagtail/wagtailcore/templates/registration/login.html
+++ b/wagtail/wagtailcore/templates/registration/login.html
@@ -1,0 +1,28 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <title>Password required</title>
+    </head>
+    <body>
+    {% if form.errors %}
+    <p>Your username and password didn't match. Please try again.</p>
+    {% endif %}
+
+    <form action="{% url 'django.contrib.auth.views.login' %}" method="post">
+        {% csrf_token %}
+        <table>
+            <tr>
+                <td>{{ form.username.label_tag }}</td>
+                <td>{{ form.username }}</td>
+            </tr>
+            <tr>
+                <td>{{ form.password.label_tag }}</td>
+                <td>{{ form.password }}</td>
+            </tr>
+        </table>
+
+        <input type="submit" value="login" />
+        <input type="hidden" name="next" value="{{ next }}" />
+    </form>
+    </body>
+</html>

--- a/wagtail/wagtailcore/urls.py
+++ b/wagtail/wagtailcore/urls.py
@@ -5,6 +5,11 @@ urlpatterns = [
     url(r'^_util/authenticate_with_password/(\d+)/(\d+)/$', views.authenticate_with_password,
         name='wagtailcore_authenticate_with_password'),
 
+    # Including the 2 basic django auth urls.
+    # If you want the rest, add them in your urls file.
+    url(r'^login/$', 'django.contrib.auth.views.login', name='login'),
+    url(r'^logout/$', 'django.contrib.auth.views.logout', name='logout'),
+
     # Front-end page views are handled through Wagtail's core.views.serve mechanism.
     # Here we match a (possibly empty) list of path segments, each followed by
     # a '/'. If a trailing slash is not present, we leave CommonMiddleware to

--- a/wagtail/wagtailcore/wagtail_hooks.py
+++ b/wagtail/wagtailcore/wagtail_hooks.py
@@ -1,4 +1,5 @@
 from django.core.urlresolvers import reverse
+from django.contrib.auth.views import login
 
 from wagtail.wagtailcore import hooks
 
@@ -17,8 +18,34 @@ def check_view_restrictions(page, request, serve_args, serve_kwargs):
         passed_restrictions = request.session.get('passed_page_view_restrictions', [])
         for restriction in restrictions:
             if restriction.id not in passed_restrictions:
-                from wagtail.wagtailcore.forms import PasswordPageViewRestrictionForm
-                form = PasswordPageViewRestrictionForm(instance=restriction,
-                    initial={'return_url': request.get_full_path()})
-                action_url = reverse('wagtailcore_authenticate_with_password', args=[restriction.id, page.id])
-                return page.serve_password_required_response(request, form, action_url)
+                if restriction.password:
+                    # password protected
+                    from wagtail.wagtailcore.forms import PasswordPageViewRestrictionForm
+
+                    form = PasswordPageViewRestrictionForm(instance=restriction,
+                                                           initial={'return_url': request.get_full_path()})
+                    action_url = reverse('wagtailcore_authenticate_with_password', args=[restriction.id, page.id])
+                    return page.serve_password_required_response(request, form, action_url)
+                else:
+                    # group protected
+                    login_required = True
+                    user = request.user
+
+                    if user.is_authenticated():
+                        if user.is_superuser:
+                            # Super users can browse the site in full. TODO: Is this what we want?
+                            login_required = False
+                        else:
+                            # See if the user is in one of the required groups.
+                            groups = set(user.groups.values_list('id', flat=True))
+                            page_groups = set(restriction.groups.values_list('id', flat=True))
+
+                            if groups.intersection(page_groups):
+                                # The user is in one of the groups
+                                login_required = False
+
+                    if login_required:
+                        # Use the Django auth flow for this to keep things consistent.
+                        return login(request, extra_context={
+                            'next': page.url
+                        })

--- a/wagtail/wagtailcore/wagtail_hooks.py
+++ b/wagtail/wagtailcore/wagtail_hooks.py
@@ -18,15 +18,7 @@ def check_view_restrictions(page, request, serve_args, serve_kwargs):
         passed_restrictions = request.session.get('passed_page_view_restrictions', [])
         for restriction in restrictions:
             if restriction.id not in passed_restrictions:
-                if restriction.password:
-                    # password protected
-                    from wagtail.wagtailcore.forms import PasswordPageViewRestrictionForm
-
-                    form = PasswordPageViewRestrictionForm(instance=restriction,
-                                                           initial={'return_url': request.get_full_path()})
-                    action_url = reverse('wagtailcore_authenticate_with_password', args=[restriction.id, page.id])
-                    return page.serve_password_required_response(request, form, action_url)
-                else:
+                if restriction.groups.all():
                     # group protected
                     login_required = True
                     user = request.user
@@ -49,3 +41,11 @@ def check_view_restrictions(page, request, serve_args, serve_kwargs):
                         return login(request, extra_context={
                             'next': page.url
                         })
+                else:
+                    # password protected
+                    from wagtail.wagtailcore.forms import PasswordPageViewRestrictionForm
+
+                    form = PasswordPageViewRestrictionForm(instance=restriction,
+                                                           initial={'return_url': request.get_full_path()})
+                    action_url = reverse('wagtailcore_authenticate_with_password', args=[restriction.id, page.id])
+                    return page.serve_password_required_response(request, form, action_url)


### PR DESCRIPTION
Here is a take on how restricting pages to users in specific groups could work. This builds on the same flow that was already in place for page restrictions and adds a groups option to the PageViewRestriction model. The login process uses the normal django auth. Please take a look and let me know what you think and if I missed anything. Thanks!