### PR TITLE
Put all wagtailimages urls in a namespace

### DIFF
--- a/wagtail/wagtailimages/admin_urls.py
+++ b/wagtail/wagtailimages/admin_urls.py
@@ -4,21 +4,21 @@ from wagtail.wagtailimages.views import images, chooser, multiple
 
 
 urlpatterns = [
-    url(r'^$', images.index, name='wagtailimages_index'),
-    url(r'^(\d+)/$', images.edit, name='wagtailimages_edit_image'),
-    url(r'^(\d+)/delete/$', images.delete, name='wagtailimages_delete_image'),
-    url(r'^(\d+)/generate_url/$', images.url_generator, name='wagtailimages_url_generator'),
-    url(r'^(\d+)/generate_url/(.*)/$', images.generate_url, name='wagtailimages_generate_url'),
-    url(r'^(\d+)/preview/(.*)/$', images.preview, name='wagtailimages_preview'),
-    url(r'^add/$', images.add, name='wagtailimages_add_image'),
-    url(r'^usage/(\d+)/$', images.usage, name='wagtailimages_image_usage'),
+    url(r'^$', images.index, name='index'),
+    url(r'^(\d+)/$', images.edit, name='edit_image'),
+    url(r'^(\d+)/delete/$', images.delete, name='delete_image'),
+    url(r'^(\d+)/generate_url/$', images.url_generator, name='url_generator'),
+    url(r'^(\d+)/generate_url/(.*)/$', images.generate_url, name='generate_url'),
+    url(r'^(\d+)/preview/(.*)/$', images.preview, name='preview'),
+    url(r'^add/$', images.add, name='add_image'),
+    url(r'^usage/(\d+)/$', images.usage, name='image_usage'),
 
-    url(r'^multiple/add/$', multiple.add, name='wagtailimages_add_multiple'),
-    url(r'^multiple/(\d+)/$', multiple.edit, name='wagtailimages_edit_multiple'),
-    url(r'^multiple/(\d+)/delete/$', multiple.delete, name='wagtailimages_delete_multiple'),
+    url(r'^multiple/add/$', multiple.add, name='add_multiple'),
+    url(r'^multiple/(\d+)/$', multiple.edit, name='edit_multiple'),
+    url(r'^multiple/(\d+)/delete/$', multiple.delete, name='delete_multiple'),
 
-    url(r'^chooser/$', chooser.chooser, name='wagtailimages_chooser'),
-    url(r'^chooser/(\d+)/$', chooser.image_chosen, name='wagtailimages_image_chosen'),
-    url(r'^chooser/upload/$', chooser.chooser_upload, name='wagtailimages_chooser_upload'),
-    url(r'^chooser/(\d+)/select_format/$', chooser.chooser_select_format, name='wagtailimages_chooser_select_format'),
+    url(r'^chooser/$', chooser.chooser, name='chooser'),
+    url(r'^chooser/(\d+)/$', chooser.image_chosen, name='image_chosen'),
+    url(r'^chooser/upload/$', chooser.chooser_upload, name='chooser_upload'),
+    url(r'^chooser/(\d+)/select_format/$', chooser.chooser_select_format, name='chooser_select_format'),
 ]

--- a/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.html
@@ -12,7 +12,7 @@
 
 <div class="tab-content">
     <section id="search" class="{% if not uploadform.errors %}active{% endif %} nice-padding">
