### PR TITLE
Prevent toolbars from overlapping the fixed footer

### DIFF
--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/components/datetimepicker.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/components/datetimepicker.scss
@@ -7,7 +7,7 @@
 	padding-left: 0px;
 	padding-top: 2px;
 	position: absolute;
-	z-index: 9999;
+	z-index: 1;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 	display:none;
@@ -98,7 +98,7 @@
 			content:"n";
 		}
 	}
-	
+
 	.xdsoft_timepicker{
 		width: 70px;
 		float:left;
@@ -153,7 +153,7 @@
 			}
 		}
 	}
-		
+
 	.xdsoft_label{
 		display: inline;
 	    position: relative;
@@ -184,16 +184,16 @@
 			background:#fff;
 			max-height:160px;
 			overflow-y:hidden;
-			
+
 			&.xdsoft_monthselect{right:-7px;}
 			&.xdsoft_yearselect{right:2px;}
-			
+
 			> div > .xdsoft_option:hover{
 				color: #fff;
 			    background: #ff8000;
 			}
 			> div > .xdsoft_option{
-				padding:2px 15px 2px 5px; 
+				padding:2px 15px 2px 5px;
 			}
 			> div > .xdsoft_option.xdsoft_current{
 				background: #33AAFF;
@@ -213,7 +213,7 @@
 	}
 	.xdsoft_calendar{
 		clear:both;
-		
+
 		table{
 			border-collapse:collapse;
 		}
@@ -256,7 +256,7 @@
 		opacity:0.5;
 		background:$color-grey-3;
 	}
-	
+
 	.xdsoft_calendar td.xdsoft_other_month.xdsoft_disabled{
 		opacity:0.2;
 	}

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/components/main-nav.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/components/main-nav.scss
@@ -101,13 +101,13 @@ $submenu-color:darken($color-grey-1, 5%);
                 top:0.5em;
                 margin-top:0.15em;
             }
-            
-        }       
+
+        }
 
         .account{
             @include clearfix();
-          
-       
+
+
             .avatar{
                 display:none;
             }
@@ -119,9 +119,9 @@ $submenu-color:darken($color-grey-1, 5%);
         }
     }
 
-    .nav-submenu{ 
+    .nav-submenu{
         background:$submenu-color;
-        
+
         h2{
             display:none;
         }
@@ -145,8 +145,8 @@ $submenu-color:darken($color-grey-1, 5%);
     }
 
     .explorer{
-        position:absolute;
-        margin-top:70px;
+        // position:absolute;
+        // margin-top:70px;
         font-size:0.95em;
     }
 
@@ -186,7 +186,7 @@ $submenu-color:darken($color-grey-1, 5%);
             padding:0;
             width:3em; height:100%;
             overflow:hidden;
-            
+
             &:before{
                 font-family:wagtail;
                 font-weight:200;
@@ -198,7 +198,7 @@ $submenu-color:darken($color-grey-1, 5%);
                 padding:0 1em;
             }
         }
-       
+
     }
 
 /* Navigation open condition */
@@ -212,6 +212,18 @@ body.nav-open{
     }
     footer{
         bottom:1px;
+    }
+}
+
+
+.explorer-close {
+    display: none;
+    padding: .9em;
+    border-bottom:1px solid rgba(200, 200, 200, 0.1);
+    cursor: pointer;
+
+    &:hover {
+        color: white;
     }
 }
 
