### PR TITLE
Make sure with_metaclass always comes from Django

### DIFF
--- a/wagtail/wagtailadmin/menu.py
+++ b/wagtail/wagtailadmin/menu.py
@@ -1,13 +1,16 @@
 from __future__ import unicode_literals
 
-from six import text_type, with_metaclass
+from six import text_type
 
 from django.forms import MediaDefiningClass, Media
 from django.forms.utils import flatatt
 from django.utils.text import slugify
 from django.utils.safestring import mark_safe
-from wagtail.utils.compat import render_to_string
 
+# Must be imported from Django so we get the new implementation of with_metaclass
+from django.utils.six import with_metaclass
+
+from wagtail.utils.compat import render_to_string
 from wagtail.wagtailcore import hooks
 
 

--- a/wagtail/wagtailcore/blocks/stream_block.py
+++ b/wagtail/wagtailcore/blocks/stream_block.py
@@ -10,7 +10,8 @@ from django.utils.encoding import python_2_unicode_compatible, force_text
 from django.utils.html import format_html_join
 from django.utils.safestring import mark_safe
 
-import six
+# Must be imported from Django so we get the new implementation of with_metaclass
+from django.utils import six
 
 from wagtail.wagtailcore.utils import escape_script
 

--- a/wagtail/wagtailcore/blocks/struct_block.py
+++ b/wagtail/wagtailcore/blocks/struct_block.py
@@ -9,7 +9,8 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
 from django.utils.html import format_html, format_html_join
 
-import six
+# Must be imported from Django so we get the new implementation of with_metaclass
+from django.utils import six
 
 from .base import Block, DeclarativeSubBlocksMetaclass
 from .utils import js_dict

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import logging
 import json
 
-import six
 from six import StringIO
 from six.moves.urllib.parse import urlparse
 
@@ -28,6 +27,9 @@ from django.core.exceptions import ValidationError, ImproperlyConfigured, Object
 from django.utils.functional import cached_property
 from django.utils.encoding import python_2_unicode_compatible
 from django.core import checks
+
+# Must be imported from Django so we get the new implementation of with_metaclass
+from django.utils import six
 
 from treebeard.mp_tree import MP_Node
 


### PR DESCRIPTION
Wagtail requires six version 1.7 or higher to get the new implementation of ``with_metaclass``.

Macs seem to have an old version preinstalled which takes priority over the version installed by PIP causing Wagtail to use the old version.

Django has a newer version of six bundled into it. This PR tweaks Wagtail's imports to use ``django.utils.six`` wherever ``with_metaclass`` is needed so we never get the old implementation.