### PR TITLE
Enhancement #644: Allow for procedural highlighting of menu items

### DIFF
--- a/wagtail/wagtailadmin/menu.py
+++ b/wagtail/wagtailadmin/menu.py
@@ -111,7 +111,7 @@ class SubmenuMenuItem(MenuItem):
         # show the submenu if one or more of its children is shown
         return bool(self.menu.menu_items_for_request(request))
 
-    def is_child_active(self, request):
+    def is_active(self, request):
         return bool(self.menu.active_menu_items(request))
 
     def render_html(self, request):
@@ -123,7 +123,7 @@ class SubmenuMenuItem(MenuItem):
             'menu_html': self.menu.render_html(request),
             'label': self.label,
             'request': request,
-            'active': self.is_child_active(request)
+            'active': self.is_active(request)
         }, request=request)
 
 

--- a/wagtail/wagtailadmin/menu.py
+++ b/wagtail/wagtailadmin/menu.py
@@ -5,14 +5,10 @@ from six import text_type, with_metaclass
 from django.forms import MediaDefiningClass, Media
 from django.forms.utils import flatatt
 from django.utils.text import slugify
-from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-
-from wagtail.wagtailcore import hooks
-
-
 from django.template import Context, loader
 
+from wagtail.wagtailcore import hooks
 
 
 class MenuItem(with_metaclass(MediaDefiningClass)):

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/components/main-nav.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/components/main-nav.scss
@@ -2,7 +2,7 @@ $selected-highlight:darken($color-grey-1, 10%);
 $submenu-color:darken($color-grey-1, 5%);
 
 .nav-wrapper{
-    position:relative;
+    position: relative;
     background: $color-grey-1;
     margin-left: -$menu-width;
     width: $menu-width;
@@ -11,9 +11,9 @@ $submenu-color:darken($color-grey-1, 5%);
     min-height:800px;
 }
     #nav-toggle{
-        left:$mobile-nice-padding;
+        left: $mobile-nice-padding;
         cursor:pointer;
-        position:absolute;
+        position: absolute;
 
         &:before{
             font-size:40px;
@@ -23,43 +23,32 @@ $submenu-color:darken($color-grey-1, 5%);
         }
     }
 