-        <form class="image-search search-bar" action="{% url 'wagtailimages_chooser' %}{% if will_select_format %}?select_format=true{% endif %}" method="GET" autocomplete="off">
+        <form class="image-search search-bar" action="{% url 'wagtailimages:chooser' %}{% if will_select_format %}?select_format=true{% endif %}" method="GET" autocomplete="off">
             <ul class="fields">
                 {% for field in searchform %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
@@ -22,7 +22,7 @@
                     <li class="taglist">
                         <h3>{% trans 'Popular tags' %}</h3>
                         {% for tag in popular_tags %}
-                            <a class="suggested-tag tag" href="{% url 'wagtailimages_index' %}?q={{ tag.name|urlencode }}">{{ tag.name }}</a>
+                            <a class="suggested-tag tag" href="{% url 'wagtailimages:index' %}?q={{ tag.name|urlencode }}">{{ tag.name }}</a>
                         {% endfor %}
                     </li>
                 {% endif %}
@@ -34,7 +34,7 @@
     </section>
     {% if uploadform %}
         <section id="upload" class="{% if uploadform.errors %}active{% endif %} nice-padding">
-            <form class="image-upload" action="{% url 'wagtailimages_chooser_upload' %}{% if will_select_format %}?select_format=true{% endif %}" method="POST" enctype="multipart/form-data">
+            <form class="image-upload" action="{% url 'wagtailimages:chooser_upload' %}{% if will_select_format %}?select_format=true{% endif %}" method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
                 <ul class="fields">
                     {% for field in uploadform %}

--- a/wagtail/wagtailimages/templates/wagtailimages/chooser/results.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/chooser/results.html
@@ -16,7 +16,7 @@
     <ul class="listing horiz images chooser">
         {% for image in images %}
             <li>
-                <a class="image-choice" href="{% if will_select_format %}{% url 'wagtailimages_chooser_select_format' image.id %}{% else %}{% url 'wagtailimages_image_chosen' image.id %}{% endif %}">
+                <a class="image-choice" href="{% if will_select_format %}{% url 'wagtailimages:chooser_select_format' image.id %}{% else %}{% url 'wagtailimages:image_chosen' image.id %}{% endif %}">
                     <div class="image">{% image image max-165x165 %}</div>
                     <h3>{{ image.title|ellipsistrim:60 }}</h3>
                 </a>

--- a/wagtail/wagtailimages/templates/wagtailimages/chooser/select_format.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/chooser/select_format.html
@@ -8,7 +8,7 @@
         {% image image max-800x600 %}
     </div>
     <div class="col6">
-        <form action="{% url 'wagtailimages_chooser_select_format' image.id %}" method="POST">
+        <form action="{% url 'wagtailimages:chooser_select_format' image.id %}" method="POST">
             {% csrf_token %}
             <ul class="fields">
                 {% for field in form %}

--- a/wagtail/wagtailimages/templates/wagtailimages/homepage/site_summary_images.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/homepage/site_summary_images.html
@@ -1,7 +1,7 @@
 {% load i18n wagtailadmin_tags %}
 
 <li class="icon icon-image">
-    <a href="{% url 'wagtailimages_index' %}">
+    <a href="{% url 'wagtailimages:index' %}">
     {% blocktrans count counter=total_images with total_images|intcomma as total %}
         <span>{{ total }}</span> Image
     {% plural %}

--- a/wagtail/wagtailimages/templates/wagtailimages/images/add.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/add.html
@@ -16,7 +16,7 @@
     {% include "wagtailadmin/shared/header.html" with title=add_str icon="image" %}
 
     <div class="nice-padding">
-        <form action="{% url 'wagtailimages_add_image' %}" method="POST" enctype="multipart/form-data">
+        <form action="{% url 'wagtailimages:add_image' %}" method="POST" enctype="multipart/form-data">
             {% csrf_token %}
             <ul class="fields">
                 {% for field in form %}

--- a/wagtail/wagtailimages/templates/wagtailimages/images/confirm_delete.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/confirm_delete.html
@@ -14,7 +14,7 @@
         </div>
         <div class="col6">
             <p>{% trans "Are you sure you want to delete this image?" %}</p>
-            <form action="{% url 'wagtailimages_delete_image' image.id %}" method="POST">
+            <form action="{% url 'wagtailimages:delete_image' image.id %}" method="POST">
                 {% csrf_token %}
                 <input type="submit" value="{% trans 'Yes, delete' %}" class="serious" />
             </form>

--- a/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
@@ -28,7 +28,7 @@
     <div class="row row-flush nice-padding">
 
         <div class="col5">
-            <form action="{% url 'wagtailimages_edit_image' image.id %}" method="POST" enctype="multipart/form-data">
+            <form action="{% url 'wagtailimages:edit_image' image.id %}" method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
                 <ul class="fields">
                     {% for field in form %}
@@ -42,7 +42,7 @@
                         {% endif %}
 
                     {% endfor %}
-                    <li><input type="submit" value="{% trans 'Save' %}" /><a href="{% url 'wagtailimages_delete_image' image.id %}" class="button button-secondary no">{% trans "Delete image" %}</a></li>
+                    <li><input type="submit" value="{% trans 'Save' %}" /><a href="{% url 'wagtailimages:delete_image' image.id %}" class="button button-secondary no">{% trans "Delete image" %}</a></li>
                 </ul>
             </form>
         </div>
@@ -67,7 +67,7 @@
         </div>
         <div class="col2 ">
             {% if url_generator_enabled %}
-                <a href="{% url 'wagtailimages_url_generator' image.id %}" class="button bicolor icon icon-link">{% trans "URL Generator" %}</a>
+                <a href="{% url 'wagtailimages:url_generator' image.id %}" class="button bicolor icon icon-link">{% trans "URL Generator" %}</a>
                 <hr />
             {% endif %}
 

--- a/wagtail/wagtailimages/templates/wagtailimages/images/index.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/index.html
@@ -7,7 +7,7 @@
 {% block extra_js %}
     <script>
         window.headerSearch = {
-            url: "{% url 'wagtailimages_index' %}",
+            url: "{% url 'wagtailimages:index' %}",
             termInput: "#id_q",
             targetOutput: "#image-results"
         }
@@ -17,7 +17,7 @@
 {% block content %}
     {% trans "Images" as im_str %}
     {% trans "Add an image" as add_img_str %}
-    {% include "wagtailadmin/shared/header.html" with title=im_str add_link="wagtailimages_add_multiple" icon="image" add_text=add_img_str search_url="wagtailimages_index" %}
+    {% include "wagtailadmin/shared/header.html" with title=im_str add_link="wagtailimages:add_multiple" icon="image" add_text=add_img_str search_url="wagtailimages:index" %}
 
     <div class="nice-padding">
         <div id="image-results">

--- a/wagtail/wagtailimages/templates/wagtailimages/images/results.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/results.html
@@ -16,7 +16,7 @@
     <ul class="listing horiz images">
         {% for image in images %}
             <li>
-                <a class="image-choice" href="{% url 'wagtailimages_edit_image' image.id %}">
+                <a class="image-choice" href="{% url 'wagtailimages:edit_image' image.id %}">
                     <div class="image">{% image image max-165x165 class="show-transparency" %}</div>
                     <h3>{{ image.title|ellipsistrim:60 }}</h3>
                 </a>
@@ -24,13 +24,13 @@
         {% endfor %}
     </ul>
 
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=images is_searching=is_searching query_string=query_string linkurl="wagtailimages_index" %}
+    {% include "wagtailadmin/shared/pagination_nav.html" with items=images is_searching=is_searching query_string=query_string linkurl="wagtailimages:index" %}
 
 {% else %}
     {% if is_searching %}
         <p>{% blocktrans %}Sorry, no images match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
     {% else %}
