### PR TITLE
Preventing thousands seperators when printing max filesize in JS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /venv
 /node_modules/
 npm-debug.log
+/.idea

--- a/wagtail/wagtailimages/templates/wagtailimages/multiple/add.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/multiple/add.html
@@ -74,7 +74,7 @@
         window.fileupload_opts = {
             simple_upload_url: "{% url 'wagtailimages_add_image' %}",
             accepted_file_types: /\.({{ allowed_extensions|join:"|" }})$/i, //must be regex
-            max_file_size: {{ max_filesize|default:"null" }}, //numeric format
+            max_file_size: {{ max_filesize|stringformat:"s"|default:"null" }}, //numeric format
             errormessages: {
                 max_file_size: "{{ error_max_file_size }}",
                 accepted_file_types: "{{ error_accepted_file_types }}"


### PR DESCRIPTION
When using l10n with thousands seperators and large file sizes, the `max_filesize` JS property in `templates/wagtailimages/multiple/add.html` can end up as `max_file_size: 10.485.760`. That isn't valid JS and breaks the upload form.