### PR TITLE
fix TypeError if submitting unchecked BooleanField

### DIFF
--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -196,7 +196,7 @@ class AbstractEmailForm(AbstractForm):
         super(AbstractEmailForm, self).process_form_submission(form)
 
         if self.to_address:
-            content = '\n'.join([x[1].label + ': ' + form.data.get(x[0]) for x in form.fields.items()])
+            content = '\n'.join([x[1].label + ': ' + str(form.data.get(x[0])) for x in form.fields.items()])
             send_mail(self.subject, content, [self.to_address], self.from_address,)
 
 


### PR DESCRIPTION
If you try to submit a form with an unchecked checkbox you will get a 500.
```
TypeError
Can't convert 'NoneType' object to str implicitly
```

This commit fixes it.