### PR TITLE
Update session auth hash on password change

### DIFF
--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -43,6 +43,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 

--- a/wagtail/wagtailadmin/views/account.py
+++ b/wagtail/wagtailadmin/views/account.py
@@ -3,6 +3,7 @@ from django.shortcuts import render, redirect
 from django.contrib import messages
 from django.contrib.auth.forms import SetPasswordForm
 from django.contrib.auth.views import logout as auth_logout, login as auth_login
+from django.contrib.auth import update_session_auth_hash
 from django.utils.translation import ugettext as _ 
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.cache import never_cache
@@ -32,6 +33,7 @@ def change_password(request):
 
             if form.is_valid():
                 form.save()
+                update_session_auth_hash(request, form.user)
 
                 messages.success(request, _("Your password has been changed successfully!"))
                 return redirect('wagtailadmin_account')


### PR DESCRIPTION
Fixes #1124

When SessionAuthenticationMiddleware is enabled, the change password form will kick the user out of all their sessions, including the one they just changed their password in.

This change prevents the middleware from kicking the user out of the current session (but they will still be kicked out all other sessions)

See: https://docs.djangoproject.com/en/dev/topics/auth/default/#session-invalidation-on-password-change