### PR TITLE
Missing + in docs.

### DIFF
--- a/docs/reference/pages/creating_pages.rst
+++ b/docs/reference/pages/creating_pages.rst
@@ -40,7 +40,7 @@ This example represents a typical blog post:
             related_name='+'
         )
 
-        content_panels = Page.content_panels [
+        content_panels = Page.content_panels + [
             FieldPanel('date'),
             FieldPanel('body', classname="full"),
         ]


### PR DESCRIPTION
Restore a missing `+`.