### PR TITLE
try to use current site for relative_urls

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -594,7 +594,7 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         Return None if the page is not routable.
         """
         if self.url_path.startswith(current_site.root_page.url_path):
-            return reverse('wagtail_serve', args=(self.url_path[len(root_path):],))
+            return reverse('wagtail_serve', args=(self.url_path[len(current_site.root_page.url_path):],))
         
         for (id, root_path, root_url) in Site.get_site_root_paths():
             if self.url_path.startswith(root_path):

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -593,6 +593,9 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         a local URL if the site matches, or a fully qualified one otherwise.
         Return None if the page is not routable.
         """
+        if self.url_path.startswith(current_site.root_page.url_path):
+            return reverse('wagtail_serve', args=(self.url_path[len(root_path):],))
+        
         for (id, root_path, root_url) in Site.get_site_root_paths():
             if self.url_path.startswith(root_path):
                 return ('' if current_site.id == id else root_url) + reverse('wagtail_serve', args=(self.url_path[len(root_path):],))


### PR DESCRIPTION
If current site and another both have the same root path, we should prefer to create a relative link to current site