### PR TITLE
Allow defining page routes with @route decorator

### DIFF
--- a/docs/contrib/routablepage.rst
+++ b/docs/contrib/routablepage.rst
@@ -1,49 +1,46 @@
 .. _routable_page_mixin:
 
-====================================
-Embedding URL configuration in Pages
-====================================
+==============
+Routable pages
+==============
 
-The ``RoutablePageMixin`` mixin provides a convenient way for a page to respond on multiple sub-URLs with different views. For example, a blog section on a site might provide several different types of index page at URLs like ``/blog/2013/06/``, ``/blog/authors/bob/``, ``/blog/tagged/python/``, all served by the same ``BlogIndex`` page.
+The ``RoutablePageMixin`` mixin provides a convenient way for a page to respond on multiple sub-URLs with different views. For example, a blog section on a site might provide several different types of index page at URLs like ``/blog/2013/06/``, ``/blog/authors/bob/``, ``/blog/tagged/python/``, all served by the same page instance.
 
-A ``Page`` using ``RoutablePageMixin`` exists within the page tree like any other page, but URL paths underneath it are checked against a list of patterns, using Django's urlconf scheme. If none of the patterns match, control is passed to subpages as usual (or failing that, a 404 error is thrown).
+A ``Page`` using ``RoutablePageMixin`` exists within the page tree like any other page, but URL paths underneath it are checked against a list of patterns. If none of the patterns match, control is passed to subpages as usual (or failing that, a 404 error is thrown).
 
 
 The basics
 ==========
 
-To use ``RoutablePageMixin``, you need to make your class inherit from both :class:`wagtail.contrib.wagtailroutablepage.models.RoutablePageMixin` and :class:`wagtail.wagtailcore.models.Page`, and configure the ``subpage_urls`` attribute with your URL configuration.
+To use ``RoutablePageMixin``, you need to make your class inherits from both :class:`wagtail.contrib.wagtailroutablepage.models.RoutablePageMixin` and :class:`wagtail.wagtailcore.models.Page`, then define some view methods and decorate them with ``wagtail.contrib.wagtailroutablepage.models.route``.
 
 Here's an example of an ``EventPage`` with three views:
 
 .. code-block:: python
 
-    from django.conf.urls import url
-
-    from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin
     from wagtail.wagtailcore.models import Page
+    from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin, route
 
 
     class EventPage(RoutablePageMixin, Page):
-        subpage_urls = (
-            url(r'^$', 'current_events', name='current_events'),
-            url(r'^past/$', 'past_events', name='past_events'),
-            url(r'^year/(\d+)/$', 'events_for_year', name='events_for_year'),
-        )
+        ...
 
+        @route(r'^$')
         def current_events(self, request):
             """
             View function for the current events page
             """
             ...
 
+        @route(r'^past/$')
         def past_events(self, request):
             """
             View function for the past events page
             """
             ...
 
-        def events_for_year(self, request):
+        @route(r'^year/(\d+)/$')
+        def events_for_year(self, request, year):
             """
             View function for the events for year page
             """
@@ -56,29 +53,7 @@ The ``RoutablePageMixin`` class
 .. automodule:: wagtail.contrib.wagtailroutablepage.models
 .. autoclass:: RoutablePageMixin
 
-    .. autoattribute:: subpage_urls
-
-        Example:
-
-        .. code-block:: python
-
-            from django.conf.urls import url
-
-            from wagtail.wagtailcore.models import Page
-
-
-            class MyPage(RoutablePageMixin, Page):
-                subpage_urls = (
-                    url(r'^$', 'main', name='main'),
-                    url(r'^archive/$', 'archive', name='archive'),
-                    url(r'^archive/(?P<year>[0-9]{4})/$', 'archive', name='archive'),
-                )
-
-                def main(self, request):
-                    ...
-
-                def archive(self, request, year=None):
-                    ...
+    .. automethod:: get_subpage_urls
 
     .. automethod:: resolve_subpage
 

