### PR TITLE
pageurl tag library was renamed to wagtailcore since 0.4

### DIFF
--- a/docs/search/searching.rst
+++ b/docs/search/searching.rst
@@ -96,7 +96,7 @@ Next, let's look at the template itself:
 .. code-block:: django
 
   {% extends "mysite/base.html" %}
-  {% load pageurl %}
+  {% load wagtailcore_tags %}
 
   {% block title %}Search{% if search_results %} Results{% endif %}{% endblock %}
 


### PR DESCRIPTION
see http://wagtail.readthedocs.org/en/stable/pages/writing_templates.html?highlight=pageurl#internal-links-tag