-        {% url 'wagtailimages_add_multiple' as wagtailimages_add_image_url %}
+        {% url 'wagtailimages:add_multiple' as wagtailimages_add_image_url %}
         <p>{% blocktrans %}You've not uploaded any images. Why not <a href="{{ wagtailimages_add_image_url }}">add one now</a>?{% endblocktrans %}</p>
     {% endif %}
 {% endif %}

--- a/wagtail/wagtailimages/templates/wagtailimages/images/url_generator.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/url_generator.html
@@ -9,7 +9,7 @@
     {% trans "Generating URL" as title_str %}
     {% include "wagtailadmin/shared/header.html" with title=title_str subtitle=image.title icon="image" %}
 
-    <div class="image-url-generator nice-padding" data-generator-url="{% url 'wagtailimages_generate_url' image.id '__filterspec__' %}">
+    <div class="image-url-generator nice-padding" data-generator-url="{% url 'wagtailimages:generate_url' image.id '__filterspec__' %}">
         <form>
             <ul class="fields">
                 {% include "wagtailadmin/shared/field_as_li.html" with field=form.filter_method %}

--- a/wagtail/wagtailimages/templates/wagtailimages/multiple/add.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/multiple/add.html
@@ -18,10 +18,10 @@
             <p>{% trans "Drag and drop images into this area to upload immediately." %}</p>
             <p>{{ help_text }}
             
-            <form action="{% url 'wagtailimages_add_multiple' %}" method="POST" enctype="multipart/form-data">
+            <form action="{% url 'wagtailimages:add_multiple' %}" method="POST" enctype="multipart/form-data">
                 <div class="replace-file-input">
                     <button class="bicolor icon icon-plus">{% trans "Or choose from your computer" %}</button>
-                    <input id="fileupload" type="file" name="files[]" data-url="{% url 'wagtailimages_add_multiple' %}" multiple>
+                    <input id="fileupload" type="file" name="files[]" data-url="{% url 'wagtailimages:add_multiple' %}" multiple>
                 </div>
                 {% csrf_token %}
             </form>
