### PR TITLE
Make Block value type handling more consistent

### DIFF
--- a/wagtail/wagtailcore/blocks/base.py
+++ b/wagtail/wagtailcore/blocks/base.py
@@ -152,13 +152,23 @@ class Block(six.with_metaclass(BaseBlock, object)):
         """
         return BoundBlock(self, value, prefix=prefix, errors=errors)
 
+    def get_default(self):
+        """
+        Return this block's default value (conventionally found in self.meta.default),
+        converted to the value type expected by this block. This caters for the case
+        where that value type is not something that can be expressed statically at
+        model definition type (e.g. something like StructValue which incorporates a
+        pointer back to the block definion object).
+        """
+        return self.meta.default
+
     def prototype_block(self):
         """
         Return a BoundBlock that can be used as a basis for new empty block instances to be added on the fly
         (new list items, for example). This will have a prefix of '__PREFIX__' (to be dynamically replaced with
         a real prefix when it's inserted into the page) and a value equal to the block's default value.
         """
-        return self.bind(self.meta.default, '__PREFIX__')
+        return self.bind(self.get_default(), '__PREFIX__')
 
     def clean(self, value):
         """

--- a/wagtail/wagtailcore/blocks/list_block.py
+++ b/wagtail/wagtailcore/blocks/list_block.py
@@ -28,7 +28,7 @@ class ListBlock(Block):
 
         if not hasattr(self.meta, 'default'):
             # Default to a list consisting of one empty (i.e. default-valued) child item
-            self.meta.default = [self.child_block.meta.default]
+            self.meta.default = [self.child_block.get_default()]
 
         self.dependencies = [self.child_block]
         self.child_js_initializer = self.child_block.js_initializer()
@@ -54,7 +54,7 @@ class ListBlock(Block):
         # this is the output of render_list_member as rendered with the prefix '__PREFIX__'
         # (to be replaced dynamically when adding the new item) and the child block's default value
         # as its value.
-        list_member_html = self.render_list_member(self.child_block.meta.default, '__PREFIX__', '')
+        list_member_html = self.render_list_member(self.child_block.get_default(), '__PREFIX__', '')
 
         return format_html(
             '<script type="text/template" id="{0}-newmember">{1}</script>',


### PR DESCRIPTION
In advance of the proposed StreamField refactor https://groups.google.com/d/msg/wagtail-developers/3HZ5WcXhovQ/kYnD-U2qIXIJ to make greater use of 'smart' block values that know their own rendering, we need to tighten up our type conversion code within the Blocks module so that we always know we're dealing with the right type of value.

This PR cleans things up and adds some extra tests, to ensure that:

* to_python and get_prep_value are now only used for serialisation / deserialisation between the block's native value and its JSON-ish representation. Previously, we were calling to_python on block default values, and the return values of form fields in FieldBlock.

* default values (as passed to a block's constructor or 'meta' class) are now passed through a 'get_default()' method to ensure they're converted to the block's native type, if necessary. This means we don't have to fudge things for StructBlock and StreamBlock, which have 'smart' value types that can't be passed as a 'default' parameter - it also means that StreamBlock now has a proper concept of default values, which it didn't before.

* FieldBlock now provides a pair of conversion functions, 'value_for_form' and 'value_from_form', so that the block can present a value to the underlying form field that doesn't necessarily match the block's own native value type. This fixes some issues with chooser blocks, where we'd like to work consistently with model instances, but the underlying ModelChoiceField works with a mixture of IDs and model instances. It's also required for the new implementation of EmbedBlock, where the native value of the block is a 'smart' value that knows its own HTML rendering, but the form field should see it as a plain string input.