### PR TITLE
Cleanup old raw SQL query

### DIFF
--- a/wagtail/wagtailadmin/views/home.py
+++ b/wagtail/wagtailadmin/views/home.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 from django.conf import settings
+from django.db.models import F
 
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import PageRevision, UserPagePermissionsProxy
@@ -31,13 +32,7 @@ class RecentEditsPanel(object):
     def __init__(self, request):
         self.request = request
         # Last n edited pages
-        self.last_edits = PageRevision.objects.raw(
-            """
-            select wp.* FROM
-                wagtailcore_pagerevision wp JOIN (
-                    SELECT max(created_at) as max_created_at, page_id FROM wagtailcore_pagerevision group by page_id
-                ) as max_rev on max_rev.max_created_at = wp.created_at and wp.user_id = %s order by wp.created_at desc
-            """, [request.user.id])[:5]
+        self.last_edits = PageRevision.objects.filter(user=self.request.user, created_at=F('page__latest_revision_created_at')).order_by('-created_at')[:5]
 
     def render(self):
         return render_to_string('wagtailadmin/home/recent_edits.html', {


### PR DESCRIPTION
This commit replaces an old query that was written before we added the ``latest_revision_created_at`` field to ``Page``.

We no longer need to use a raw SQL query and the new query should also run a bit faster too.