@@ -72,7 +72,7 @@
     {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
     <script>
         window.fileupload_opts = {
-            simple_upload_url: "{% url 'wagtailimages_add_image' %}",
+            simple_upload_url: "{% url 'wagtailimages:add_image' %}",
             accepted_file_types: /\.({{ allowed_extensions|join:"|" }})$/i, //must be regex
             max_file_size: {{ max_filesize|stringformat:"s"|default:"null" }}, //numeric format
             errormessages: {

--- a/wagtail/wagtailimages/templates/wagtailimages/multiple/edit_form.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/multiple/edit_form.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<form action="{% url 'wagtailimages_edit_multiple' image.id %}" method="POST" enctype="multipart/form-data">
+<form action="{% url 'wagtailimages:edit_multiple' image.id %}" method="POST" enctype="multipart/form-data">
     <ul class="fields">
         {% csrf_token %}
         {% for field in form %}
@@ -12,7 +12,7 @@
         {% endfor %}
         <li>
             <input type="submit" value="{% trans 'Update' %}" />
-            <a href="{% url 'wagtailimages_delete_multiple' image.id %}" class="delete button button-secondary no">{% trans "Delete" %}</a>
+            <a href="{% url 'wagtailimages:delete_multiple' image.id %}" class="delete button button-secondary no">{% trans "Delete" %}</a>
         </li>
     </ul>
 </form>

--- a/wagtail/wagtailimages/templates/wagtailimages/widgets/image_chooser.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/widgets/image_chooser.html
@@ -13,4 +13,4 @@
     </div>
 {% endblock %}
 
-{% block edit_chosen_item_url %}{% if image %}{% url 'wagtailimages_edit_image' image.id %}{% endif %}{% endblock %}
+{% block edit_chosen_item_url %}{% if image %}{% url 'wagtailimages:edit_image' image.id %}{% endif %}{% endblock %}

--- a/wagtail/wagtailimages/tests/test_admin_views.py
+++ b/wagtail/wagtailimages/tests/test_admin_views.py
@@ -25,7 +25,7 @@ class TestImageIndexView(TestCase, WagtailTestUtils):
         self.login()
 
     def get(self, params={}):
-        return self.client.get(reverse('wagtailimages_index'), params)
+        return self.client.get(reverse('wagtailimages:index'), params)
 
     def test_simple(self):
         response = self.get()
@@ -55,10 +55,10 @@ class TestImageAddView(TestCase, WagtailTestUtils):
         self.login()
 
     def get(self, params={}):
-        return self.client.get(reverse('wagtailimages_add_image'), params)
+        return self.client.get(reverse('wagtailimages:add_image'), params)
 
     def post(self, post_data={}):
-        return self.client.post(reverse('wagtailimages_add_image'), post_data)
+        return self.client.post(reverse('wagtailimages:add_image'), post_data)
 
     def test_simple(self):
         response = self.get()
@@ -72,7 +72,7 @@ class TestImageAddView(TestCase, WagtailTestUtils):
         })
 
         # Should redirect back to index
-        self.assertRedirects(response, reverse('wagtailimages_index'))
+        self.assertRedirects(response, reverse('wagtailimages:index'))
 
         # Check that the image was created
         images = Image.objects.filter(title="Test image")
@@ -107,10 +107,10 @@ class TestImageEditView(TestCase, WagtailTestUtils):
         )
 
     def get(self, params={}):
-        return self.client.get(reverse('wagtailimages_edit_image', args=(self.image.id,)), params)
+        return self.client.get(reverse('wagtailimages:edit_image', args=(self.image.id,)), params)
 
     def post(self, post_data={}):
-        return self.client.post(reverse('wagtailimages_edit_image', args=(self.image.id,)), post_data)
+        return self.client.post(reverse('wagtailimages:edit_image', args=(self.image.id,)), post_data)
 
     def test_simple(self):
         response = self.get()
@@ -123,7 +123,7 @@ class TestImageEditView(TestCase, WagtailTestUtils):
         })
 
         # Should redirect back to index
-        self.assertRedirects(response, reverse('wagtailimages_index'))
+        self.assertRedirects(response, reverse('wagtailimages:index'))
 
         # Check that the image was edited
         image = Image.objects.get(id=self.image.id)
@@ -148,10 +148,10 @@ class TestImageDeleteView(TestCase, WagtailTestUtils):
         )
 
     def get(self, params={}):
-        return self.client.get(reverse('wagtailimages_delete_image', args=(self.image.id,)), params)
+        return self.client.get(reverse('wagtailimages:delete_image', args=(self.image.id,)), params)
 
     def post(self, post_data={}):
-        return self.client.post(reverse('wagtailimages_delete_image', args=(self.image.id,)), post_data)
+        return self.client.post(reverse('wagtailimages:delete_image', args=(self.image.id,)), post_data)
 
     def test_simple(self):
         response = self.get()
