### PR TITLE
fixed upload button disabled during image upload

### DIFF
--- a/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.js
+++ b/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.js
@@ -49,6 +49,12 @@ function(modal) {
     $('form.image-upload', modal.body).submit(function() {
         var formdata = new FormData(this);
 
+        $('form.image-upload input:submit').attr("disabled", true);
+        $(this).append('<div style="line-height: 22px;">' +
+            '<img style="float: left; margin-right: 5px; border: none;" ' +
+                'src="{{ STATIC_URL }}wagtailadmin/images/spinner.gif" ' +
+                'alt="Spinner" width="20" /> Uploading...</div>');
+
         $.ajax({
             url: this.action,
             data: formdata,


### PR DESCRIPTION
When uploading to S3 (for example), the upload button was not being disabled, this was causing unnecessary uploads of the same file.

This fix disabled the button during the upload and adds a text with an animated 'loading' gif informing that the upload is processing.