### PR TITLE
Fix search on user without username

### DIFF
--- a/wagtail/wagtailusers/views/users.py
+++ b/wagtail/wagtailusers/views/users.py
@@ -33,7 +33,11 @@ def index(request):
             q = form.cleaned_data['q']
 
             is_searching = True
-            users = User.objects.filter(Q(username__icontains=q) | Q(first_name__icontains=q) | Q(last_name__icontains=q) | Q(email__icontains=q))
+
+            if User.USERNAME_FIELD == 'username':
+                users = User.objects.filter(Q(username__icontains=q) | Q(first_name__icontains=q) | Q(last_name__icontains=q) | Q(email__icontains=q))
+            else:
+                users = User.objects.filter(Q(first_name__icontains=q) | Q(last_name__icontains=q) | Q(email__icontains=q))
     else:
         form = SearchForm(placeholder=_("Search users"))
 


### PR DESCRIPTION
Search in user section crashes when the custom user model doesn't have a username field. This PR fixes it.