### PR TITLE
Removed sendfile dependency

### DIFF
--- a/docs/reference/contrib/staticsitegen.rst
+++ b/docs/reference/contrib/staticsitegen.rst
@@ -10,11 +10,11 @@ This document describes how to render your Wagtail site into static HTML files o
 Installing ``django-medusa``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-First, install ``django-medusa`` from pip:
+First, install ``django-medusa`` and ``django-sendfile`` from pip:
 
 .. code::
 
-    pip install django-medusa
+    pip install django-medusa django-sendfile
 
 Then add ``django_medusa`` and ``wagtail.contrib.wagtailmedusa`` to ``INSTALLED_APPS``:
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ install_requires = [
     "django-modelcluster>=0.6",
     "django-taggit>=0.13.0",
     "django-treebeard==3.0",
-    "django-sendfile==0.3.7",
     "Pillow>=2.6.1",
     "beautifulsoup4>=4.3.2",
     "html5lib==0.999",


### PR DESCRIPTION
Not actually needed unless you're setting a ``SENDFILE_BACKEND`` and in that case, you'll know you need it.

This doesn't remove any functionality from wagtail. Just makes it so ``django-sendfile`` only gets installed by those who want it.