### PR TITLE
Make RawHTMLBlock consistently use SafeText as its native value

### DIFF
--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import datetime
+import six
 
 from django import forms
 from django.db.models.fields import BLANK_CHOICE_DASH
@@ -270,11 +271,11 @@ class RawHTMLBlock(FieldBlock):
     def get_prep_value(self, value):
         # explicitly convert to a plain string, just in case we're using some serialisation method
         # that doesn't cope with SafeText values correctly
-        return str(value)
+        return six.text_type(value)
 
     def value_for_form(self, value):
         # need to explicitly mark as unsafe, or it'll output unescaped HTML in the textarea
-        return str(value)
+        return six.text_type(value)
 
     def value_from_form(self, value):
         return mark_safe(value)

--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -261,8 +261,23 @@ class RawHTMLBlock(FieldBlock):
             widget=forms.Textarea)
         super(RawHTMLBlock, self).__init__(**kwargs)
 
-    def render_basic(self, value):
-        return mark_safe(value)  # if it isn't safe, that's the site admin's problem for allowing raw HTML blocks in the first place...
+    def get_default(self):
+        return mark_safe(self.meta.default or '')
+
+    def to_python(self, value):
+        return mark_safe(value)
+
+    def get_prep_value(self, value):
+        # explicitly convert to a plain string, just in case we're using some serialisation method
+        # that doesn't cope with SafeText values correctly
+        return str(value)
+
+    def value_for_form(self, value):
+        # need to explicitly mark as unsafe, or it'll output unescaped HTML in the textarea
+        return str(value)
+
+    def value_from_form(self, value):
+        return mark_safe(value)
 
     class Meta:
         icon = 'code'

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -293,6 +293,7 @@ class TestRawHTMLBlock(unittest.TestCase):
         block = blocks.RawHTMLBlock()
         result = block.get_prep_value(mark_safe('<blink>BOOM</blink>'))
         self.assertEqual(result, '<blink>BOOM</blink>')
+        self.assertNotIsInstance(result, SafeData)
 
     def test_deserialize(self):
         block = blocks.RawHTMLBlock()

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -4,7 +4,7 @@ from django import forms
 from django.forms.utils import ErrorList
 from django.core.exceptions import ValidationError
 from django.test import TestCase
-from django.utils.safestring import mark_safe, SafeText
+from django.utils.safestring import mark_safe, SafeData
 
 from wagtail.wagtailcore import blocks
 from wagtail.wagtailcore.models import Page
@@ -272,22 +272,22 @@ class TestRawHTMLBlock(unittest.TestCase):
     def test_get_default_with_fallback_value(self):
         default_value = blocks.RawHTMLBlock().get_default()
         self.assertEqual(default_value, '')
-        self.assertTrue(isinstance(default_value, SafeText))
+        self.assertIsInstance(default_value, SafeData)
 
     def test_get_default_with_none(self):
         default_value = blocks.RawHTMLBlock(default=None).get_default()
         self.assertEqual(default_value, '')
-        self.assertTrue(isinstance(default_value, SafeText))
+        self.assertIsInstance(default_value, SafeData)
 
     def test_get_default_with_empty_string(self):
         default_value = blocks.RawHTMLBlock(default='').get_default()
         self.assertEqual(default_value, '')
-        self.assertTrue(isinstance(default_value, SafeText))
+        self.assertIsInstance(default_value, SafeData)
 
     def test_get_default_with_nonempty_string(self):
         default_value = blocks.RawHTMLBlock(default='<blink>BOOM</blink>').get_default()
         self.assertEqual(default_value, '<blink>BOOM</blink>')
-        self.assertTrue(isinstance(default_value, SafeText))
+        self.assertIsInstance(default_value, SafeData)
 
     def test_serialize(self):
         block = blocks.RawHTMLBlock()
@@ -298,13 +298,13 @@ class TestRawHTMLBlock(unittest.TestCase):
         block = blocks.RawHTMLBlock()
         result = block.to_python('<blink>BOOM</blink>')
         self.assertEqual(result, '<blink>BOOM</blink>')
-        self.assertTrue(isinstance(result, SafeText))
+        self.assertIsInstance(result, SafeData)
 
     def test_render(self):
         block = blocks.RawHTMLBlock()
         result = block.render(mark_safe('<blink>BOOM</blink>'))
         self.assertEqual(result, '<blink>BOOM</blink>')
-        self.assertTrue(isinstance(result, SafeText))
+        self.assertIsInstance(result, SafeData)
 
     def test_render_form(self):
         block = blocks.RawHTMLBlock()
@@ -317,13 +317,13 @@ class TestRawHTMLBlock(unittest.TestCase):
         block = blocks.RawHTMLBlock()
         result = block.value_from_datadict({'rawhtml': '<blink>BOOM</blink>'}, {}, prefix='rawhtml')
         self.assertEqual(result, '<blink>BOOM</blink>')