@@ -232,13 +244,15 @@ body.explorer-open {
 
     .explorer{
         display:block;
-        border-top:1px solid rgba(200,200,200,0.1);
+    }
 
-        &:before{
-            position:absolute;
-            top:-3em;
-            content:"Close explorer";
-            padding:0.9em;
+    .explorer-close {
+        display: block;
+    }
+
+    @media screen and (min-width: $breakpoint-mobile) {
+        .explorer-close {
+            display: none;
         }
     }
 }
@@ -280,13 +294,13 @@ body.explorer-open {
             position:fixed;
             width:$menu-width - 7;
             bottom:0;
-           
+
         }
         .account{
             @include clearfix();
             padding-right:0;
             padding-left:15px;
-       
+
             .avatar{
                 display:inline-block;
                 padding:0;
@@ -307,7 +321,7 @@ body.explorer-open {
         }
     }
 
-    .nav-submenu{ 
+    .nav-submenu{
         position:fixed;
         height:100%;
         width:0;
@@ -317,7 +331,7 @@ body.explorer-open {
         overflow:auto;
         max-height:100%;
         border-right:1px solid rgba(0,0,0,0.1);
-        
+
         h2,ul{
             float:right;
             width:$menu-width;
@@ -348,9 +362,9 @@ body.explorer-open {
 
         > a{
             text-shadow:-1px -1px 0px rgba(0,0,0,0.3);
-            
+
             &:hover{
-                background-color:transparent;  
+                background-color:transparent;
             }
         }
         .nav-submenu{

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/core.scss
@@ -407,16 +407,21 @@ footer, .logo{
         }
     }
     .explorer {
-        z-index:$explorer-z-index;
+        z-index: $explorer-z-index;
     }
     .nav-submenu {
-        z-index:$explorer-z-index;
+        z-index: $explorer-z-index;
     }
-    .nav-wrapper{
-        z-index:auto;  /* allows overspill of messages banner onto left menu, but also explorer to spill over main content */
+
+    // Allows overspill of messages banner onto left menu, but also explorer
+    // to spill over main content
+    .nav-wrapper {
+        z-index: auto;
     }
-    .nav-wrapper.submenu-active{
-        z-index:5;
+
+    // footer is z-index: 100, so ensure the navigation sits on top of it.
+    .nav-wrapper.submenu-active {
+        z-index: 200;
     }
 }
 

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/core.scss
@@ -80,6 +80,9 @@ body{
         border:0;
         margin-right:1em;
     }
+    &:hover {
+        color: white;
+    }
 }
 
 .content-wrapper{
@@ -187,7 +190,7 @@ footer{
 
             &:after{
                 right:0;
-                z-index:5;
+                // z-index:5;
                 position:absolute;
                 font-family:wagtail;
                 content:"n";

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/core.scss
@@ -265,9 +265,16 @@ footer{
 .nav-wrapper{
     z-index:2;
 }
-.content-wrapper{
-    z-index:3;
-}
+
+// Avoiding a stacking context for the content-wrapper saves us a world
+// of pain when dealing with overlays that are appended to the end of
+// <body>, eg Hallo & calendars. As long as content-wrapper remains floated,
+// the z-index shouldn't be required.
+
+// .content-wrapper{
+    // z-index:3;
+// }
+
 .nav-submenu{
     z-index:6;
 }
@@ -338,7 +345,7 @@ footer, .logo{
     }
     .content-wrapper{
         border-bottom-right-radius: 5px;
-    }    
+    }
 
     .logo{
         margin:1em auto;
@@ -353,13 +360,13 @@ footer, .logo{
             margin:auto;
             display:block;
         }
-    }   
+    }
 
     footer{
         width:80%;
         margin-left:50px;
     }
-    
+
     .content{
         border-top:0;
         background-color:none;

--- a/wagtail/wagtailadmin/templates/wagtailadmin/base.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/base.html
@@ -10,7 +10,7 @@
                 {% endblock %}
                 <span>{% trans "Dashboard" %}</span>
             </a>
-            
+
             <form class="nav-search" action="{% url 'wagtailadmin_pages_search' %}" method="get">
                 <div>
                     <label for="menu-search-q">{% trans "Search" %}</label>
@@ -22,7 +22,9 @@
             {% main_nav %}
         </div>
 
-        <nav id="explorer" class="explorer"></nav>
+        <span class="explorer-close">Close explorer</span>
+        <nav id="explorer" class="explorer">
+        </nav>
     </div>
 
     <div class="content-wrapper">


### PR DESCRIPTION
Removing the z-index for the `.content-wrapper` saves us a world of pain when dealing with overlays that are appended to the end of `<body>`, eg Hallo & calendars. It does this by avoiding the creation of a new stacking context on the wrapper, meaning z-index on `footer` and `hallotoolbar` will be respected:

![screen shot 2015-04-03 at 8 19 49 pm](https://cloud.githubusercontent.com/assets/1715456/6982707/cb1bc2f6-da71-11e4-95ce-61b315f46eb6.png)

becomes...

![screen shot 2015-04-04 at 2 09 37 am](https://cloud.githubusercontent.com/assets/1715456/6982708/cb2001f4-da71-11e4-9b95-75f5649b89a3.png)

Also: 

![screen shot 2015-04-04 at 2 09 18 am](https://cloud.githubusercontent.com/assets/1715456/6982807/007235d8-da73-11e4-9ac1-1d816ac46890.png)

Just checking, this is now the expected behaviour? It looks good in my local testing, but does anyone know if the explicit z-index on `.content-wrapper` was solving another problem?

