### PR TITLE
add target _blank to non page URLs

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
@@ -57,6 +57,9 @@
                                     if (pageData.id) {
                                         a.setAttribute('data-id', pageData.id);
                                         a.setAttribute('data-linktype', 'page');
+                                    } else {
+                                        // add target="_blank" to non page URLs.
+                                        a.setAttribute('target', '_blank');
                                     }
 
                                     if ((!lastSelection.collapsed) && lastSelection.canSurroundContents()) {


### PR DESCRIPTION
Hi,

At the moment when adding a external link via the WYSIWYG editor it opens in the same window (by default).. I couldn't find any option to open it in a new window, so I would like to propose opening those links in a new window by default. I already implemented in the attached pull request.