--- a/wagtail/contrib/wagtailroutablepage/models.py
+++ b/wagtail/contrib/wagtailroutablepage/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from six import string_types
+import warnings
 
 from django.http import Http404
 from django.core.urlresolvers import RegexURLResolver
@@ -8,6 +9,7 @@ from django.conf.urls import url
 
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.url_routing import RouteResult
+from wagtail.utils.deprecation import RemovedInWagtail12Warning
 
 
 _creation_counter = 0
@@ -40,6 +42,18 @@ class RoutablePageMixin(object):
     """
     #: Set this to a tuple of ``django.conf.urls.url`` objects.
     subpage_urls = None
+
+    @classmethod
+    def check(cls, **kwargs):
+        if cls.subpage_urls:
+            warnings.warn(
+                "{app_label}.{classname}: subpage_urls is deprecated. Use the "
+                "@route decorator to define page routes instead.".format(
+                    app_label=cls._meta.app_label,
+                    classname=cls.__name__,
+                ), RemovedInWagtail12Warning)
+
+        return super(RoutablePageMixin, cls).check(**kwargs)
 
     @classmethod
     def get_subpage_urls(cls):

--- a/wagtail/contrib/wagtailroutablepage/models.py
+++ b/wagtail/contrib/wagtailroutablepage/models.py
@@ -45,7 +45,7 @@ class RoutablePageMixin(object):
 
     @classmethod
     def check(cls, **kwargs):
-        if cls.subpage_urls:
+        if cls.subpage_urls and not hasattr(cls, '_disable_subpage_urls_deprecation_warning'):
             warnings.warn(
                 "{app_label}.{classname}: subpage_urls is deprecated. Use the "
                 "@route decorator to define page routes instead.".format(

--- a/wagtail/contrib/wagtailroutablepage/tests.py
+++ b/wagtail/contrib/wagtailroutablepage/tests.py
@@ -1,3 +1,6 @@
+import unittest
+
+import django
 from django.test import TestCase, RequestFactory
 from django.core.urlresolvers import NoReverseMatch
 
@@ -112,6 +115,7 @@ class TestNewStyleRoutablePage(TestCase):
         self.assertContains(response, "EXTERNAL VIEW: ARG NOT SET")
 
 
+@unittest.skipIf(django.VERSION >= (1, 8), "Old style routable pages don't work on Django 1.8")
 class TestOldStyleRoutablePage(TestNewStyleRoutablePage):
     model = OldStyleRoutablePageTest
 

--- a/wagtail/contrib/wagtailroutablepage/tests.py
+++ b/wagtail/contrib/wagtailroutablepage/tests.py
@@ -141,14 +141,15 @@ class TestOldStyleRoutablePage(TestNewStyleRoutablePage, WagtailTestUtils):
         from django.conf.urls import url
 
         class TestPageModel(RoutablePageMixin, Page):
-            abstract = True
-
             subpage_urls = (
                 url('r^$', 'main'),
             )
 
             def main(self, request):
                 pass
+
+            class Meta:
+                abstract = True
 
         # Calling check() should raise a deprecation warning
         # This would usually be called by Django when it loads

--- a/wagtail/tests/routablepage/migrations/0002_auto_20150407_1121.py
+++ b/wagtail/tests/routablepage/migrations/0002_auto_20150407_1121.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import wagtail.contrib.wagtailroutablepage.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0013_update_golive_expire_help_text'),
+        ('routablepagetests', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='OldStyleRoutablePageTest',
+            fields=[
+                ('page_ptr', models.OneToOneField(primary_key=True, auto_created=True, serialize=False, to='wagtailcore.Page', parent_link=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=(wagtail.contrib.wagtailroutablepage.models.RoutablePageMixin, 'wagtailcore.page'),
+        ),
+        migrations.RenameModel(
+            old_name='RoutablePageTest',
+            new_name='NewStyleRoutablePageTest',
+        ),
+    ]

--- a/wagtail/tests/routablepage/models.py
+++ b/wagtail/tests/routablepage/models.py
@@ -16,6 +16,9 @@ class OldStyleRoutablePageTest(RoutablePage):
         url(r'^external/(.+)/$', routable_page_external_view, name='external_view')
     )
 
+    # Don't show deprecation warning for this class to keep test log clean
+    _disable_subpage_urls_deprecation_warning = True
+
     def archive_by_year(self, request, year):
         return HttpResponse("ARCHIVE BY YEAR: " + str(year))
 

--- a/wagtail/tests/routablepage/models.py
+++ b/wagtail/tests/routablepage/models.py
@@ -1,13 +1,14 @@
 from django.http import HttpResponse
 from django.conf.urls import url
 
-from wagtail.contrib.wagtailroutablepage.models import RoutablePage
+from wagtail.contrib.wagtailroutablepage.models import RoutablePage, route
 
 
-def routable_page_external_view(request, arg):
+def routable_page_external_view(request, arg="ARG NOT SET"):
     return HttpResponse("EXTERNAL VIEW: " + arg)
 
-class RoutablePageTest(RoutablePage):
+
+class OldStyleRoutablePageTest(RoutablePage):
     subpage_urls = (
         url(r'^$', 'main', name='main'),
         url(r'^archive/year/(\d+)/$', 'archive_by_year', name='archive_by_year'),
@@ -23,3 +24,28 @@ class RoutablePageTest(RoutablePage):
 
     def main(self, request):
         return HttpResponse("MAIN VIEW")
+
+
+class NewStyleRoutablePageTest(RoutablePage):
+    @route(r'^$')
+    def main(self, request):
+        return HttpResponse("MAIN VIEW")
+
+    @route(r'^archive/year/(\d+)/$')
+    def archive_by_year(self, request, year):
+        return HttpResponse("ARCHIVE BY YEAR: " + str(year))
+
+    @route(r'^archive/author/(?P<author_slug>.+)/$')
+    def archive_by_author(self, request, author_slug):
+        return HttpResponse("ARCHIVE BY AUTHOR: " + author_slug)
+
+    @route(r'^external/(.+)/$')
+    @route(r'^external-no-arg/$')
+    def external_view(self, *args, **kwargs):
+        return routable_page_external_view(*args, **kwargs)
+
+    # By default, the method name would be used as the url name but when the
+    # "name" kwarg is specified, this should override the default.
+    @route(r'^override-name-test/$', name='name_overridden')
+    def override_name_test(self, request):
+        pass


### PR DESCRIPTION
This PR changes the routablepage mixin by adding a new decorator, ``@route``.

You can use this to decorate methods on your page page class with a url and name. I hope this would replace the old ``subpage_urls`` attribute. The main advantages are a cleaner look and works better with inheritance and mixins.

Before:

```python
from django.conf.urls import url

from wagtail.contrib.wagtailroutablepage.models import RoutablePage


class MyPage(RoutablePage):
    subpage_urls = (
        url(r'^$', 'main', name='main'),
        url(r'^archive/year/(\d+)/$', 'archive_by_year', name='archive_by_year'),
        url(r'^archive/author/(?P<author_slug>.+)/$', 'archive_by_author', name='archive_by_author'),
    )

    def main(self, request):
        ...

    def archive_by_year(self, request, year):
        ...

    def archive_by_author(self, request, author_slug):
        ...
```

After:

```python
from wagtail.contrib.wagtailroutablepage.models import RoutablePage, route


class MyPage(RoutablePage):
    @route(r'^$')
    def main(self, request):
        ...

    @route(r'^archive/year/(\d+)/$')
    def archive_by_year(self, request, year):
        ...

    @route(r'^archive/author/(?P<author_slug>.+)/$')
    def archive_by_author(self, request, author_slug):
        ...
```

This is also fully backwards compatible. Just need to update the docs and this will be ready for merge.