### PR TITLE
Allow for overriding image upload path

### DIFF
--- a/wagtail/tests/testapp/migrations/0004_customimagefilepath.py
+++ b/wagtail/tests/testapp/migrations/0004_customimagefilepath.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+import taggit.managers
+import wagtail.wagtailadmin.taggable
+import wagtail.wagtailimages.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taggit', '0001_initial'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('tests', '0003_streammodel'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CustomImageFilePath',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('title', models.CharField(max_length=255, verbose_name='Title')),
+                ('file', models.ImageField(height_field='height', upload_to=wagtail.wagtailimages.models.get_upload_to, width_field='width', verbose_name='File')),
+                ('width', models.IntegerField(verbose_name='Width', editable=False)),
+                ('height', models.IntegerField(verbose_name='Height', editable=False)),
+                ('created_at', models.DateTimeField(auto_now_add=True, verbose_name='Created at')),
+                ('focal_point_x', models.PositiveIntegerField(null=True, blank=True)),
+                ('focal_point_y', models.PositiveIntegerField(null=True, blank=True)),
+                ('focal_point_width', models.PositiveIntegerField(null=True, blank=True)),
+                ('focal_point_height', models.PositiveIntegerField(null=True, blank=True)),
+                ('tags', taggit.managers.TaggableManager(to='taggit.Tag', through='taggit.TaggedItem', blank=True, help_text=None, verbose_name='Tags')),
+                ('uploaded_by_user', models.ForeignKey(blank=True, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Uploaded by user')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=(models.Model, wagtail.wagtailadmin.taggable.TagSearchable),
+        ),
+    ]

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -1,5 +1,8 @@
 from __future__ import unicode_literals
 
+import hashlib
+import os
+
 from django.db import models
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.utils.encoding import python_2_unicode_compatible
@@ -409,3 +412,34 @@ class StreamModel(models.Model):
         ('text', CharBlock()),
         ('image', ImageChooserBlock()),
     ])
+
+class CustomImageFilePath(AbstractImage):
+    @staticmethod
+    def get_upload_to(instance, filename):
+        """Create a path that's file-system friendly.
+
+        By hashing the file's contents we guarantee an equal distribution
+        of files within our root directories. This also gives us a
+        better chance of uploading images with the same filename, but
+        different contents - this isn't guaranteed as we're only using
+        the first three characters of the checksum.
+        """
+        original_filepath = AbstractImage.get_upload_to(instance, filename)
+        folder_name, filename = original_filepath.split(os.path.sep)
+
+        # Ensure that we consume the entire file, we can't guarantee that
+        # the stream has not be partially (or entirely) consumed by
+        # another process
+        original_position = instance.file.tell()
+        instance.file.seek(0)
+        hash256 = hashlib.sha256()
+
+        while True:
+            data = instance.file.read(256)
+            if not data:
+                break
+            hash256.update(data)
+        checksum = hash256.hexdigest()
+
+        instance.file.seek(original_position)
+        return os.path.join(folder_name, checksum[:3], filename)

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -413,9 +413,9 @@ class StreamModel(models.Model):
         ('image', ImageChooserBlock()),
     ])
 
+
 class CustomImageFilePath(AbstractImage):
-    @staticmethod
-    def get_upload_to(instance, filename):
+    def get_upload_to(self, filename):
         """Create a path that's file-system friendly.
 
         By hashing the file's contents we guarantee an equal distribution
@@ -424,22 +424,22 @@ class CustomImageFilePath(AbstractImage):
         different contents - this isn't guaranteed as we're only using
         the first three characters of the checksum.
         """
-        original_filepath = AbstractImage.get_upload_to(instance, filename)
+        original_filepath = super(CustomImageFilePath, self).get_upload_to(filename)
         folder_name, filename = original_filepath.split(os.path.sep)
 
         # Ensure that we consume the entire file, we can't guarantee that
         # the stream has not be partially (or entirely) consumed by
         # another process
-        original_position = instance.file.tell()
-        instance.file.seek(0)
+        original_position = self.file.tell()
+        self.file.seek(0)
         hash256 = hashlib.sha256()
 
         while True:
-            data = instance.file.read(256)
+            data = self.file.read(256)
             if not data:
                 break
             hash256.update(data)
         checksum = hash256.hexdigest()
 
-        instance.file.seek(original_position)
+        self.file.seek(original_position)
         return os.path.join(folder_name, checksum[:3], filename)

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -42,18 +42,8 @@ class SourceImageIOError(IOError):
 
 
 def get_upload_to(instance, filename):
-    folder_name = 'original_images'
-    filename = instance.file.field.storage.get_valid_name(filename)
-
-    # do a unidecode in the filename and then
-    # replace non-ascii characters in filename with _ , to sidestep issues with filesystem encoding
-    filename = "".join((i if ord(i) < 128 else '_') for i in unidecode(filename))
-
-    while len(os.path.join(folder_name, filename)) >= 95:
-        prefix, dot, extension = filename.rpartition('.')
-        filename = prefix[:-1] + dot + extension
-    return os.path.join(folder_name, filename)
-
+    # Dumb proxy to instance method.
+    return instance.get_upload_to(instance, filename)
 
 @python_2_unicode_compatible
 class AbstractImage(models.Model, TagSearchable):
