### PR TITLE
Minor feature: Branding favicon.

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/admin_base.html
@@ -8,6 +8,7 @@
     {% endcompress %}
 
     {% block extra_css %}{% endblock %}
+    {% block branding_favicon %}{% endblock %}
 {% endblock %}
 
 {% block js %}


### PR DESCRIPTION
Guys, i don't know where add a small suggestion, a feature, branding favicon, now i'm using brandins welcome message for do this, override de block extra_css with all code, like this:
```
{% overextends "wagtailadmin/home.html" %}
{% load i18n static compress %}
{% block extra_css %}
    {% compress css %}
        <link rel="stylesheet" href="{{ STATIC_URL }}wagtailadmin/scss/layouts/home.scss" type="text/x-scss" />
    {% endcompress %}
    <link rel="icon" href="{% static 'app/images/favicon.ico' %}" type="image/x-icon; charset=binary"/>
{% endblock %}
```

But, i think that will be better put a branding block for custom favicon :D