### PR TITLE
Remove unicodecsv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,6 @@ except ImportError:
     pass
 
 
-PY3 = sys.version_info[0] == 3
-
-
 install_requires = [
     "Django>=1.7.1,<1.9",
     "django-compressor>=1.4",
@@ -40,12 +37,6 @@ install_requires = [
     'requests>=2.0.0',
     "Willow==0.2.1",
 ]
-
-
-if not PY3:
-    install_requires += [
-        "unicodecsv>=0.9.4"
-    ]
 
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,6 @@ deps =
     Willow==0.2
     coverage
 
-    py27: unicodecsv>=0.9.4
     dj17: Django>=1.7.1,<1.8
     dj18: Django>=1.8,<1.9
     postgres: psycopg2>=2.6

--- a/wagtail/wagtailforms/tests.py
+++ b/wagtail/wagtailforms/tests.py
@@ -360,6 +360,24 @@ class TestFormsSubmissions(TestCase, WagtailTestUtils):
         data_line = response.content.decode().split("\n")[1]
         self.assertIn('new@example.com', data_line)
 
+    def test_list_submissions_csv_export_with_unicode(self):
+        unicode_form_submission = FormSubmission.objects.create(
+            page=self.form_page,
+            form_data=json.dumps({
+                'your-email': "unicode@example.com",
+                'your-message': 'こんにちは、世界',
+            }),
+        )
+        unicode_form_submission.submit_time = '2014-01-02T12:00:00.000Z'
+        unicode_form_submission.save()
+
+        response = self.client.get(reverse('wagtailforms_list_submissions', args=(self.form_page.id, )), {'date_from': '01/02/2014', 'action': 'CSV'})
+
+        # Check response
+        self.assertEqual(response.status_code, 200)
+        data_line = response.content.decode('utf-8').split("\n")[1]
+        self.assertIn('こんにちは、世界', data_line)
+
 
 class TestIssue798(TestCase):
     fixtures = ['test.json']

--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -1,16 +1,12 @@
 import datetime
 
-try:
-    import unicodecsv as csv
-    using_unicodecsv = True
-except ImportError:
-    import csv
-    using_unicodecsv = False
+import csv
 
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, render
+from django.utils.encoding import smart_str
 
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailforms.models import FormSubmission, get_forms_for_user
@@ -69,10 +65,7 @@ def list_submissions(request, page_id):
         response = HttpResponse(content_type='text/csv; charset=utf-8')
         response['Content-Disposition'] = 'attachment;filename=export.csv'
 
-        if using_unicodecsv:
-            writer = csv.writer(response, encoding='utf-8')
-        else:
-            writer = csv.writer(response)
+        writer = csv.writer(response)
 
         header_row = ['Submission date'] + [label for name, label in data_fields]
 
@@ -81,7 +74,7 @@ def list_submissions(request, page_id):
             data_row = [s.submit_time]
             form_data = s.get_data()
             for name, label in data_fields:
-                data_row.append(form_data.get(name))
+                data_row.append(smart_str(form_data.get(name)))
             writer.writerow(data_row)
         return response
 


### PR DESCRIPTION
This removes the unicodecsv dependency (replacing it with a call to ``django.utils.encoding.smart_str``). ``unicodecsv`` is only a dependency of Python 2 and cannot be used on Python 3 which prevents us from creating universal wheel files.