@@ -70,6 +60,20 @@ class AbstractImage(models.Model, TagSearchable):
     focal_point_y = models.PositiveIntegerField(null=True, blank=True)
     focal_point_width = models.PositiveIntegerField(null=True, blank=True)
     focal_point_height = models.PositiveIntegerField(null=True, blank=True)
+
+    @staticmethod
+    def get_upload_to(instance, filename):
+        folder_name = 'original_images'
+        filename = instance.file.field.storage.get_valid_name(filename)
+
+        # do a unidecode in the filename and then
+        # replace non-ascii characters in filename with _ , to sidestep issues with filesystem encoding
+        filename = "".join((i if ord(i) < 128 else '_') for i in unidecode(filename))
+
+        while len(os.path.join(folder_name, filename)) >= 95:
+            prefix, dot, extension = filename.rpartition('.')
+            filename = prefix[:-1] + dot + extension
+        return os.path.join(folder_name, filename)
 
     def get_usage(self):
         return get_object_usage(self)

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -43,7 +43,8 @@ class SourceImageIOError(IOError):
 
 def get_upload_to(instance, filename):
     # Dumb proxy to instance method.
-    return instance.get_upload_to(instance, filename)
+    return instance.get_upload_to(filename)
+
 
 @python_2_unicode_compatible
 class AbstractImage(models.Model, TagSearchable):
@@ -61,10 +62,9 @@ class AbstractImage(models.Model, TagSearchable):
     focal_point_width = models.PositiveIntegerField(null=True, blank=True)
     focal_point_height = models.PositiveIntegerField(null=True, blank=True)
 
-    @staticmethod
-    def get_upload_to(instance, filename):
+    def get_upload_to(self, filename):
         folder_name = 'original_images'
-        filename = instance.file.field.storage.get_valid_name(filename)
+        filename = self.file.field.storage.get_valid_name(filename)
 
         # do a unidecode in the filename and then
         # replace non-ascii characters in filename with _ , to sidestep issues with filesystem encoding

--- a/wagtail/wagtailimages/tests/tests.py
+++ b/wagtail/wagtailimages/tests/tests.py
@@ -10,7 +10,7 @@ from django.core.urlresolvers import reverse
 from taggit.forms import TagField, TagWidget
 
 from wagtail.utils.deprecation import RemovedInWagtail12Warning
-from wagtail.tests.testapp.models import CustomImageWithAdminFormFields, CustomImageWithoutAdminFormFields
+from wagtail.tests.testapp.models import CustomImageWithAdminFormFields, CustomImageWithoutAdminFormFields, CustomImageFilePath
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailimages.utils import generate_signature, verify_signature
 from wagtail.wagtailimages.rect import Rect
@@ -358,3 +358,21 @@ class TestRenditionFilenames(TestCase):
         rendition = image.get_rendition('fill-100x100')
 
         self.assertEqual(rendition.file.name, 'images/test_rf3.15ee4958.fill-100x100.png')
+
+
+class TestDifferentUpload(TestCase):
+    def test_upload_path(self):
+        image = CustomImageFilePath.objects.create(
+            title="Test image",
+            file=get_test_image_file(),
+        )
+
+        second_image = CustomImageFilePath.objects.create(
+            title="Test Image",
+            file=get_test_image_file(colour='black'),
+
+        )
+
+        # The files should be uploaded based on it's content, not just
+        # it's filename
+        self.assertFalse(image.file.url == second_image.file.url)

--- a/wagtail/wagtailimages/tests/utils.py
+++ b/wagtail/wagtailimages/tests/utils.py
@@ -9,8 +9,8 @@ from wagtail.wagtailimages.models import get_image_model
 Image = get_image_model()
 
 
-def get_test_image_file(filename='test.png'):
+def get_test_image_file(filename='test.png', colour='white', size=(640, 480)):
     f = BytesIO()
-    image = PIL.Image.new('RGB', (640, 480), 'white')
+    image = PIL.Image.new('RGB', size, colour)
     image.save(f, 'PNG')
     return ImageFile(f, name=filename)


### PR DESCRIPTION
Previously I've worked on a project that has quite a few images being uploaded (it's currently using ~ 28,000 images, and then that's multiplied for the renditions). In the not too distant future the file system will stop being able to parse the tree (in a reasonable time frame), and backups will no longer be able to taken!

This allows the user to override the default image file path with a more friendly version - the example I've given should scale for most systems. An added benefit for this type of file positioning is that the path is generated based on the contents, so files that share the same name will probably* have different paths.

*As I'm only using the first three characters of the checksum, there's still a chance that images sharing the same name will be positioned in the same folder, all be it pretty small.