@@ -164,7 +164,7 @@ class TestImageDeleteView(TestCase, WagtailTestUtils):
         })
 
         # Should redirect back to index
-        self.assertRedirects(response, reverse('wagtailimages_index'))
+        self.assertRedirects(response, reverse('wagtailimages:index'))
 
         # Check that the image was deleted
         images = Image.objects.filter(title="Test image")
@@ -176,7 +176,7 @@ class TestImageChooserView(TestCase, WagtailTestUtils):
         self.login()
 
     def get(self, params={}):
-        return self.client.get(reverse('wagtailimages_chooser'), params)
+        return self.client.get(reverse('wagtailimages:chooser'), params)
 
     def test_simple(self):
         response = self.get()
@@ -207,7 +207,7 @@ class TestImageChooserChosenView(TestCase, WagtailTestUtils):
         )
 
     def get(self, params={}):
-        return self.client.get(reverse('wagtailimages_image_chosen', args=(self.image.id,)), params)
+        return self.client.get(reverse('wagtailimages:image_chosen', args=(self.image.id,)), params)
 
     def test_simple(self):
         response = self.get()
@@ -222,7 +222,7 @@ class TestImageChooserUploadView(TestCase, WagtailTestUtils):
         self.login()
 
     def get(self, params={}):
-        return self.client.get(reverse('wagtailimages_chooser_upload'), params)
+        return self.client.get(reverse('wagtailimages:chooser_upload'), params)
 
     def test_simple(self):
         response = self.get()
@@ -231,7 +231,7 @@ class TestImageChooserUploadView(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, 'wagtailimages/chooser/chooser.js')
 
     def test_upload(self):