-        self.assertTrue(isinstance(result, SafeText))
+        self.assertIsInstance(result, SafeData)
 
     def test_clean_required_field(self):
         block = blocks.RawHTMLBlock()
         result = block.clean(mark_safe('<blink>BOOM</blink>'))
         self.assertEqual(result, '<blink>BOOM</blink>')
-        self.assertTrue(isinstance(result, SafeText))
+        self.assertIsInstance(result, SafeData)
 
         with self.assertRaises(ValidationError):
             block.clean(mark_safe(''))
@@ -332,11 +332,11 @@ class TestRawHTMLBlock(unittest.TestCase):
         block = blocks.RawHTMLBlock(required=False)
         result = block.clean(mark_safe('<blink>BOOM</blink>'))
         self.assertEqual(result, '<blink>BOOM</blink>')
-        self.assertTrue(isinstance(result, SafeText))
+        self.assertIsInstance(result, SafeData)
 
         result = block.clean(mark_safe(''))
         self.assertEqual(result, '')
-        self.assertTrue(isinstance(result, SafeText))
+        self.assertIsInstance(result, SafeData)
 
 
 class TestMeta(unittest.TestCase):

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -4,6 +4,7 @@ from django import forms
 from django.forms.utils import ErrorList
 from django.core.exceptions import ValidationError
 from django.test import TestCase
+from django.utils.safestring import mark_safe, SafeText
 
 from wagtail.wagtailcore import blocks
 from wagtail.wagtailcore.models import Page
@@ -265,6 +266,77 @@ class TestChoiceBlock(unittest.TestCase):
                 },
             )
         )
+
+
+class TestRawHTMLBlock(unittest.TestCase):
+    def test_get_default_with_fallback_value(self):
+        default_value = blocks.RawHTMLBlock().get_default()
+        self.assertEqual(default_value, '')
+        self.assertTrue(isinstance(default_value, SafeText))
+
+    def test_get_default_with_none(self):
+        default_value = blocks.RawHTMLBlock(default=None).get_default()
+        self.assertEqual(default_value, '')
+        self.assertTrue(isinstance(default_value, SafeText))
+
+    def test_get_default_with_empty_string(self):
+        default_value = blocks.RawHTMLBlock(default='').get_default()
+        self.assertEqual(default_value, '')
+        self.assertTrue(isinstance(default_value, SafeText))
+
+    def test_get_default_with_nonempty_string(self):
+        default_value = blocks.RawHTMLBlock(default='<blink>BOOM</blink>').get_default()
+        self.assertEqual(default_value, '<blink>BOOM</blink>')
+        self.assertTrue(isinstance(default_value, SafeText))
+
+    def test_serialize(self):
+        block = blocks.RawHTMLBlock()
+        result = block.get_prep_value(mark_safe('<blink>BOOM</blink>'))
+        self.assertEqual(result, '<blink>BOOM</blink>')
+
+    def test_deserialize(self):
+        block = blocks.RawHTMLBlock()
+        result = block.to_python('<blink>BOOM</blink>')
+        self.assertEqual(result, '<blink>BOOM</blink>')
+        self.assertTrue(isinstance(result, SafeText))
+
+    def test_render(self):
+        block = blocks.RawHTMLBlock()
+        result = block.render(mark_safe('<blink>BOOM</blink>'))
+        self.assertEqual(result, '<blink>BOOM</blink>')
+        self.assertTrue(isinstance(result, SafeText))
+
+    def test_render_form(self):
+        block = blocks.RawHTMLBlock()
+        result = block.render_form(mark_safe('<blink>BOOM</blink>'), prefix='rawhtml')
+        self.assertIn('<textarea ', result)
+        self.assertIn('name="rawhtml"', result)
+        self.assertIn('&lt;blink&gt;BOOM&lt;/blink&gt;', result)
+
+    def test_form_response(self):
+        block = blocks.RawHTMLBlock()
+        result = block.value_from_datadict({'rawhtml': '<blink>BOOM</blink>'}, {}, prefix='rawhtml')
+        self.assertEqual(result, '<blink>BOOM</blink>')
+        self.assertTrue(isinstance(result, SafeText))
+
+    def test_clean_required_field(self):
+        block = blocks.RawHTMLBlock()
+        result = block.clean(mark_safe('<blink>BOOM</blink>'))
+        self.assertEqual(result, '<blink>BOOM</blink>')
+        self.assertTrue(isinstance(result, SafeText))
+
+        with self.assertRaises(ValidationError):
+            block.clean(mark_safe(''))
+
+    def test_clean_nonrequired_field(self):
+        block = blocks.RawHTMLBlock(required=False)
+        result = block.clean(mark_safe('<blink>BOOM</blink>'))
+        self.assertEqual(result, '<blink>BOOM</blink>')
+        self.assertTrue(isinstance(result, SafeText))
+
+        result = block.clean(mark_safe(''))
+        self.assertEqual(result, '')
+        self.assertTrue(isinstance(result, SafeText))
 
 
 class TestMeta(unittest.TestCase):

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*
+from __future__ import unicode_literals
+
 import unittest
 
 from django import forms
