### PR TITLE
Generate user forms at runtime. Fixes #1345

### DIFF
--- a/wagtail/wagtailusers/forms.py
+++ b/wagtail/wagtailusers/forms.py
@@ -1,7 +1,6 @@
 from django import forms
 from django.contrib.auth.forms import UserCreationForm as BaseUserCreationForm
 from django.utils.translation import ugettext_lazy as _
-from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.forms.models import inlineformset_factory
 
@@ -11,133 +10,136 @@ from wagtail.wagtailusers.models import UserProfile
 from wagtail.wagtailcore.models import UserPagePermissionsProxy, GroupPagePermission
 
 
-User = get_user_model()
+def get_user_creation_form(user_model):
+    # extend Django's UserCreationForm with an 'is_superuser' field
+    class UserCreationForm(BaseUserCreationForm):
 
-
-# extend Django's UserCreationForm with an 'is_superuser' field
-class UserCreationForm(BaseUserCreationForm):
-
-    required_css_class = "required"
-    is_superuser = forms.BooleanField(
-        label=_("Administrator"),
-        required=False,
-        help_text=_("If ticked, this user has the ability to manage user accounts.")
-    )
-
-    email = forms.EmailField(required=True, label=_("Email"))
-    first_name = forms.CharField(required=True, label=_("First Name"))
-    last_name = forms.CharField(required=True, label=_("Last Name"))
-
-    class Meta:
-        model = User
-        fields = ("username", "email", "first_name", "last_name", "is_superuser", "groups")
-        widgets = {
-            'groups': forms.CheckboxSelectMultiple
-        }
-
-    def clean_username(self):
-        # Method copied from parent
-
-        username = self.cleaned_data["username"]
-        try:
-            # When called from BaseUserCreationForm, the method fails if using a AUTH_MODEL_MODEL,
-            # This is because the following line tries to perform a lookup on
-            # the default "auth_user" table.
-            User._default_manager.get(username=username)
-        except User.DoesNotExist:
-            return username
-        raise forms.ValidationError(
-            self.error_messages['duplicate_username'],
-            code='duplicate_username',
+        required_css_class = "required"
+        is_superuser = forms.BooleanField(
+            label=_("Administrator"),
+            required=False,
+            help_text=_("If ticked, this user has the ability to manage user accounts.")
         )
 
-    def save(self, commit=True):
-        user = super(UserCreationForm, self).save(commit=False)
+        email = forms.EmailField(required=True, label=_("Email"))
+        first_name = forms.CharField(required=True, label=_("First Name"))
+        last_name = forms.CharField(required=True, label=_("Last Name"))
 
-        # users can access django-admin iff they are a superuser
-        user.is_staff = user.is_superuser
+        class Meta:
+            model = user_model
+            fields = ("username", "email", "first_name", "last_name", "is_superuser", "groups")
+            widgets = {
+                'groups': forms.CheckboxSelectMultiple
+            }
 
-        if commit:
-            user.save()
-            self.save_m2m()
-        return user
+        def clean_username(self):
+            # Method copied from parent
 
-
-# Largely the same as django.contrib.auth.forms.UserCreationForm, but with enough subtle changes
-# (to make password non-required) that it isn't worth inheriting...
-class UserEditForm(forms.ModelForm):
-    required_css_class = "required"
-
-    error_messages = {
-        'duplicate_username': _("A user with that username already exists."),
-        'password_mismatch': _("The two password fields didn't match."),
-    }
-    username = forms.RegexField(
-        label=_("Username"),
-        max_length=30,
-        regex=r'^[\w.@+-]+$',
-        help_text=_("Required. 30 characters or fewer. Letters, digits and @/./+/-/_ only."),
-        error_messages={
-            'invalid': _("This value may contain only letters, numbers and @/./+/-/_ characters.")
-        })
-
-    email = forms.EmailField(required=True, label=_("Email"))
-    first_name = forms.CharField(required=True, label=_("First Name"))
-    last_name = forms.CharField(required=True, label=_("Last Name"))
-
-    password1 = forms.CharField(
-        label=_("Password"),
-        required=False,
-        widget=forms.PasswordInput,
-        help_text=_("Leave blank if not changing."))
-    password2 = forms.CharField(
-        label=_("Password confirmation"), required=False,
-        widget=forms.PasswordInput,
-        help_text=_("Enter the same password as above, for verification."))
-
-    is_superuser = forms.BooleanField(
-        label=_("Administrator"),
-        required=False,
-        help_text=_("Administrators have the ability to manage user accounts.")
-    )
-
-    class Meta:
-        model = User
-        fields = ("username", "email", "first_name", "last_name", "is_active", "is_superuser", "groups")
-        widgets = {
-            'groups': forms.CheckboxSelectMultiple
-        }
-
-    def clean_username(self):
-        # Since User.username is unique, this check is redundant,
-        # but it sets a nicer error message than the ORM. See #13147.
-        username = self.cleaned_data["username"]
-        try:
-            User._default_manager.exclude(id=self.instance.id).get(username=username)
-        except User.DoesNotExist:
-            return username
-        raise forms.ValidationError(self.error_messages['duplicate_username'])
-
-    def clean_password2(self):
-        password1 = self.cleaned_data.get("password1")
-        password2 = self.cleaned_data.get("password2")
-        if password1 != password2:
+            username = self.cleaned_data["username"]
+            try:
+                # When called from BaseUserCreationForm, the method fails if using a AUTH_MODEL_MODEL,
+                # This is because the following line tries to perform a lookup on
+                # the default "auth_user" table.
+                user_model._default_manager.get(username=username)
+            except user_model.DoesNotExist:
+                return username
             raise forms.ValidationError(
-                self.error_messages['password_mismatch'])
-        return password2
+                self.error_messages['duplicate_username'],
+                code='duplicate_username',
+            )
 