-        response = self.client.post(reverse('wagtailimages_chooser_upload'), {
+        response = self.client.post(reverse('wagtailimages:chooser_upload'), {
             'title': "Test image",
             'file': SimpleUploadedFile('test.png', get_test_image_file().file.getvalue()),
         })
@@ -249,7 +249,7 @@ class TestImageChooserUploadView(TestCase, WagtailTestUtils):
         self.assertEqual(image.height, 480)
 
     def test_upload_no_file_selected(self):
-        response = self.client.post(reverse('wagtailimages_chooser_upload'), {
+        response = self.client.post(reverse('wagtailimages:chooser_upload'), {
             'title': "Test image",
         })
 
@@ -279,7 +279,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         This tests that the add view responds correctly on a GET request
         """
         # Send request
-        response = self.client.get(reverse('wagtailimages_add_multiple'))
+        response = self.client.get(reverse('wagtailimages:add_multiple'))
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -289,7 +289,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         """
         This tests that a POST request to the add view saves the image and returns an edit form
         """
-        response = self.client.post(reverse('wagtailimages_add_multiple'), {
+        response = self.client.post(reverse('wagtailimages:add_multiple'), {
             'files[]': SimpleUploadedFile('test.png', get_test_image_file().file.getvalue()),
         }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
 
@@ -318,7 +318,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         """
         This tests that only AJAX requests are allowed to POST to the add view
         """
-        response = self.client.post(reverse('wagtailimages_add_multiple'), {})
+        response = self.client.post(reverse('wagtailimages:add_multiple'), {})
 
         # Check response
         self.assertEqual(response.status_code, 400)
@@ -327,7 +327,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         """
         This tests that the add view checks for a file when a user POSTs to it
         """
-        response = self.client.post(reverse('wagtailimages_add_multiple'), {}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        response = self.client.post(reverse('wagtailimages:add_multiple'), {}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
 
         # Check response
         self.assertEqual(response.status_code, 400)
@@ -336,7 +336,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         """
         This tests that the add view checks for a file when a user POSTs to it
         """
-        response = self.client.post(reverse('wagtailimages_add_multiple'), {
+        response = self.client.post(reverse('wagtailimages:add_multiple'), {
             'files[]': SimpleUploadedFile('test.png', b"This is not an image!"),
         }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
 
@@ -358,7 +358,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         This tests that a GET request to the edit view returns a 405 "METHOD NOT ALLOWED" response
         """
         # Send request
-        response = self.client.get(reverse('wagtailimages_edit_multiple', args=(self.image.id, )))
+        response = self.client.get(reverse('wagtailimages:edit_multiple', args=(self.image.id, )))
 
         # Check response
         self.assertEqual(response.status_code, 405)
@@ -368,7 +368,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         This tests that a POST request to the edit view edits the image
         """
         # Send request
-        response = self.client.post(reverse('wagtailimages_edit_multiple', args=(self.image.id, )), {
+        response = self.client.post(reverse('wagtailimages:edit_multiple', args=(self.image.id, )), {
             ('image-%d-title' % self.image.id): "New title!",
             ('image-%d-tags' % self.image.id): "",
         }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
@@ -390,7 +390,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         This tests that a POST request to the edit view without AJAX returns a 400 response
         """
         # Send request
-        response = self.client.post(reverse('wagtailimages_edit_multiple', args=(self.image.id, )), {
+        response = self.client.post(reverse('wagtailimages:edit_multiple', args=(self.image.id, )), {
             ('image-%d-title' % self.image.id): "New title!",
             ('image-%d-tags' % self.image.id): "",
         })
@@ -404,7 +404,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         and a form with the validation error indicated
         """
         # Send request
-        response = self.client.post(reverse('wagtailimages_edit_multiple', args=(self.image.id, )), {
+        response = self.client.post(reverse('wagtailimages:edit_multiple', args=(self.image.id, )), {
             ('image-%d-title' % self.image.id): "", # Required
             ('image-%d-tags' % self.image.id): "",
         }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
@@ -430,7 +430,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         This tests that a GET request to the delete view returns a 405 "METHOD NOT ALLOWED" response
         """
         # Send request
-        response = self.client.get(reverse('wagtailimages_delete_multiple', args=(self.image.id, )))
+        response = self.client.get(reverse('wagtailimages:delete_multiple', args=(self.image.id, )))
 
         # Check response
         self.assertEqual(response.status_code, 405)
@@ -440,7 +440,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         This tests that a POST request to the delete view deletes the image
         """
         # Send request
-        response = self.client.post(reverse('wagtailimages_delete_multiple', args=(self.image.id, )), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        response = self.client.post(reverse('wagtailimages:delete_multiple', args=(self.image.id, )), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -461,7 +461,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         This tests that a POST request to the delete view without AJAX returns a 400 response
         """
         # Send request
-        response = self.client.post(reverse('wagtailimages_delete_multiple', args=(self.image.id, )))
+        response = self.client.post(reverse('wagtailimages:delete_multiple', args=(self.image.id, )))
 
         # Check response
         self.assertEqual(response.status_code, 400)
@@ -483,7 +483,7 @@ class TestURLGeneratorView(TestCase, WagtailTestUtils):
         This tests that the view responds correctly for a user with edit permissions on this image
         """
         # Get
-        response = self.client.get(reverse('wagtailimages_url_generator', args=(self.image.id, )))
+        response = self.client.get(reverse('wagtailimages:url_generator', args=(self.image.id, )))
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -501,7 +501,7 @@ class TestURLGeneratorView(TestCase, WagtailTestUtils):
         self.user.save()
 
         # Get
-        response = self.client.get(reverse('wagtailimages_url_generator', args=(self.image.id, )))
+        response = self.client.get(reverse('wagtailimages:url_generator', args=(self.image.id, )))
 
         # Check response
         self.assertEqual(response.status_code, 403)
@@ -523,7 +523,7 @@ class TestGenerateURLView(TestCase, WagtailTestUtils):
         This tests that the view responds correctly for a user with edit permissions on this image
         """
         # Get
-        response = self.client.get(reverse('wagtailimages_generate_url', args=(self.image.id, 'fill-800x600')))
+        response = self.client.get(reverse('wagtailimages:generate_url', args=(self.image.id, 'fill-800x600')))
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -540,7 +540,7 @@ class TestGenerateURLView(TestCase, WagtailTestUtils):
         }
         self.assertEqual(content_json['url'], expected_url)
 
-        expected_preview_url = reverse('wagtailimages_preview', args=(self.image.id, 'fill-800x600'))
+        expected_preview_url = reverse('wagtailimages:preview', args=(self.image.id, 'fill-800x600'))
         self.assertEqual(content_json['preview_url'], expected_preview_url)
 
     def test_get_bad_permissions(self):
@@ -555,7 +555,7 @@ class TestGenerateURLView(TestCase, WagtailTestUtils):
         self.user.save()
 
         # Get
-        response = self.client.get(reverse('wagtailimages_generate_url', args=(self.image.id, 'fill-800x600')))
+        response = self.client.get(reverse('wagtailimages:generate_url', args=(self.image.id, 'fill-800x600')))
 
         # Check response
         self.assertEqual(response.status_code, 403)
@@ -571,7 +571,7 @@ class TestGenerateURLView(TestCase, WagtailTestUtils):
         This tests that the view gives a 404 response if a user attempts to use it with an image which doesn't exist
         """
         # Get
-        response = self.client.get(reverse('wagtailimages_generate_url', args=(self.image.id + 1, 'fill-800x600')))
+        response = self.client.get(reverse('wagtailimages:generate_url', args=(self.image.id + 1, 'fill-800x600')))
 
         # Check response
         self.assertEqual(response.status_code, 404)
@@ -587,7 +587,7 @@ class TestGenerateURLView(TestCase, WagtailTestUtils):
         This tests that the view gives a 400 response if the user attempts to use it with an invalid filter spec
         """
         # Get
-        response = self.client.get(reverse('wagtailimages_generate_url', args=(self.image.id, 'bad-filter-spec')))
+        response = self.client.get(reverse('wagtailimages:generate_url', args=(self.image.id, 'bad-filter-spec')))
 
         # Check response
         self.assertEqual(response.status_code, 400)
@@ -615,7 +615,7 @@ class TestPreviewView(TestCase, WagtailTestUtils):
         Test a valid GET request to the view
         """
         # Get the image
-        response = self.client.get(reverse('wagtailimages_preview', args=(self.image.id, 'fill-800x600')))
+        response = self.client.get(reverse('wagtailimages:preview', args=(self.image.id, 'fill-800x600')))
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -631,7 +631,7 @@ class TestPreviewView(TestCase, WagtailTestUtils):
         anyway though.
         """
         # Get the image
-        response = self.client.get(reverse('wagtailimages_preview', args=(self.image.id, 'bad-filter-spec')))
+        response = self.client.get(reverse('wagtailimages:preview', args=(self.image.id, 'bad-filter-spec')))
 
         # Check response
         self.assertEqual(response.status_code, 400)

--- a/wagtail/wagtailimages/tests/test_models.py
+++ b/wagtail/wagtailimages/tests/test_models.py
@@ -307,10 +307,10 @@ class TestIssue613(TestCase, WagtailTestUtils):
             'file': SimpleUploadedFile('test.png', get_test_image_file().file.getvalue()),
         }
         post_data.update(params)
-        response = self.client.post(reverse('wagtailimages_add_image'), post_data)
+        response = self.client.post(reverse('wagtailimages:add_image'), post_data)
 
         # Should redirect back to index
-        self.assertRedirects(response, reverse('wagtailimages_index'))
+        self.assertRedirects(response, reverse('wagtailimages:index'))
 
         # Check that the image was created
         images = Image.objects.filter(title="Test image")
@@ -335,10 +335,10 @@ class TestIssue613(TestCase, WagtailTestUtils):
             'title': "Edited",
         }
         post_data.update(params)
-        response = self.client.post(reverse('wagtailimages_edit_image', args=(self.image.id,)), post_data)
+        response = self.client.post(reverse('wagtailimages:edit_image', args=(self.image.id,)), post_data)
 
         # Should redirect back to index
-        self.assertRedirects(response, reverse('wagtailimages_index'))
+        self.assertRedirects(response, reverse('wagtailimages:index'))
 
         # Check that the image was edited
         image = Image.objects.get(id=self.image.id)

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -24,7 +24,7 @@ def get_image_json(image):
 
     return json.dumps({
         'id': image.id,
-        'edit_link': reverse('wagtailimages_edit_image', args=(image.id,)),
+        'edit_link': reverse('wagtailimages:edit_image', args=(image.id,)),
         'title': image.title,
         'preview': {
             'url': preview_image.url,
@@ -167,7 +167,7 @@ def chooser_select_format(request, image_id):
                 'format': format.name,
                 'alt': form.cleaned_data['alt_text'],
                 'class': format.classnames,
-                'edit_link': reverse('wagtailimages_edit_image', args=(image.id,)),
+                'edit_link': reverse('wagtailimages:edit_image', args=(image.id,)),
                 'preview': {
                     'url': preview_image.url,
                     'width': preview_image.width,

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -104,9 +104,9 @@ def edit(request, image_id):
                 backend.add(image)
 
             messages.success(request, _("Image '{0}' updated.").format(image.title), buttons=[
-                messages.button(reverse('wagtailimages_edit_image', args=(image.id,)), _('Edit again'))
+                messages.button(reverse('wagtailimages:edit_image', args=(image.id,)), _('Edit again'))
             ])
-            return redirect('wagtailimages_index')
+            return redirect('wagtailimages:index')
         else:
             messages.error(request, _("The image could not be saved due to errors."))
     else:
@@ -126,7 +126,7 @@ def edit(request, image_id):
         # File doesn't exist
         filesize = None
         messages.error(request, _("The source image file could not be found. Please change the source or delete the image.").format(image.title), buttons=[
-            messages.button(reverse('wagtailimages_delete_image', args=(image.id,)), _('Delete'))
+            messages.button(reverse('wagtailimages:delete_image', args=(image.id,)), _('Delete'))
         ])
 
     return render(request, "wagtailimages/images/edit.html", {
@@ -194,7 +194,7 @@ def generate_url(request, image_id, filter_spec):
         site_root_url = Site.objects.first().root_url
 
     # Generate preview url
-    preview_url = reverse('wagtailimages_preview', args=(image_id, filter_spec))
+    preview_url = reverse('wagtailimages:preview', args=(image_id, filter_spec))
 
     return json_response({'url': site_root_url + url, 'preview_url': preview_url}, status=200)
 
@@ -219,7 +219,7 @@ def delete(request, image_id):
     if request.POST:
         image.delete()
         messages.success(request, _("Image '{0}' deleted.").format(image.title))
-        return redirect('wagtailimages_index')
+        return redirect('wagtailimages:index')
 
     return render(request, "wagtailimages/images/confirm_delete.html", {
         'image': image,
@@ -242,9 +242,9 @@ def add(request):
                 backend.add(image)
 
             messages.success(request, _("Image '{0}' added.").format(image.title), buttons=[
-                messages.button(reverse('wagtailimages_edit_image', args=(image.id,)), _('Edit'))
+                messages.button(reverse('wagtailimages:edit_image', args=(image.id,)), _('Edit'))
             ])
-            return redirect('wagtailimages_index')
+            return redirect('wagtailimages:index')
         else:
             messages.error(request, _("The image could not be created due to errors."))
     else:

--- a/wagtail/wagtailimages/wagtail_hooks.py
+++ b/wagtail/wagtailimages/wagtail_hooks.py
@@ -19,7 +19,7 @@ from wagtail.wagtailimages.rich_text import ImageEmbedHandler
 @hooks.register('register_admin_urls')
 def register_admin_urls():
     return [
-        url(r'^images/', include(admin_urls)),
+        url(r'^images/', include(admin_urls, namespace='wagtailimages', app_name='wagtailimages')),
     ]
 
 
@@ -41,7 +41,7 @@ def check_old_style_urlconf():
 
     # A faulty urls.py will place wagtail.wagtailimages.urls at the same path that
     # wagtail.wagtailimages.admin_urls is loaded to, resulting in the wagtailimages_serve path
-    # being equal to wagtailimages_index followed by three arbitrary args
+    # being equal to wagtailimages:index followed by three arbitrary args
     try:
         wagtailimages_serve_path = urlresolvers.reverse('wagtailimages_serve', args=['123', '456', '789'])
     except urlresolvers.NoReverseMatch:
@@ -49,7 +49,7 @@ def check_old_style_urlconf():
         OLD_STYLE_URLCONF_CHECK_PASSED = True
         return
 
-    wagtailimages_index_path = urlresolvers.reverse('wagtailimages_index')
+    wagtailimages_index_path = urlresolvers.reverse('wagtailimages:index')
     if wagtailimages_serve_path == wagtailimages_index_path + '123/456/789/':
         raise ImproperlyConfigured("""Your urls.py contains an entry for %s that needs to be removed.
             See http://wagtail.readthedocs.org/en/latest/releases/0.5.html#urlconf-entries-for-admin-images-admin-embeds-etc-need-to-be-removed"""
@@ -71,7 +71,7 @@ class ImagesMenuItem(MenuItem):
 
 @hooks.register('register_admin_menu_item')
 def register_images_menu_item():
-    return ImagesMenuItem(_('Images'), urlresolvers.reverse('wagtailimages_index'), name='images', classnames='icon icon-image', order=300)
+    return ImagesMenuItem(_('Images'), urlresolvers.reverse('wagtailimages:index'), name='images', classnames='icon icon-image', order=300)
 
 
 @hooks.register('insert_editor_js')
@@ -90,7 +90,7 @@ def editor_js():
             registerHalloPlugin('hallowagtailimage');
         </script>
         """,
-        urlresolvers.reverse('wagtailimages_chooser')
+        urlresolvers.reverse('wagtailimages:chooser')
     )
 
 


### PR DESCRIPTION
This allows the urls to be registered multiple times with different app labels

I've basically gone through and replaced all occurances of ``wagtailimages_`` with ``wagtailimages:`` for all admin urls.

See: https://docs.djangoproject.com/en/1.8/topics/http/urls/#reversing-namespaced-urls