### PR TITLE
Add AUTO_UPDATE option to backend parameters

### DIFF
--- a/docs/topics/search/backends.rst
+++ b/docs/topics/search/backends.rst
@@ -7,13 +7,45 @@ Backends
 
 Wagtailsearch has support for multiple backends giving you the choice between using the database for search or an external service such as Elasticsearch.
 
-You can configure which backend to use with the ``WAGTAILSEARCH_BACKENDS`` setting.
+You can configure which backend to use with the ``WAGTAILSEARCH_BACKENDS`` setting:
 
+.. code-block:: python
+
+  WAGTAILSEARCH_BACKENDS = {
+      'default': {
+          'BACKEND': 'wagtail.wagtailsearch.backends.db.DBSearch',
+      }
+  }
+
+
+``AUTO_UPDATE``
+===============
+
+By default, Wagtail will automatically keep all indexes up to date. This could impact performance when editing content, especially if your index is hosted on an external service.
+
+The ``AUTO_UPDATE`` setting allows you to disable this on a per-index basis:
+
+.. code-block:: python
+
+  WAGTAILSEARCH_BACKENDS = {
+      'default': {
+          'BACKEND': ...,
+          'AUTO_UPDATE': False,
+      }
+  }
+
+If you have disabled auto update, you must run the :ref:`update_index` command on a regular basis to keep the index in sync with the database.
+
+
+``BACKEND``
+===========
+
+Here's a list of backends that Wagtail supports out of the box.
 
 .. _wagtailsearch_backends_database:
 
 Database Backend (default)
-==========================
+--------------------------
 
 ``wagtail.wagtailsearch.backends.db.DBSearch``
 
@@ -29,7 +61,7 @@ If any of these features are important to you, we recommend using Elasticsearch 
 
 
 Elasticsearch Backend
-=====================
+---------------------
 
 ``wagtail.wagtailsearch.backends.elasticsearch.ElasticSearch``
 
@@ -71,6 +103,6 @@ If you prefer not to run an Elasticsearch server in development or production, t
 
 
 Rolling Your Own
-================
+----------------
 
 Wagtail search backends implement the interface defined in ``wagtail/wagtail/wagtailsearch/backends/base.py``. At a minimum, the backend's ``search()`` method must return a collection of objects or ``model.objects.none()``. For a fully-featured search backend, examine the Elasticsearch backend code in ``elasticsearch.py``.

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -150,6 +150,7 @@ try:
         'BACKEND': 'wagtail.wagtailsearch.backends.elasticsearch.ElasticSearch',
         'TIMEOUT': 10,
         'max_retries': 1,
+        'AUTO_UPDATE': False,
     }
 
     if 'ELASTICSEARCH_URL' in os.environ:

--- a/wagtail/wagtailsearch/backends/__init__.py
+++ b/wagtail/wagtailsearch/backends/__init__.py
@@ -51,9 +51,12 @@ def get_search_backend(backend='default', **kwargs):
     return backend_cls(params)
 
 
-def get_search_backends():
+def get_search_backends(with_auto_update=False):
     if hasattr(settings, 'WAGTAILSEARCH_BACKENDS'):
-        for backend in settings.WAGTAILSEARCH_BACKENDS.keys():
+        for backend, params in settings.WAGTAILSEARCH_BACKENDS.items():
+            if with_auto_update and params.get('AUTO_UPDATE', True) is False:
+                continue
+
             yield get_search_backend(backend)
     else:
         yield get_search_backend('default')

--- a/wagtail/wagtailsearch/signal_handlers.py
+++ b/wagtail/wagtailsearch/signal_handlers.py
@@ -20,7 +20,7 @@ def post_save_signal_handler(instance, **kwargs):
     indexed_instance = get_indexed_instance(instance)
 
     if indexed_instance:
-        for backend in get_search_backends():
+        for backend in get_search_backends(with_auto_update=True):
             backend.add(indexed_instance)
 
 
@@ -28,7 +28,7 @@ def post_delete_signal_handler(instance, **kwargs):
     indexed_instance = get_indexed_instance(instance)
 
     if indexed_instance:
-        for backend in get_search_backends():
+        for backend in get_search_backends(with_auto_update=True):
             backend.delete(indexed_instance)
 
 


### PR DESCRIPTION
By default, Wagtail will keep all search indexes up to date using signal handlers.

This is sometimes not needed/wanted. This PR allows auto-update to be configured on a per-index basis.