### PR TITLE
Added manage.py for demosite to make contributing easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /docs/_build/
 /.tox/
 /venv
+/demosite.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /.tox/
 /venv
 /demosite.sqlite3
+/demosite-static
+/demosite-media

--- a/demosite.py
+++ b/demosite.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "wagtail.tests.demosite.settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/wagtail/tests/demosite/settings.py
+++ b/wagtail/tests/demosite/settings.py
@@ -10,7 +10,7 @@ https://docs.djangoproject.com/en/1.7/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 
 # Quick-start development settings - unsuitable for production
@@ -109,9 +109,9 @@ STATICFILES_FINDERS = (
     'compressor.finders.CompressorFinder',
 )
 
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+STATIC_ROOT = os.path.join(BASE_DIR, 'demosite-static')
 
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_ROOT = os.path.join(BASE_DIR, 'demosite-media')
 MEDIA_URL = '/media/'
 
 

--- a/wagtail/tests/demosite/settings.py
+++ b/wagtail/tests/demosite/settings.py
@@ -1,0 +1,134 @@
+"""
+Django settings for demosite project.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/1.7/topics/settings/
+
+For the full list of settings and their values, see
+https://docs.djangoproject.com/en/1.7/ref/settings/
+"""
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+import os
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = '2a3_2!!^_cz)47#5+9v$5uoa@bhwc0dj7w2&%pawea!$rv8u@y'
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+TEMPLATE_DEBUG = True
+
+ALLOWED_HOSTS = []
+
+
+# Application definition
+
+INSTALLED_APPS = (
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+
+    'taggit',
+    'compressor',
+    'modelcluster',
+
+    'wagtail.wagtailcore',
+    'wagtail.wagtailadmin',
+    'wagtail.wagtailsearch',
+    'wagtail.wagtailimages',
+    'wagtail.wagtaildocs',
+    'wagtail.wagtailsnippets',
+    'wagtail.wagtailusers',
+    'wagtail.wagtailsites',
+    'wagtail.wagtailembeds',
+    'wagtail.wagtailredirects',
+    'wagtail.wagtailforms',
+    'wagtail.tests.demosite',
+    'wagtail.contrib.wagtailstyleguide',
+)
+
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+    'wagtail.wagtailcore.middleware.SiteMiddleware',
+    'wagtail.wagtailredirects.middleware.RedirectMiddleware',
+)
+
+ROOT_URLCONF = 'wagtail.tests.demosite.urls'
+
+WSGI_APPLICATION = 'wagtail.tests.demosite.wsgi.application'
+
+
+# Database
+# https://docs.djangoproject.com/en/1.7/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'demosite.sqlite3',
+    }
+}
+
+# Internationalization
+# https://docs.djangoproject.com/en/1.7/topics/i18n/
+
+LANGUAGE_CODE = 'en-us'
+
+TIME_ZONE = 'UTC'
+
+USE_I18N = True
+
+USE_L10N = True
+
+USE_TZ = True
+
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/1.7/howto/static-files/
+
+STATIC_URL = '/static/'
+
+STATICFILES_FINDERS = (
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'compressor.finders.CompressorFinder',
+)
+
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_URL = '/media/'
+
+
+# Django compressor settings
+# http://django-compressor.readthedocs.org/en/latest/settings/
+
+COMPRESS_PRECOMPILERS = (
+    ('text/x-scss', 'django_libsass.SassCompiler'),
+)
+
+
+# Template context processors
+
+from django.conf import global_settings
+TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
+    'django.core.context_processors.request',
+)
+
+
+WAGTAIL_SITE_NAME = "demosite"

--- a/wagtail/tests/demosite/urls.py
+++ b/wagtail/tests/demosite/urls.py
@@ -21,3 +21,10 @@ urlpatterns = patterns('',
 
     url(r'', include(wagtail_urls)),
 )
+
+
+if settings.DEBUG:
+    import os.path
+    from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+
+    urlpatterns += static(settings.MEDIA_URL + 'images/', document_root=os.path.join(settings.MEDIA_ROOT, 'images'))

--- a/wagtail/tests/demosite/urls.py
+++ b/wagtail/tests/demosite/urls.py
@@ -1,0 +1,23 @@
+from django.conf.urls import patterns, include, url
+from django.conf.urls.static import static
+from django.conf import settings
+from django.contrib import admin
+
+from wagtail.wagtailadmin import urls as wagtailadmin_urls
+from wagtail.wagtailcore import urls as wagtail_urls
+from wagtail.wagtaildocs import urls as wagtaildocs_urls
+from wagtail.wagtailsearch.views import search
+
+
+urlpatterns = patterns('',
+    # Examples:
+    # url(r'^$', 'testy.views.home', name='home'),
+    # url(r'^blog/', include('blog.urls')),
+
+    url(r'^django-admin/', include(admin.site.urls)),
+    url(r'^admin/', include(wagtailadmin_urls)),
+    url(r'^documents/', include(wagtaildocs_urls)),
+    url(r'^search/$', search, name='search'),
+
+    url(r'', include(wagtail_urls)),
+)

--- a/wagtail/tests/demosite/wsgi.py
+++ b/wagtail/tests/demosite/wsgi.py
@@ -1,0 +1,14 @@
+"""
+WSGI config for testy project.
+
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
+"""
+
+import os
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "wagtail.tests.demosite.settings")
+
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()


### PR DESCRIPTION
In https://github.com/torchbox/wagtail/pull/1121 we merged the models/data from Wagtaildemo into Wagtail. The original intention of this was to provide a base for writing unit tests against.

I found that if we add a ``manage.py`` file (and some settings files) into Wagtail, we could actually launch this app.

I think this would make contributing to Wagtail much easier as you no longer need to setup wagtaildemo (or mess around with Python paths in order to test UI changes).

**Usage:**

Once you have Wagtail cloned locally and tests are running (see: http://docs.wagtail.io/en/latest/howto/contributing.html#running-the-unit-tests), run the following commands.

```
demosite.py migrate
demosite.py createsuperuser
demosite.py loaddata demosite.json
demosite.py runserver
```

The first three commands only need to be run on initial set up.

This doesn't require Vagrant or PostgreSQL to be installed (it uses SQLite)