### PR TITLE
#1183 add note to staticsitegen documentation 

### DIFF
--- a/docs/contrib/staticsitegen.rst
+++ b/docs/contrib/staticsitegen.rst
@@ -16,6 +16,11 @@ First, install ``django-medusa`` from pip:
 
     pip install django-medusa
 
+.. note::
+
+    Since 0.8.6, Wagtail uses StreamingHttpResponse to return Documents. `django-medusa`_ currently does not support this and the staticsitegen command will fail if your site contains Documents.
+    For a temporary fix, install this fork https://github.com/ctxis/django-medusa. (see also #1183)
+
 
 Then add ``django_medusa`` and ``wagtail.contrib.wagtailmedusa`` to ``INSTALLED_APPS``:
 


### PR DESCRIPTION
add note to staticsitegen documentation about temporarily using fork https://github.com/ctxis/django-medusa to generate static versions of sites that contain Documents