### PR TITLE
Replaced models.get_models with apps.get_models

### DIFF
--- a/wagtail/contrib/wagtailfrontendcache/signal_handlers.py
+++ b/wagtail/contrib/wagtailfrontendcache/signal_handlers.py
@@ -1,4 +1,4 @@
-from django.db import models
+from django.apps import apps
 
 from wagtail.wagtailcore.signals import page_published, page_unpublished
 
@@ -15,8 +15,8 @@ def page_unpublished_signal_handler(instance, **kwargs):
 
 def register_signal_handlers():
     # Get list of models that are page types
-    Page = models.get_model('wagtailcore', 'Page')
-    indexed_models = [model for model in models.get_models() if issubclass(model, Page)]
+    Page = apps.get_model('wagtailcore', 'Page')
+    indexed_models = [model for model in apps.get_models() if issubclass(model, Page)]
 
     # Loop through list and register signal handlers for each one
     for model in indexed_models:

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -261,7 +261,7 @@ def image_delete(sender, instance, **kwargs):
 
 def get_image_model():
     from django.conf import settings
-    from django.db.models import get_model
+    from django.apps import apps
 
     try:
         app_label, model_name = settings.WAGTAILIMAGES_IMAGE_MODEL.split('.')
@@ -270,7 +270,7 @@ def get_image_model():
     except ValueError:
         raise ImproperlyConfigured("WAGTAILIMAGES_IMAGE_MODEL must be of the form 'app_label.model_name'")
 
-    image_model = get_model(app_label, model_name)
+    image_model = apps.get_model(app_label, model_name)
     if image_model is None:
         raise ImproperlyConfigured("WAGTAILIMAGES_IMAGE_MODEL refers to model '%s' that has not been installed" % settings.WAGTAILIMAGES_IMAGE_MODEL)
     return image_model

--- a/wagtail/wagtailsearch/index.py
+++ b/wagtail/wagtailsearch/index.py
@@ -3,6 +3,7 @@ import warnings
 from six import string_types
 
 from django.db import models
+from django.apps import apps
 
 
 class Indexed(object):
@@ -74,7 +75,7 @@ class Indexed(object):
 
 def get_indexed_models():
     return [
-        model for model in models.get_models()
+        model for model in apps.get_models()
         if issubclass(model, Indexed) and not model._meta.abstract
     ]
 


### PR DESCRIPTION
``models.get_models`` is deprecated in Django 1.7 and removed in Django 1.9.