### PR TITLE
Fix image filenames

### DIFF
--- a/wagtail/wagtailadmin/static/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static/wagtailadmin/js/core.js
@@ -8,15 +8,17 @@ function addMessage(status, text) {
 }
 
 function escapeHtml(text) {
-  var map = {
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#039;'
-  };
+    var map = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#039;'
+    };
 
-  return text.replace(/[&<>"']/g, function(m) { return map[m]; });
+    return text.replace(/[&<>"']/g, function(m) {
+        return map[m];
+    });
 }
 
 $(function() {

--- a/wagtail/wagtailadmin/static/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static/wagtailadmin/js/core.js
@@ -7,6 +7,18 @@ function addMessage(status, text) {
     }, 100);
 }
 
+function escapeHtml(text) {
+  var map = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;'
+  };
+
+  return text.replace(/[&<>"']/g, function(m) { return map[m]; });
+}
+
 $(function() {
     // Add class to the body from which transitions may be hung so they don't appear to transition as the page loads
     $('body').addClass('ready');

--- a/wagtail/wagtailadmin/static/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static/wagtailadmin/js/core.js
@@ -13,7 +13,7 @@ function escapeHtml(text) {
         '<': '&lt;',
         '>': '&gt;',
         '"': '&quot;',
-        "'": '&#039;'
+        '\'': '&#039;'
     };
 
     return text.replace(/[&<>"']/g, function(m) {

--- a/wagtail/wagtailimages/static/wagtailimages/js/add-multiple.js
+++ b/wagtail/wagtailimages/static/wagtailimages/js/add-multiple.js
@@ -38,7 +38,7 @@ $(function() {
             }).always(function() {
                 data.context.removeClass('processing');
                 data.context.find('.left').each(function(index, elm) {
-                    $(elm).append(data.files[index].name);
+                    $(elm).append(escapeHtml(data.files[index].name));
                 });
 
                 data.context.find('.preview .thumb').each(function(index, elm) {


### PR DESCRIPTION
This fixes #1293. Potentially quite a serious issue and I appreciate that it probably warrants more than a pull request from a new kid but I thought I'd give it a go.

It might be worth taking this much further and denying any similar filename from entering the system at all, but even if you do that, it seems that escaping this input is a good idea anyway. Once the name hits Django it gets escaped via the templates without issue, so only this initial case appears to be affected.

I added an escapeHtml function to core as jQuery's .html() is rather cumbersome to use here and doesn't deal with quotes (Here's a 3 year old ticket about it: http://bugs.jquery.com/ticket/11773).

I couldn't spot any related tests - please point me in the right direction if I've missed them.