### PR TITLE
Show ResourceWarnings when running tests

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -17,6 +17,10 @@ def runtests():
     warnings.simplefilter('default', DeprecationWarning)
     warnings.simplefilter('default', PendingDeprecationWarning)
 
+    # Don't ignore ResourceWarnings (Python 3 only)
+    if sys.version_info >= (3, 0):
+        warnings.simplefilter('default', ResourceWarning)
+
     argv = sys.argv[:1] + ['test'] + sys.argv[1:]
     try:
         execute_from_command_line(argv)


### PR DESCRIPTION
This warning is raised when a file is opened inside a test, but not closed. This can help spot bugs in Wagtail.

ResourceWarning was added in Python 3.2 and isn't available in Python 2