### PR TITLE
Keep collapsible blocks open if there is any form error.

### DIFF
--- a/wagtail/wagtailadmin/static/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static/wagtailadmin/js/page-editor.js
@@ -331,7 +331,7 @@ function initCollapsibleBlocks() {
     $('.object.multi-field.collapsible').each(function() {
         var $li = $(this);
         var $fieldset = $li.find('fieldset');
-        if ($li.hasClass('collapsed')) {
+        if ($li.hasClass('collapsed') && $li.find('.error-message').length == 0) {
             $fieldset.hide();
         }
 


### PR DESCRIPTION
By default the collapsible blocks will be hidden after saving or from preview.
When there is a form error inside one of these blocks, the block is hidden and the user does not know where the form errors are located.