@@ -285,45 +288,45 @@ class TestRawHTMLBlock(unittest.TestCase):
         self.assertIsInstance(default_value, SafeData)
 
     def test_get_default_with_nonempty_string(self):
-        default_value = blocks.RawHTMLBlock(default='<blink>BOOM</blink>').get_default()
-        self.assertEqual(default_value, '<blink>BOOM</blink>')
+        default_value = blocks.RawHTMLBlock(default='<blink>BÖÖM</blink>').get_default()
+        self.assertEqual(default_value, '<blink>BÖÖM</blink>')
         self.assertIsInstance(default_value, SafeData)
 
     def test_serialize(self):
         block = blocks.RawHTMLBlock()
-        result = block.get_prep_value(mark_safe('<blink>BOOM</blink>'))
-        self.assertEqual(result, '<blink>BOOM</blink>')
+        result = block.get_prep_value(mark_safe('<blink>BÖÖM</blink>'))
+        self.assertEqual(result, '<blink>BÖÖM</blink>')
         self.assertNotIsInstance(result, SafeData)
 
     def test_deserialize(self):
         block = blocks.RawHTMLBlock()
-        result = block.to_python('<blink>BOOM</blink>')
-        self.assertEqual(result, '<blink>BOOM</blink>')
+        result = block.to_python('<blink>BÖÖM</blink>')
+        self.assertEqual(result, '<blink>BÖÖM</blink>')
         self.assertIsInstance(result, SafeData)
 
     def test_render(self):
         block = blocks.RawHTMLBlock()
-        result = block.render(mark_safe('<blink>BOOM</blink>'))
-        self.assertEqual(result, '<blink>BOOM</blink>')
+        result = block.render(mark_safe('<blink>BÖÖM</blink>'))
+        self.assertEqual(result, '<blink>BÖÖM</blink>')
         self.assertIsInstance(result, SafeData)
 
     def test_render_form(self):
         block = blocks.RawHTMLBlock()
-        result = block.render_form(mark_safe('<blink>BOOM</blink>'), prefix='rawhtml')
+        result = block.render_form(mark_safe('<blink>BÖÖM</blink>'), prefix='rawhtml')
         self.assertIn('<textarea ', result)
         self.assertIn('name="rawhtml"', result)
-        self.assertIn('&lt;blink&gt;BOOM&lt;/blink&gt;', result)
+        self.assertIn('&lt;blink&gt;BÖÖM&lt;/blink&gt;', result)
 
     def test_form_response(self):
         block = blocks.RawHTMLBlock()
-        result = block.value_from_datadict({'rawhtml': '<blink>BOOM</blink>'}, {}, prefix='rawhtml')
-        self.assertEqual(result, '<blink>BOOM</blink>')
+        result = block.value_from_datadict({'rawhtml': '<blink>BÖÖM</blink>'}, {}, prefix='rawhtml')
+        self.assertEqual(result, '<blink>BÖÖM</blink>')
         self.assertIsInstance(result, SafeData)
 
     def test_clean_required_field(self):
         block = blocks.RawHTMLBlock()
-        result = block.clean(mark_safe('<blink>BOOM</blink>'))
-        self.assertEqual(result, '<blink>BOOM</blink>')
+        result = block.clean(mark_safe('<blink>BÖÖM</blink>'))
+        self.assertEqual(result, '<blink>BÖÖM</blink>')
         self.assertIsInstance(result, SafeData)
 
         with self.assertRaises(ValidationError):
@@ -331,8 +334,8 @@ class TestRawHTMLBlock(unittest.TestCase):
 
     def test_clean_nonrequired_field(self):
         block = blocks.RawHTMLBlock(required=False)
-        result = block.clean(mark_safe('<blink>BOOM</blink>'))
-        self.assertEqual(result, '<blink>BOOM</blink>')
+        result = block.clean(mark_safe('<blink>BÖÖM</blink>'))
+        self.assertEqual(result, '<blink>BÖÖM</blink>')
         self.assertIsInstance(result, SafeData)
 
         result = block.clean(mark_safe(''))


### PR DESCRIPTION
Same deal as #1357 and #1360 - allows using RawHTMLBlock within a StructBlock with no special template syntax. This time, rather than introducing a new custom type, we use Django's SafeText.