### PR TITLE
Remove link to now-defunct Google Chrome Frame in warning for <IE9 browsers

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/skeleton.html
@@ -18,7 +18,7 @@
 </head>
 <body class="{% block bodyclass %}{% endblock %} {% if messages %}has-messages{% endif %}">
     <!--[if lt IE 9]>
-        <p class="capabilitymessage">{% blocktrans %}You are using an <strong>outdated</strong> browser not supported by this software. Please <a href="http://browsehappy.com/">upgrade your browser</a> or <a href="http://www.google.com/chromeframe/?redirect=true">activate Google Chrome Frame</a>.{% endblocktrans %}</p>
+        <p class="capabilitymessage">{% blocktrans %}You are using an <strong>outdated</strong> browser not supported by this software. Please <a href="http://browsehappy.com/">upgrade your browser</a>.{% endblocktrans %}</p>
     <![endif]-->
     <noscript class="capabilitymessage">{% trans 'Javascript is required to use Wagtail, but it is currently disabled' %}</noscript>
 


### PR DESCRIPTION
Link returned a 404 error, too.


