### PR TITLE
Add support for user models with no username

### DIFF
--- a/wagtail/tests/customuser/migrations/0001_initial.py
+++ b/wagtail/tests/customuser/migrations/0001_initial.py
@@ -46,4 +46,29 @@ class Migration(migrations.Migration):
             },
             bases=(models.Model,),
         ),
+        migrations.CreateModel(
+            name='EmailUser',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('password', models.CharField(max_length=128, verbose_name='password')),
+                (
+                    'last_login',
+                    models.DateTimeField(null=True, verbose_name='last login', blank=True)
+                    if django.VERSION >= (1, 8) else
+                    models.DateTimeField(default=django.utils.timezone.now, verbose_name='last login')
+                ),
+                ('email', models.EmailField(unique=True, max_length=255)),
+                ('is_staff', models.BooleanField(default=True)),
+                ('is_active', models.BooleanField(default=True)),
+                ('first_name', models.CharField(max_length=50, blank=True)),
+                ('last_name', models.CharField(max_length=50, blank=True)),
+                ('is_superuser', models.BooleanField(default=False)),
+                ('groups', models.ManyToManyField(related_name='+', to='auth.Group', blank=True)),
+                ('user_permissions', models.ManyToManyField(related_name='+', to='auth.Permission', blank=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=(models.Model,),
+        ),
     ]

--- a/wagtail/tests/customuser/models.py
+++ b/wagtail/tests/customuser/models.py
@@ -1,6 +1,9 @@
+import sys
+
 from django.db import models
 
-from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin, BaseUserManager
+from django.contrib.auth.models import (
+    Group, Permission, AbstractBaseUser, PermissionsMixin, BaseUserManager)
 
 
 class CustomUserManager(BaseUserManager):
@@ -37,6 +40,7 @@ class CustomUser(AbstractBaseUser, PermissionsMixin):
     last_name = models.CharField(max_length=50, blank=True)
 
     USERNAME_FIELD = 'username'
+    REQUIRED_FIELDS = ['email']
 
     objects = CustomUserManager()
 
@@ -45,3 +49,61 @@ class CustomUser(AbstractBaseUser, PermissionsMixin):
 
     def get_short_name(self):
         return self.first_name
+
+
+class EmailUserManager(BaseUserManager):
+    def _create_user(self, email, password,
+                     is_staff, is_superuser, **extra_fields):
+        """
+        Creates and saves a User with the given email and password.
+        """
+        email = self.normalize_email(email)
+        user = self.model(email=email, is_staff=is_staff, is_active=True,
+                          is_superuser=is_superuser, **extra_fields)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
+
+    def create_user(self, email=None, password=None, **extra_fields):
+        return self._create_user(email, password, False, False,
+                                 **extra_fields)
+
+    def create_superuser(self, email, password, **extra_fields):
+        return self._create_user(email, password, True, True,
+                                 **extra_fields)
+
+
+class EmailUser(AbstractBaseUser):
+    # Cant inherit from PermissionsMixin because of clashes with
+    # groups/user_permissions related_names.
+    email = models.EmailField(max_length=255, unique=True)
+    is_staff = models.BooleanField(default=True)
+    is_active = models.BooleanField(default=True)
+    first_name = models.CharField(max_length=50, blank=True)
+    last_name = models.CharField(max_length=50, blank=True)
+
+    is_superuser = models.BooleanField(default=False)
+    groups = models.ManyToManyField(Group, related_name='+', blank=True)
+    user_permissions = models.ManyToManyField(Permission, related_name='+', blank=True)
+
+    USERNAME_FIELD = 'email'
+
+    objects = EmailUserManager()
+
+    def get_full_name(self):
+        return self.first_name + ' ' + self.last_name
+
+    def get_short_name(self):
+        return self.first_name
+
+
+def steal_method(name):
+    func = getattr(PermissionsMixin, name)
+    if sys.version_info < (3,):
+        func = func.__func__
+    setattr(EmailUser, name, func)
+
+methods = ['get_group_permissions', 'get_all_permissions', 'has_perm',
+           'has_perms', 'has_module_perms']
+for method in methods:
+    steal_method(method)

--- a/wagtail/wagtailusers/templates/wagtailusers/users/create.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/create.html
@@ -18,7 +18,9 @@
             {% csrf_token %}
             <section id="account" class="active nice-padding">
                 <ul class="fields">
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.username %}
+                    {% if form.separate_username_field %}
+                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.username_field %}
+                    {% endif %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.email %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.first_name %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.last_name %}

--- a/wagtail/wagtailusers/templates/wagtailusers/users/edit.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/edit.html
@@ -19,7 +19,9 @@
 
             <section id="account" class="active nice-padding">
                 <ul class="fields">
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.username %}
+                    {% if form.separate_username_field %}
+                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.username_field %}
+                    {% endif %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.email %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.first_name %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.last_name %}


### PR DESCRIPTION
The User forms were the only known sections to fail when using a swapped User model that did not have a `username` field, using an `email` field instead for example.

This commit makes the User forms work with `User.USERNAME_FIELD` instead of hardcoding `"username"`.

Truly strange user models are not yet supported.

The tests do not test this custom user functionality yet, as this is quite difficult to do. Lots of code does not support dynamically changing the `AUTH_USER_MODEL` setting for the tests, so only one custom
user model for most of the tests.

Fixes #1345, also see #1380