### PR TITLE
Skip front-end cache purge for pages with no routable URL - fixes #1208

### DIFF
--- a/wagtail/contrib/wagtailfrontendcache/tests.py
+++ b/wagtail/contrib/wagtailfrontendcache/tests.py
@@ -1,8 +1,10 @@
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from wagtail.tests.testapp.models import EventIndex
+
 from wagtail.contrib.wagtailfrontendcache.utils import get_backends
-from wagtail.contrib.wagtailfrontendcache.backends import HTTPBackend, CloudflareBackend
+from wagtail.contrib.wagtailfrontendcache.backends import HTTPBackend, CloudflareBackend, BaseBackend
 
 
 class TestBackendConfiguration(TestCase):
@@ -76,3 +78,36 @@ class TestBackendConfiguration(TestCase):
         self.assertEqual(set(backends.keys()), set(['default']))
         self.assertIsInstance(backends['default'], HTTPBackend)
         self.assertEqual(backends['default'].cache_location, 'http://localhost:8000')
+
+
+PURGED_URLS = []
+
+
+class MockBackend(BaseBackend):
+    def __init__(self, config):
+        pass
+
+    def purge(self, url):
+        PURGED_URLS.append(url)
+
+
+@override_settings(WAGTAILFRONTENDCACHE={
+    'varnish': {
+        'BACKEND': 'wagtail.contrib.wagtailfrontendcache.tests.MockBackend',
+    },
+})
+class TestCachePurging(TestCase):
+
+    fixtures = ['test.json']
+
+    def test_purge_on_publish(self):
+        PURGED_URLS[:] = []  # reset PURGED_URLS to the empty list
+        page = EventIndex.objects.get(url_path='/home/events/')
+        page.save_revision().publish()
+        self.assertEqual(PURGED_URLS, ['http://localhost/events/'])
+
+    def test_purge_on_unpublish(self):
+        PURGED_URLS[:] = []  # reset PURGED_URLS to the empty list
+        page = EventIndex.objects.get(url_path='/home/events/')
+        page.unpublish()
+        self.assertEqual(PURGED_URLS, ['http://localhost/events/'])

--- a/wagtail/contrib/wagtailfrontendcache/tests.py
+++ b/wagtail/contrib/wagtailfrontendcache/tests.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from wagtail.wagtailcore.models import Page
 from wagtail.tests.testapp.models import EventIndex
 
 from wagtail.contrib.wagtailfrontendcache.utils import get_backends
@@ -111,3 +112,11 @@ class TestCachePurging(TestCase):
         page = EventIndex.objects.get(url_path='/home/events/')
         page.unpublish()
         self.assertEqual(PURGED_URLS, ['http://localhost/events/'])
+
+    def test_purge_with_unroutable_page(self):
+        PURGED_URLS[:] = []  # reset PURGED_URLS to the empty list
+        root = Page.objects.get(url_path='/')
+        page = EventIndex(title='new top-level page', slug='new-top-level-page')
+        root.add_child(instance=page)
+        page.save_revision().publish()
+        self.assertEqual(PURGED_URLS, [])

--- a/wagtail/contrib/wagtailfrontendcache/utils.py
+++ b/wagtail/contrib/wagtailfrontendcache/utils.py
@@ -61,8 +61,12 @@ def purge_url_from_cache(url, backend_settings=None, backends=None):
 
 
 def purge_page_from_cache(page, backend_settings=None, backends=None):
+    page_url = page.full_url
+    if page_url is None:  # nothing to be done if the page has no routable URL
+        return
+
     for backend_name, backend in get_backends(backend_settings=backend_settings, backends=backends).items():
         # Purge cached paths from cache
         for path in page.specific.get_cached_paths():
-            logger.info("[%s] Purging URL: %s", backend_name, page.full_url + path[1:])
-            backend.purge(page.full_url + path[1:])
+            logger.info("[%s] Purging URL: %s", backend_name, page_url + path[1:])
+            backend.purge(page_url + path[1:])


### PR DESCRIPTION
Also add some tests that the signal handlers actually work, since we didn't have any...