### PR TITLE
Cleanup - render labels within ObjectList <h2>s

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -77,7 +77,7 @@
         opacity:1;
     }
 
-    > h2, &.single-field label{
+    > h2{
         -webkit-font-smoothing: auto;
         background:$color-salmon-light;
         text-transform:uppercase;
@@ -93,7 +93,17 @@
         z-index:1;
         overflow:hidden;
 
-        &:before{
+        label{
+            display: inline;
+            text-transform: inherit;
+            font-weight: inherit;
+            float: none;
+            width: auto;
+            color: inherit;
+            font-size: inherit;
+        }
+
+        &:before, label:before{
             text-shadow:none;
             font-family:wagtail;
             text-transform:none;
@@ -127,18 +137,20 @@
         }
     }
 
-    &.single-field{
-        h2, .object-help{
-            display:none; /* The field label is used instead */
+    &.required{
+        > h2 label:after{
+            content:"*";
+            color:$color-red;
+            font-weight:bold;
+            display:inline-block;
+            margin-left:0.5em;
+            line-height:1em;
+            font-size:13px;
         }
     }
 
     /* Special full-width, one-off fields i.e a single text or textarea input */
     &.full{
-        h2{
-            display:none; /* The field label is used instead */
-        }
-
         .object-help{
             display:block;
         }
@@ -146,10 +158,6 @@
         fieldset{
             display:block;
             float:none;
-
-            .help{
-                display:none;
-            }
         }
         li{
             padding:0;
@@ -542,7 +550,7 @@
     &.empty{
         border-bottom:1px solid white;
 
-        > h2, &.single-field label{
+        > h2{
             margin:0 0;
             border-bottom:1px solid white;
         }
@@ -731,13 +739,6 @@ footer .preview{
 
         &.empty .add{
             margin:0 0 0 -50px;
-        }
-
-        &.single-field label{
-            display: block;
-            float: none;
-            width: auto;
-            padding:auto;
         }
     }
 }

--- a/wagtail/wagtailadmin/templates/wagtailadmin/edit_handlers/object_list.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/edit_handlers/object_list.html
@@ -2,7 +2,11 @@
     {% for child in self.children %}
         <li class="object {{ child.classes|join:" " }}">
             {% if child.heading %}
-                <h2>{{ child.heading }}</h2>
+                <h2>
+                    <label {% if child.id_for_label %}for="{{ child.id_for_label }}"{% endif %}>
+                        {{ child.heading }}
+                    </label>
+                </h2>
             {% endif %}
             {% if child.help_text %}
                 <div class="object-help help">{{ child.help_text }}</div>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/edit_handlers/single_field_panel.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/edit_handlers/single_field_panel.html
@@ -1,6 +1,27 @@
+{% load wagtailadmin_tags %}
 <fieldset>
     <legend>{{ self.heading }}</legend>
     <ul class="fields">
-        <li>{{ field_content }}</li>
+        <li>
+            {# render field with markup as per wagtailadmin/shared/field.html, but with label/help text omitted (those are handled by object_list.html) #}
+            <div class="field {{ field|fieldtype }} {{ field|widgettype }}">
+                <div class="field-content">
+                    <div class="input">
+                        {{ field|render_with_errors }}
+
+                        {# This span only used on rare occasions by certain types of input #}
+                        <span></span>
+                    </div>
+
+                    {% if field|has_unrendered_errors %}
+                        <p class="error-message">
+                            {% for error in field.errors %}
+                                <span>{{ error|escape }}</span>
+                            {% endfor %}
+                        </p>
+                    {% endif %}
+                </div>
+            </div>
+        </li>
     </ul>
 </fieldset>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/edit_handlers/single_field_panel.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/edit_handlers/single_field_panel.html
@@ -1,27 +1,8 @@
-{% load wagtailadmin_tags %}
 <fieldset>
     <legend>{{ self.heading }}</legend>
     <ul class="fields">
         <li>
-            {# render field with markup as per wagtailadmin/shared/field.html, but with label/help text omitted (those are handled by object_list.html) #}
-            <div class="field {{ field|fieldtype }} {{ field|widgettype }}">
-                <div class="field-content">
-                    <div class="input">
-                        {{ field|render_with_errors }}
-
-                        {# This span only used on rare occasions by certain types of input #}
-                        <span></span>
-                    </div>
-
-                    {% if field|has_unrendered_errors %}
-                        <p class="error-message">
-                            {% for error in field.errors %}
-                                <span>{{ error|escape }}</span>
-                            {% endfor %}
-                        </p>
-                    {% endif %}
-                </div>
-            </div>
+            {% include "wagtailadmin/shared/field.html" with show_label=False show_help_text=False %}
         </li>
     </ul>
 </fieldset>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/field.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/field.html
@@ -1,6 +1,6 @@
 {% load wagtailadmin_tags %}
 <div class="field {{ field|fieldtype }} {{ field|widgettype }} {{ field_classes }}">
-    {{ field.label_tag }}
+    {% if show_label|default_if_none:True %}{{ field.label_tag }}{% endif %}
     <div class="field-content">
         <div class="input {{ input_classes }} ">
             {% block form_field %}
@@ -10,7 +10,7 @@
             {# This span only used on rare occasions by certain types of input #}
             <span></span>
         </div>
-        {% if field.help_text %}
+        {% if show_help_text|default_if_none:True and field.help_text %}
             <p class="help">{{ field.help_text }}</p>
         {% endif %}
 

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -247,8 +247,11 @@ class TestObjectList(TestCase):
         # result should contain ObjectList furniture
         self.assertIn('<ul class="objects">', result)
 
-        # result should contain h2 headings for children
-        self.assertIn('<h2>Start date</h2>', result)
+        # result should contain h2 headings (including labels) for children
+        self.assertInHTML('<h2><label for="id_date_from">Start date</label></h2>', result)
+
+        # result should include help text for children
+        self.assertIn('<div class="object-help help">Not required if event is on a single day</div>', result)
 
         # result should contain rendered content from descendants
         self.assertIn('Abergavenny sheepdog trials</textarea>', result)
@@ -278,12 +281,13 @@ class TestFieldPanel(TestCase):
         )
         result = field_panel.render_as_object()
 
-        # check that label appears in the 'object' wrapper as well as the field
+        # check that label appears as a legend in the 'object' wrapper,
+        # but not as a field label (that would be provided by ObjectList instead)
         self.assertIn('<legend>End date</legend>', result)
-        self.assertIn('<label for="id_date_to">End date:</label>', result)
+        self.assertNotIn('<label for="id_date_to">End date:</label>', result)
 
-        # check that help text is included
-        self.assertIn('Not required if event is on a single day', result)
+        # check that help text is not included (it's provided by ObjectList instead)
+        self.assertNotIn('Not required if event is on a single day', result)
 
         # check that the populated form field is included
         self.assertIn('value="2014-07-22"', result)


### PR DESCRIPTION
Overview of changes:

* The output of FieldPanel.render_as_object no longer incorporates the output of FieldPanel.render_as_field (via a convoluted chain of includes) - instead, it renders a slightly-tweaked version of shared/field.html with the label and help text omitted.
* This means we no longer have duplicate copies of the heading text and help text that we have to hide in CSS (which we were failing to do properly for StreamField), and no need for a .single-field label style that replicates the `<h2>` style.
* This leaves top-level FieldPanels without a `<label>`, so we add that inside the `<h2>` which is now shown consistently for all blocks. To assist with this, EditHandler now provides an `id_for_label` method as standard, to specify what the ID for this label should be. As a bonus, rendering our own label means we can ditch the colon...
* `single-field` is then no longer required at all in the CSS, so we can get rid of the hack where FieldPanel adds it as a classname and StreamFieldPanel removes it again.