### PR TITLE
reduce django template control structures inside js code

### DIFF
--- a/wagtail/wagtailadmin/static/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static/wagtailadmin/js/page-editor.js
@@ -385,16 +385,16 @@ $(function() {
 
                             frame = frame.contentWindow || frame.contentDocument.document || frame.contentDocument;
                             frame.document.open();
-                            frame.document.write(data);                 
+                            frame.document.write(data);
                             frame.document.close();
 
                             var hideTimeout = setTimeout(function(){
                                 previewDoc.getElementById('loading-spinner-wrapper').className += ' remove';
                                 clearTimeout(hideTimeout);
-                            }) // just enough to give effect without adding discernible slowness                       
+                            }) // just enough to give effect without adding discernible slowness
                         } else {
                             previewDoc.open();
-                            previewDoc.write(data);                 
+                            previewDoc.write(data);
                             previewDoc.close()
                         }
 
@@ -419,6 +419,6 @@ $(function() {
             });
 
         }
-        
+
     });
 });

--- a/wagtail/wagtailadmin/templates/wagtailadmin/edit_handlers/inline_panel.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/edit_handlers/inline_panel.js
@@ -1,13 +1,15 @@
 (function() {
+    var children = JSON.parse('[{% for child in self.children %}"{{child.form.prefix}}"{% if not forloop.last %},{% endif %}{% endfor %}]');
     var panel = InlinePanel({
-        formsetPrefix: "id_{{ self.formset.prefix }}",
-        emptyChildFormPrefix: "{{ self.empty_child.form.prefix }}",
-        canOrder: {% if can_order %}true{% else %}false{% endif %}
+        formsetPrefix: 'id_{{ self.formset.prefix }}',
+        emptyChildFormPrefix: '{{ self.empty_child.form.prefix }}',
+        canOrder: '{% if can_order %}true{% endif %}' === 'true' ? true: false
     });
 
-    {% for child in self.children %}
-        panel.initChildControls("{{ child.form.prefix }}");
-    {% endfor %}
+    for (var i = 0; i < children.length; i++) {
+        panel.initChildControls(children[i]);
+    }
+
     panel.setHasContent();
     panel.updateMoveButtonDisabledStates();
 })();

--- a/wagtail/wagtailadmin/templates/wagtailadmin/edit_handlers/inline_panel.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/edit_handlers/inline_panel.js
@@ -3,7 +3,7 @@
     var panel = InlinePanel({
         formsetPrefix: 'id_{{ self.formset.prefix }}',
         emptyChildFormPrefix: '{{ self.empty_child.form.prefix }}',
-        canOrder: '{% if can_order %}true{% endif %}' === 'true' ? true: false
+        canOrder: '{% if can_order %}true{% endif %}' === 'true'
     });
 
     for (var i = 0; i < children.length; i++) {

--- a/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy_done.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy_done.js
@@ -1,4 +1,4 @@
 function(modal) {
-    modal.respond('setPermission', '{% if is_public %}true{% endif %}' === 'true' ? true : false );
+    modal.respond('setPermission', '{% if is_public %}true{% endif %}' === 'true' );
     modal.close();
 }

--- a/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy_done.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy_done.js
@@ -1,4 +1,4 @@
 function(modal) {
-    modal.respond('setPermission', {% if is_public %}true{% else %}false{% endif %});
+    modal.respond('setPermission', '{% if is_public %}true{% endif %}' === 'true' ? true : false );
     modal.close();
 }

--- a/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy_done.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy_done.js
@@ -1,4 +1,4 @@
 function(modal) {
-    modal.respond('setPermission', '{% if is_public %}true{% endif %}' === 'true' );
+    modal.respond('setPermission', '{% if is_public %}true{% endif %}' === 'true');
     modal.close();
 }

--- a/wagtail/wagtailadmin/tests/test_privacy.py
+++ b/wagtail/wagtailadmin/tests/test_privacy.py
@@ -84,7 +84,7 @@ class TestSetPrivacyView(TestCase, WagtailTestUtils):
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "modal.respond('setPermission', false);")
+        self.assertContains(response, "modal.respond('setPermission', '' === 'true');")
 
         # Check that a page restriction has been created
         self.assertTrue(PageViewRestriction.objects.filter(page=self.public_page).exists())
@@ -120,7 +120,7 @@ class TestSetPrivacyView(TestCase, WagtailTestUtils):
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "modal.respond('setPermission', true);")
+        self.assertContains(response, "modal.respond('setPermission', 'true' === 'true' );")
 
         # Check that the page restriction has been deleted
         self.assertFalse(PageViewRestriction.objects.filter(page=self.private_page).exists())

--- a/wagtail/wagtailadmin/tests/test_privacy.py
+++ b/wagtail/wagtailadmin/tests/test_privacy.py
@@ -120,7 +120,7 @@ class TestSetPrivacyView(TestCase, WagtailTestUtils):
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "modal.respond('setPermission', 'true' === 'true' );")
+        self.assertContains(response, "modal.respond('setPermission', 'true' === 'true');")
 
         # Check that the page restriction has been deleted
         self.assertFalse(PageViewRestriction.objects.filter(page=self.private_page).exists())

