### PR TITLE
Enable optional RichTextBlocks

### DIFF
--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -211,10 +211,15 @@ class ChoiceBlock(FieldBlock):
 
 
 class RichTextBlock(FieldBlock):
+
+    def __init__(self, required=True, help_text=None, **kwargs):
+        self.field_options = {'required': required, 'help_text': help_text}
+        super(RichTextBlock, self).__init__(**kwargs)
+
     @cached_property
     def field(self):
         from wagtail.wagtailcore.fields import RichTextArea
-        return forms.CharField(widget=RichTextArea)
+        return forms.CharField(widget=RichTextArea, **self.field_options)
 
     def render_basic(self, value):
         return mark_safe('<div class="rich-text">' + expand_db_html(value) + '</div>')

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -82,6 +82,23 @@ class TestFieldBlock(unittest.TestCase):
         self.assertEqual(content, ["Choice 1"])
 
 
+class TestRichTextBlock(unittest.TestCase):
+
+    def test_validate_required_richtext_block(self):
+        block = blocks.RichTextBlock()
+
+        with self.assertRaises(ValidationError):
+            block.clean('')
+
+        with self.assertRaises(ValidationError):
+            block.clean(None)
+
+    def test_validate_non_required_richtext_block(self):
+        block = blocks.RichTextBlock(required=False)
+        self.assertEqual(block.clean(''), '')
+        self.assertEqual(block.clean(None), '')
+
+
 class TestChoiceBlock(unittest.TestCase):
     def setUp(self):
         from django.db.models.fields import BLANK_CHOICE_DASH


### PR DESCRIPTION
Use `required` and `help_text` for validation and field display when they are passed as parameters to the RichTextBlock constructor.