### PR TITLE
Add fetch-translations.sh

### DIFF
--- a/scripts/fetch-translations.sh
+++ b/scripts/fetch-translations.sh
@@ -1,0 +1,20 @@
+# Delete old translation files (except "en" which is the source translation)
+find ../wagtail -iname *.po ! -iwholename */en/* -delete
+
+# Fetch new translations from transifex
+tx pull -a --minimum-perc=30
+
+# Clean the PO files using msgattrib
+# This removes the following:
+#  - Blank, fuzzy and obsolete translations
+#  - The line numbers above each translation
+# These things are only needed by translators (which they won't be seen by) and make the translation updates difficult to check
+find ../wagtail -iname *.po ! -iwholename */en/* -exec msgattrib --translated --no-fuzzy --no-obsolete --no-location -o {} {} \;
+
+# Run makemessages on each app
+for d in $(find ../wagtail -iname *.po | sed 's|\(.*\)/locale.*|\1|' | sort -u);
+do
+    pushd $d
+    django-admin compilemessages
+    popd
+done


### PR DESCRIPTION
This script fetches the latest translations from transifex, cleans the files and runs compilemessages on each app

This should make pulling translations quicker. It also cleans the PO files (removes line numbers for example) which should make translation update commits much easier to review. This cleanup isn't done to the "en" files though.

See https://github.com/torchbox/wagtail/pull/1296 for an example of how the PO files will look

Usage (make sure transifex-client is set up first):
```
cd scripts
./fetch-translations.sh
# Wait about 1 minute for the command to finish
# Create a git commit and push
# Done!
```