### PR TITLE
Make StreamField lazily prepare its contents

### DIFF
--- a/wagtail/tests/testapp/migrations/0003_streammodel.py
+++ b/wagtail/tests/testapp/migrations/0003_streammodel.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import wagtail.wagtailcore.fields
+import wagtail.wagtailcore.blocks
+import wagtail.wagtailimages.blocks
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tests', '0002_add_verbose_names'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='StreamModel',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('body', wagtail.wagtailcore.fields.StreamField([('text', wagtail.wagtailcore.blocks.CharBlock()), ('image', wagtail.wagtailimages.blocks.ImageChooserBlock())])),
+            ],
+        ),
+    ]

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -10,7 +10,8 @@ from modelcluster.fields import ParentalKey
 from modelcluster.tags import ClusterTaggableManager
 
 from wagtail.wagtailcore.models import Page, Orderable
-from wagtail.wagtailcore.fields import RichTextField
+from wagtail.wagtailcore.fields import RichTextField, StreamField
+from wagtail.wagtailcore.blocks import CharBlock
 from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel, InlinePanel, PageChooserPanel, TabbedInterface, ObjectList
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 from wagtail.wagtaildocs.edit_handlers import DocumentChooserPanel
@@ -19,6 +20,7 @@ from wagtail.wagtailforms.models import AbstractEmailForm, AbstractFormField
 from wagtail.wagtailsnippets.edit_handlers import SnippetChooserPanel
 from wagtail.wagtailsearch import index
 from wagtail.wagtailimages.models import AbstractImage, Image
+from wagtail.wagtailimages.blocks import ImageChooserBlock
 
 
 EVENT_AUDIENCE_CHOICES = (
@@ -400,3 +402,10 @@ class CustomImageWithAdminFormFields(AbstractImage):
     admin_form_fields = Image.admin_form_fields + (
         'caption',
     )
+
+
+class StreamModel(models.Model):
+    body = StreamField([
+        ('text', CharBlock()),
+        ('image', ImageChooserBlock()),
+    ])

--- a/wagtail/wagtailcore/tests/test_streamfield.py
+++ b/wagtail/wagtailcore/tests/test_streamfield.py
@@ -1,0 +1,69 @@
+import json
+
+from django.test import TestCase
+
+from wagtail.tests.testapp.models import StreamModel
+from wagtail.wagtailimages.models import Image
+from wagtail.wagtailimages.tests.utils import get_test_image_file
+
+
+class TestLazyStreamField(TestCase):
+    def setUp(self):
+        self.image = Image.objects.create(
+            title='Test image',
+            file=get_test_image_file())
+        self.with_image = StreamModel.objects.create(body=json.dumps([
+            {'type': 'image', 'value': self.image.pk},
+            {'type': 'text', 'value': 'foo'}]))
+        self.no_image = StreamModel.objects.create(body=json.dumps([
+            {'type': 'text', 'value': 'foo'}]))
+
+    def test_lazy_load(self):
+        """
+        Getting a single item should lazily load the StreamField, only
+        accessing the database once the StreamField is accessed
+        """
+        with self.assertNumQueries(1):
+            # Get the instance. The StreamField should *not* load the image yet
+            instance = StreamModel.objects.get(pk=self.with_image.pk)
+
+        with self.assertNumQueries(1):
+            # Access the body. The StreamField should now get the image.
+            body = instance.body
+
+        with self.assertNumQueries(0):
+            # Everything has been fetched now, no further database queries.
+            self.assertEqual(body[0].value, self.image)
+            self.assertEqual(body[1].value, 'foo')
+
+    def test_lazy_load_no_images(self):
+        """
+        Getting a single item whose StreamField never accesses the database
+        should behave as expected.
+        """
+        with self.assertNumQueries(1):
+            # Get the instance, nothing else
+            instance = StreamModel.objects.get(pk=self.no_image.pk)
+
+        with self.assertNumQueries(0):
+            # Access the body. The StreamField has no images, so nothing should
+            # happen
+            body = instance.body
+            self.assertEqual(body[0].value, 'foo')
+
+    def test_lazy_load_queryset(self):
+        """
+        Ensure that lazy loading StreamField works when gotten as part of a
+        queryset list
+        """
+        with self.assertNumQueries(1):
+            instances = StreamModel.objects.filter(
+                pk__in=[self.with_image.pk, self.no_image.pk])
+            instances_lookup = {instance.pk: instance for instance in instances}
+
+
+        with self.assertNumQueries(1):
+            instances_lookup[self.with_image.pk].body
+
+        with self.assertNumQueries(0):
+            instances_lookup[self.no_image.pk].body


### PR DESCRIPTION
StreamFields should not go and grab related objects from the database as soon as they are loaded, as the StreamField may not be used. For example, getting a list of Page titles for a menu does not require the StreamField content. For example, <http://digitalready.tas.gov.au/resources/> will load the all the images in all the StreamFields for every linked resource on that page, even though the StreamField is never used.

This commit adapts some code from django-json-field, which itself apapts some code from Django.

There is a bit of nasty code to get `StreamField.contribute_to_class` working properly. I would fix it in the correct manner by making a new Metaclass for StreamField to unoverride the `contribute_to_class` override done by the `SubfieldBase` Metaclass, but it is 11:30 at night on a Friday. Ignoring that bit of code, what are your thoughts?

Fixes #1200