-    def save(self, commit=True):
-        user = super(UserEditForm, self).save(commit=False)
+        def save(self, commit=True):
+            user = super(UserCreationForm, self).save(commit=False)
 
-        # users can access django-admin iff they are a superuser
-        user.is_staff = user.is_superuser
+            # users can access django-admin iff they are a superuser
+            user.is_staff = user.is_superuser
 
-        if self.cleaned_data["password1"]:
-            user.set_password(self.cleaned_data["password1"])
-        if commit:
-            user.save()
-            self.save_m2m()
-        return user
+            if commit:
+                user.save()
+                self.save_m2m()
+            return user
+
+    return UserCreationForm
+
+
+def get_user_edit_form(user_model):
+    # Largely the same as django.contrib.auth.forms.UserCreationForm, but with enough subtle changes
+    # (to make password non-required) that it isn't worth inheriting...
+    class UserEditForm(forms.ModelForm):
+        required_css_class = "required"
+
+        error_messages = {
+            'duplicate_username': _("A user with that username already exists."),
+            'password_mismatch': _("The two password fields didn't match."),
+        }
+        username = forms.RegexField(
+            label=_("Username"),
+            max_length=30,
+            regex=r'^[\w.@+-]+$',
+            help_text=_("Required. 30 characters or fewer. Letters, digits and @/./+/-/_ only."),
+            error_messages={
+                'invalid': _("This value may contain only letters, numbers and @/./+/-/_ characters.")
+            })
+
+        email = forms.EmailField(required=True, label=_("Email"))
+        first_name = forms.CharField(required=True, label=_("First Name"))
+        last_name = forms.CharField(required=True, label=_("Last Name"))
+
+        password1 = forms.CharField(
+            label=_("Password"),
+            required=False,
+            widget=forms.PasswordInput,
+            help_text=_("Leave blank if not changing."))
+        password2 = forms.CharField(
+            label=_("Password confirmation"), required=False,
+            widget=forms.PasswordInput,
+            help_text=_("Enter the same password as above, for verification."))
+
+        is_superuser = forms.BooleanField(
+            label=_("Administrator"),
+            required=False,
+            help_text=_("Administrators have the ability to manage user accounts.")
+        )
+
+        class Meta:
+            model = user_model
+            fields = ("username", "email", "first_name", "last_name", "is_active", "is_superuser", "groups")
+            widgets = {
+                'groups': forms.CheckboxSelectMultiple
+            }
+
+        def clean_username(self):
+            # Since User.username is unique, this check is redundant,
+            # but it sets a nicer error message than the ORM. See #13147.
+            username = self.cleaned_data["username"]
+            try:
+                user_model._default_manager.exclude(id=self.instance.id).get(username=username)
+            except user_model.DoesNotExist:
+                return username
+            raise forms.ValidationError(self.error_messages['duplicate_username'])
+
+        def clean_password2(self):
+            password1 = self.cleaned_data.get("password1")
+            password2 = self.cleaned_data.get("password2")
+            if password1 != password2:
+                raise forms.ValidationError(
+                    self.error_messages['password_mismatch'])
+            return password2
+
+        def save(self, commit=True):
+            user = super(UserEditForm, self).save(commit=False)
+
+            # users can access django-admin iff they are a superuser
+            user.is_staff = user.is_superuser
+
+            if self.cleaned_data["password1"]:
+                user.set_password(self.cleaned_data["password1"])
+            if commit:
+                user.save()
+                self.save_m2m()
+            return user
+
+    return UserEditForm
 
 
 class GroupForm(forms.ModelForm):

--- a/wagtail/wagtailusers/views/users.py
+++ b/wagtail/wagtailusers/views/users.py
@@ -9,7 +9,7 @@ from django.views.decorators.vary import vary_on_headers
 
 from wagtail.wagtailadmin import messages
 from wagtail.wagtailadmin.forms import SearchForm
-from wagtail.wagtailusers.forms import UserCreationForm, UserEditForm
+from wagtail.wagtailusers.forms import get_user_creation_form, get_user_edit_form
 from wagtail.wagtailcore.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
 
 User = get_user_model()
@@ -79,6 +79,8 @@ def index(request):
 
 @permission_required(change_user_perm)
 def create(request):
+    UserCreationForm = get_user_creation_form(User)
+
     if request.POST:
         form = UserCreationForm(request.POST)
         if form.is_valid():
@@ -99,7 +101,10 @@ def create(request):
 
 @permission_required(change_user_perm)
 def edit(request, user_id):
+    UserEditForm = get_user_edit_form(User)
+
     user = get_object_or_404(User, id=user_id)
+
     if request.POST:
         form = UserEditForm(request.POST, instance=user)
         if form.is_valid():


### PR DESCRIPTION
This code fails on Django 1.8 and causes the whole site to crash. This commit makes the forms only get generated when they're needed so only the users admin will crash (which is what already happens anyway).