### PR TITLE
Skip sendfile tests if django-sendfile is not installed. Fixes #1367

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ mock>=1.0.0
 python-dateutil>=2.2
 pytz>=2014.7
 Pillow>=2.7.0
-django-sendfile==0.3.6
 
 # For coverage and PEP8 linting
 coverage>=3.7.0

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -83,7 +83,6 @@ INSTALLED_APPS = (
 
     'taggit',
     'compressor',
-    'sendfile',
 
     'wagtail.wagtailcore',
     'wagtail.wagtailadmin',
@@ -112,8 +111,6 @@ INSTALLED_APPS = (
     # app which uses AppConfigs to test that hooks load properly
     'wagtail.wagtailredirects.apps.WagtailRedirectsAppConfig',
 )
-
-
 
 
 # Using DatabaseCache to make sure that the cache is cleared between tests.

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -591,6 +591,26 @@ class TestServeView(TestCase):
         from wagtail.utils.sendfile import _get_sendfile
         _get_sendfile.clear()
 
+
+class TestServeViewWithSendfile(TestCase):
+    def setUp(self):
+        # Import using a try-catch block to prevent crashes if the
+        # django-sendfile module is not installed
+        try:
+            import sendfile  # noqa
+        except ImportError:
+            raise unittest.SkipTest("django-sendfile not installed")
+
+        self.document = models.Document(title="Test document")
+        self.document.file.save('example.doc', ContentFile("A boring example document"))
+
+    def get(self):
+        return self.client.get(reverse('wagtaildocs_serve', args=(self.document.id, 'example.doc')))
+
+    def clear_sendfile_cache(self):
+        from wagtail.utils.sendfile import _get_sendfile
+        _get_sendfile.clear()
+
     @override_settings(SENDFILE_BACKEND='sendfile.backends.xsendfile')
     def test_sendfile_xsendfile_backend(self):
         self.clear_sendfile_cache()


### PR DESCRIPTION
Takes an example from the ElasticSearch tests and only runs the sendfile test when django-sendfile is installed.

The PR also removes django-sendfile from requirements-dev.txt, but leaves it in tox.ini