--- a/wagtail/wagtaildocs/templates/wagtaildocs/chooser/chooser.js
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/chooser/chooser.js
@@ -71,7 +71,6 @@ function(modal) {
         $(this).data('timer', wait);
     });
 
-    {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
     $('#id_tags', modal.body).tagit({
         autocomplete: {source: "{{ autocomplete_url|addslashes }}"}
     });

--- a/wagtail/wagtaildocs/views/chooser.py
+++ b/wagtail/wagtaildocs/views/chooser.py
@@ -86,6 +86,7 @@ def chooser(request):
         'uploadform': uploadform,
         'searchform': searchform,
         'is_searching': False,
+        'autocomplete_url': reverse('wagtailadmin_tag_autocomplete')
     })
 
 
@@ -121,6 +122,9 @@ def chooser_upload(request):
     documents = Document.objects.order_by('title')
 
     return render_modal_workflow(
-        request, 'wagtaildocs/chooser/chooser.html', 'wagtaildocs/chooser/chooser.js',
-        {'documents': documents, 'uploadform': form}
+        request, 'wagtaildocs/chooser/chooser.html', 'wagtaildocs/chooser/chooser.js', {
+            'documents': documents,
+            'uploadform': form,
+            'autocomplete_url': reverse('wagtailadmin_tag_autocomplete')
+        }
     )

--- a/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.js
+++ b/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.js
@@ -77,8 +77,7 @@ function(modal) {
         return false;
     });
 
-    {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
-    
+
     /* Add tag entry interface (with autocompletion) to the tag field of the image upload form */
     $('#id_tags', modal.body).tagit({
         autocomplete: {source: "{{ autocomplete_url|addslashes }}"}

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -98,6 +98,7 @@ def chooser(request):
         'query_string': q,
         'will_select_format': request.GET.get('select_format'),
         'popular_tags': Image.popular_tags(),
+        'autocomplete_url': reverse('wagtailadmin_tag_autocomplete')
     })
 
 
@@ -146,8 +147,13 @@ def chooser_upload(request):
     images = Image.objects.order_by('title')
 
     return render_modal_workflow(
-        request, 'wagtailimages/chooser/chooser.html', 'wagtailimages/chooser/chooser.js',
-        {'images': images, 'uploadform': form, 'searchform': searchform, 'max_filesize': MAX_UPLOAD_SIZE}
+        request, 'wagtailimages/chooser/chooser.html', 'wagtailimages/chooser/chooser.js', {
+            'images': images,
+            'uploadform': form,
+            'searchform': searchform,
+            'max_filesize': MAX_UPLOAD_SIZE,
+            'autocomplete_url': reverse('wagtailadmin_tag_autocomplete')
+        }
     )
 
 

--- a/wagtail/wagtailsearch/templates/wagtailsearch/editorspicks/includes/editorspicks_formset.js
+++ b/wagtail/wagtailsearch/templates/wagtailsearch/editorspicks/includes/editorspicks_formset.js
@@ -1,13 +1,17 @@
 $(function() {
+    var prefix = '{{formset.prefix}}';
+    var emptyPrefix = '{{formset.empty_form.prefix}}';
+    var numForms = parseInt('{{formset.forms|length}}', 10);
+
     var panel = InlinePanel({
-        formsetPrefix: "id_{{ formset.prefix }}",
-        emptyChildFormPrefix: "{{ formset.empty_form.prefix }}",
+        formsetPrefix: 'id_' + prefix,
+        emptyChildFormPrefix: emptyPrefix,
         canOrder: true
     });
 
-    {% for form in formset.forms %}
-        panel.initChildControls('{{ formset.prefix }}-{{ forloop.counter0 }}');
-    {% endfor %}
+    for (var i = 0; i < numForms; i++) {
+        panel.initChildControls([prefix, i].join('-'));
+    }
 
     panel.updateMoveButtonDisabledStates();
 });

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/includes/page_permissions_formset.js
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/includes/page_permissions_formset.js
@@ -1,12 +1,16 @@
 $(function() {
+    var prefix = '{{formset.prefix}}';
+    var emptyPrefix = '{{formset.empty_form.prefix}}';
+    var numForms = parseInt('{{formset.forms|length}}', 10);
+
     var panel = InlinePanel({
-        formsetPrefix: "id_{{ formset.prefix }}",
-        emptyChildFormPrefix: "{{ formset.empty_form.prefix }}"
+        formsetPrefix: 'id_' + prefix,
+        emptyChildFormPrefix: emptyPrefix,
     });
 
-    {% for form in formset.forms %}
-        panel.initChildControls('{{ formset.prefix }}-{{ forloop.counter0 }}');
-    {% endfor %}
+    for (var i = 0; i < numForms; i++) {
+        panel.initChildControls([prefix, i].join('-'));
+    }
 
     panel.updateMoveButtonDisabledStates();
 });


### PR DESCRIPTION
This is an attempt to make the Javascript linter happier about django variables injected into Javascript code, mainly by wrapping them in strings and replacing django control structures with javascript ones. 

There's still a piece of work to be done in `browse.js` and `search.js` to clean up a common dependency, `{% include 'wagtailadmin/chooser/_search_behaviour.js' %}`, which might be better moved into to the modal workflow js? 