-    .nav-main{
+    .menu-active {
+        background: $selected-highlight;
+        text-shadow: -1px -1px 0px rgba(0,0,0,0.3);
+
+        & > a {
+            border-left-color:$color-salmon;
+            color:white;
+        }
+    }
+
+
+    .nav-main {
         top: 43px;
         bottom: 0px;
         overflow: auto;
-        width:100%;
+        width: 100%;
 
-        ul, li{
-            margin:0;
-            padding:0;
-            list-style-type:none;
+        ul, li {
+            margin: 0;
+            padding: 0;
+            list-style-type: none;
         }
 
-        li{
+        li {
             @include transition(border-color 0.2s ease);
-            position:relative;
-
-            /* TODO: find better way to procedurally detect the appropriate menu to highlight */
-            .menu-snippets &.menu-snippets,
-            .menu-users &.menu-users,
-            .menu-groups &.menu-groups,
-            .menu-sites &.menu-sites,
-            .menu-redirects &.menu-redirects,
-            .menu-editorspicks &.menu-editors-picks,
-            .menu-snippets &.menu-snippets,
-            .menu-documents &.menu-documents,
-            .menu-images &.menu-images,
-            .menu-search &.menu-search,
-            .menu-explorer &.menu-explorer,
-            .menu-forms &.menu-forms{
-                background:$selected-highlight;
-                text-shadow:-1px -1px 0px rgba(0,0,0,0.3);
-
-                a{
-                    border-left-color:$color-salmon;
-                    color:white;
-                }
-            }
+            position: relative;
         }
 
         a{
@@ -101,13 +90,13 @@ $submenu-color:darken($color-grey-1, 5%);
                 top:0.5em;
                 margin-top:0.15em;
             }
-            
-        }       
+
+        }
 
         .account{
             @include clearfix();
-          
-       
+
+
             .avatar{
                 display:none;
             }
@@ -119,9 +108,9 @@ $submenu-color:darken($color-grey-1, 5%);
         }
     }
 
-    .nav-submenu{ 
+    .nav-submenu{
         background:$submenu-color;
-        
+
         h2{
             display:none;
         }
@@ -186,7 +175,7 @@ $submenu-color:darken($color-grey-1, 5%);
             padding:0;
             width:3em; height:100%;
             overflow:hidden;
-            
+
             &:before{
                 font-family:wagtail;
                 font-weight:200;
@@ -198,7 +187,7 @@ $submenu-color:darken($color-grey-1, 5%);
                 padding:0 1em;
             }
         }
-       
+
     }
 
 /* Navigation open condition */
@@ -280,13 +269,13 @@ body.explorer-open {
             position:fixed;
             width:$menu-width - 7;
             bottom:0;
-           
+
         }
         .account{
             @include clearfix();
             padding-right:0;
             padding-left:15px;
-       
+
             .avatar{
                 display:inline-block;
                 padding:0;
@@ -307,7 +296,7 @@ body.explorer-open {
         }
     }
 
-    .nav-submenu{ 
+    .nav-submenu{
         position:fixed;
         height:100%;
         width:0;
@@ -317,7 +306,7 @@ body.explorer-open {
         overflow:auto;
         max-height:100%;
         border-right:1px solid rgba(0,0,0,0.1);
-        
+
         h2,ul{
             float:right;
             width:$menu-width;
@@ -348,9 +337,9 @@ body.explorer-open {
 
         > a{
             text-shadow:-1px -1px 0px rgba(0,0,0,0.3);
-            
+
             &:hover{
-                background-color:transparent;  
+                background-color:transparent;
             }
         }
         .nav-submenu{

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/menu_item.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/menu_item.html
@@ -1,0 +1,3 @@
+<li class="menu-item menu-{{name}}{% if active %} menu-active{% endif %}">
+    <a href="{{url}}" class="{{classnames}}"{{attr_string}}>{{label}}</a>
+</li>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/menu_item.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/menu_item.html
@@ -1,3 +1,3 @@
-<li class="menu-item menu-{{name}}{% if active %} menu-active{% endif %}">
-    <a href="{{url}}" class="{{classnames}}"{{attr_string}}>{{label}}</a>
+<li class="menu-item menu-{{ name }}{% if active %} menu-active{% endif %}">
+    <a href="{{ url }}" class="{{ classnames }}"{{ attr_string }}>{{ label }}</a>
 </li>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/menu_submenu_item.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/menu_submenu_item.html
@@ -1,7 +1,7 @@
-<li class="menu-item menu-{{name}}{% if active %} menu-active{% endif %}">
-    <a href="#" class="submenu-trigger {{classnames}}"{{attr_string}}>{{label}}</a>
+<li class="menu-item menu-{{ name }}{% if active %} menu-active{% endif %}">
+    <a href="#" class="submenu-trigger {{ classnames }}"{{ attr_string }}>{{ label }}</a>
     <div class="nav-submenu">
-        <h2 class="{{classnames}}">{{label}}</h2>
-        <ul>{{menu_html}}</ul>
+        <h2 class="{{ classnames }}">{{ label }}</h2>
+        <ul>{{ menu_html }}</ul>
     </div>
 </li>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/menu_submenu_item.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/menu_submenu_item.html
@@ -1,0 +1,7 @@
+<li class="menu-item menu-{{name}}{% if active %} menu-active{% endif %}">
+    <a href="#" class="submenu-trigger {{classnames}}"{{attr_string}}>{{label}}</a>
+    <div class="nav-submenu">
+        <h2 class="{{classnames}}">{{label}}</h2>
+        <ul>{{menu_html}}</ul>
+    </div>
+</li>


### PR DESCRIPTION
I've updated the menu class for the admin, so that it references a template in the `render_html()` method, instead of keeping the HTML in the menu class. This felt sensible as it means you can just pass a template path into the constructor, eg `MenuItem(template='mymodule/some_template.html')` rather than subclassing `MenuItem`. 

How do we make sure this is right for all the contrib modules as well? Are they adding extra CSS? 

cheers,

Josh
