### PR TITLE
Tidy up render_modal_workflow

### DIFF
--- a/wagtail/wagtailadmin/modal_workflow.py
+++ b/wagtail/wagtailadmin/modal_workflow.py
@@ -6,20 +6,18 @@ from wagtail.utils.compat import render_to_string
 
 
 def render_modal_workflow(request, html_template, js_template, template_vars=None):
-    """"
+    """
     Render a response consisting of an HTML chunk and a JS onload chunk
     in the format required by the modal-workflow framework.
     """
-    response_keyvars = []
+    response_keyvars = {}
 
     if html_template:
         html = render_to_string(html_template, template_vars or {}, request=request)
-        response_keyvars.append("'html': %s" % json.dumps(html))
+        response_keyvars['html'] = html
 
     if js_template:
         js = render_to_string(js_template, template_vars or {}, request=request)
-        response_keyvars.append("'onload': %s" % js)
+        response_keyvars['onload'] = js
 
-    response_text = "{%s}" % ','.join(response_keyvars)
-
-    return HttpResponse(response_text, content_type="text/javascript")
+    return HttpResponse(json.dumps(response_keyvars), content_type="application/json")

--- a/wagtail/wagtailadmin/tests/test_page_chooser.py
+++ b/wagtail/wagtailadmin/tests/test_page_chooser.py
@@ -103,20 +103,20 @@ class TestChooserExternalLink(TestCase, WagtailTestUtils):
     def test_create_link(self):
         response = self.post({'url': 'http://www.example.com/'})
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "'onload'")  # indicates success / post back to calling page
+        self.assertContains(response, '"onload"')  # indicates success / post back to calling page
         self.assertContains(response, "'url': 'http://www.example.com/',")
         self.assertContains(response, "'title': 'http://www.example.com/'")
 
     def test_invalid_url(self):
         response = self.post({'url': 'ntp://www.example.com'})
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "'html'")  # indicates failure / show error message
+        self.assertContains(response, '"html"')  # indicates failure / show error message
         self.assertContains(response, "Enter a valid URL.")
 
     def test_allow_local_url(self):
         response = self.post({'url': '/admin/'})
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "'onload'")  # indicates success / post back to calling page
+        self.assertContains(response, '"onload"')  # indicates success / post back to calling page
         self.assertContains(response, "'url': '/admin/',")
         self.assertContains(response, "'title': '/admin/'")
 


### PR DESCRIPTION
Also, now returns valid JSON with correct content type header