### PR TITLE
Add missing requiresment to requirements-dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ mock>=1.0.0
 python-dateutil>=2.2
 pytz>=2014.7
 Pillow>=2.7.0
+django-sendfile==0.3.6
 
 # For coverage and PEP8 linting
 coverage>=3.7.0


### PR DESCRIPTION
Sendfile is required for running the tests, it's present in the tox.ini but not for normal development.