### PR TITLE
Allow non-html template files

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -244,7 +244,11 @@ class PageBase(models.base.ModelBase):
 
         if 'template' not in dct:
             # Define a default template path derived from the app name and model name
-            cls.template = "%s/%s.html" % (cls._meta.app_label, camelcase_to_underscore(name))
+            if hasattr(cls, 'template_extension'):
+                ext = cls.template_extension
+            else:
+                ext = "html"
+            cls.template = "%s/%s.%s" % (cls._meta.app_label, camelcase_to_underscore(name), ext)
 
         if 'ajax_template' not in dct:
             cls.ajax_template = None


### PR DESCRIPTION
Useful when using other template engines.

We're using it like this:
```
class SomePageType(Page):
    body = RichTextField()
    ...

    template_extension = "jade"
```