### PR TITLE
Serve documents by direct sendfile mechanism

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ install_requires = [
     "django-modelcluster>=0.4",
     "django-taggit==0.12.2",
     "django-treebeard==2.0",
+    "django-sendfile==0.3.6",
     "Pillow>=2.6.1",
     "beautifulsoup4>=4.3.2",
     "html5lib==0.999",

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -60,6 +60,7 @@ INSTALLED_APPS = [
 
     'taggit',
     'compressor',
+    'sendfile',
 
     'wagtail.wagtailcore',
     'wagtail.wagtailadmin',
@@ -140,5 +141,7 @@ try:
 except ImportError:
     pass
 
+# Sendfile dev backend, do NOT use in production https://github.com/johnsensible/django-sendfile#django-sendfile
+SENDFILE_BACKEND = 'sendfile.backends.development'
 
 WAGTAIL_SITE_NAME = "Test Site"

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -141,6 +141,37 @@ class TestDocumentAddView(TestCase, WagtailTestUtils):
         self.assertTrue(models.Document.objects.filter(title="Test document").exists())
 
 
+class TestDocumentServeView(TestCase, WagtailTestUtils):
+
+    def test_get(self):
+        self.login()
+
+        # Build a fake file
+        fake_file = ContentFile(b("A boring example document"))
+        fake_file.name = 'test.txt'
+
+        # Submit
+        post_data = {
+            'title': "Test document",
+            'file': fake_file,
+        }
+        response = self.client.post(reverse('wagtaildocs_add_document'), post_data)
+
+        # User should be redirected back to the index
+        self.assertRedirects(response, reverse('wagtaildocs_index'))
+
+        # Document should be created
+        self.assertTrue(models.Document.objects.filter(title="Test document").exists())
+
+        self.client.logout()
+
+        self.document = Document.objects.get(title="Test document")
+
+        response = self.client.get(reverse('wagtaildocs_serve', args=(self.document.id, self.document.filename)))
+
+        self.assertEqual(response.status_code, 200)
+
+
 class TestDocumentEditView(TestCase, WagtailTestUtils):
     def setUp(self):
         self.login()

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -150,7 +150,7 @@ class TestDocumentServeView(TestCase, WagtailTestUtils):
         fake_file = ContentFile(b("A boring example document"))
         fake_file.name = 'test.txt'
 
-        # Submit
+        # Submit it
         post_data = {
             'title': "Test document",
             'file': fake_file,
@@ -165,11 +165,20 @@ class TestDocumentServeView(TestCase, WagtailTestUtils):
 
         self.client.logout()
 
+        # Serve document
         self.document = Document.objects.get(title="Test document")
 
         response = self.client.get(reverse('wagtaildocs_serve', args=(self.document.id, self.document.filename)))
 
         self.assertEqual(response.status_code, 200)
+        self.assertEquals(
+            response.get('Content-Disposition'),
+            'attachment; filename="%s"' % self.document.filename
+        )
+        self.assertEquals(
+            response.get('Content-Type'),
+            "text/plain"
+        )
 
 
 class TestDocumentEditView(TestCase, WagtailTestUtils):

--- a/wagtail/wagtaildocs/views/serve.py
+++ b/wagtail/wagtaildocs/views/serve.py
@@ -11,4 +11,4 @@ def serve(request, document_id, document_filename):
     # Send document_served signal
     document_served.send(sender=doc, request=request)
 
-    return sendfile(request, doc.file, attachment=True, attachment_filename=doc.filename)
+    return sendfile(request, doc.file.path, attachment=True, attachment_filename=doc.filename)

--- a/wagtail/wagtaildocs/views/serve.py
+++ b/wagtail/wagtaildocs/views/serve.py
@@ -1,21 +1,14 @@
 from django.shortcuts import get_object_or_404
-from django.core.servers.basehttp import FileWrapper
-from django.http import HttpResponse
+
+from sendfile import sendfile
 
 from wagtail.wagtaildocs.models import Document, document_served
 
 
 def serve(request, document_id, document_filename):
     doc = get_object_or_404(Document, id=document_id)
-    wrapper = FileWrapper(doc.file)
-    response = HttpResponse(wrapper, content_type='application/octet-stream')
-
-    # TODO: strip out weird characters like semicolons from the filename
-    # (there doesn't seem to be an official way of escaping them)
-    response['Content-Disposition'] = 'attachment; filename=%s' % doc.filename
-    response['Content-Length'] = doc.file.size
 
     # Send document_served signal
     document_served.send(sender=doc, request=request)
 
-    return response
+    return sendfile(request, doc.file, attachment=True, attachment_filename=doc.filename)


### PR DESCRIPTION
I've tried to implement the issue described in https://github.com/torchbox/wagtail/issues/1115
Not sure if this is what you guys were after, I've added the sendfile module and tweak the serve view to use it. The setting SENDFILE_BACKEND can be set to development, simple or more advanced mods (xsednfile, wsgi etc..) up to the user to set the preferred one.
