### PR TITLE
Use six from Django

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ install_requires = [
     "beautifulsoup4>=4.3.2",
     "html5lib==0.999",
     "Unidecode>=0.04.14",
-    "six>=1.7.0",
     'requests>=2.0.0',
     "Willow==0.2.1",
 ]

--- a/wagtail/contrib/wagtailapi/utils.py
+++ b/wagtail/contrib/wagtailapi/utils.py
@@ -1,6 +1,5 @@
-from six.moves.urllib.parse import urlparse
-
 from django.conf import settings
+from django.utils.six.moves.urllib.parse import urlparse
 
 
 class BadRequestError(Exception):

--- a/wagtail/contrib/wagtailfrontendcache/backends.py
+++ b/wagtail/contrib/wagtailfrontendcache/backends.py
@@ -1,8 +1,8 @@
 import logging
-
-from six.moves.urllib.parse import urlparse
-
 import requests
+
+from django.utils.six.moves.urllib.parse import urlparse
+
 from requests.adapters import HTTPAdapter
 
 

--- a/wagtail/contrib/wagtailroutablepage/models.py
+++ b/wagtail/contrib/wagtailroutablepage/models.py
@@ -1,11 +1,11 @@
 from __future__ import unicode_literals
 
-from six import string_types
 import warnings
 
 from django.http import Http404
 from django.core.urlresolvers import RegexURLResolver
 from django.conf.urls import url
+from django.utils.six import string_types
 
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.url_routing import RouteResult

--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -3,13 +3,12 @@ from __future__ import unicode_literals
 import copy
 import warnings
 
-from six import text_type
-
 from modelcluster.forms import ClusterForm, ClusterFormMetaclass
 
 from django.db import models
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
+from django.utils.six import text_type
 from django import forms
 from django.forms.models import fields_for_model
 from django.contrib.contenttypes.models import ContentType

--- a/wagtail/wagtailadmin/menu.py
+++ b/wagtail/wagtailadmin/menu.py
@@ -1,13 +1,11 @@
 from __future__ import unicode_literals
 
-from six import text_type
-
 from django.forms import MediaDefiningClass, Media
 from django.forms.utils import flatatt
 from django.utils.text import slugify
 from django.utils.safestring import mark_safe
+from django.utils.six import text_type
 
-# Must be imported from Django so we get the new implementation of with_metaclass
 from django.utils.six import with_metaclass
 
 from wagtail.utils.compat import render_to_string

--- a/wagtail/wagtailadmin/templatetags/gravatar.py
+++ b/wagtail/wagtailadmin/templatetags/gravatar.py
@@ -9,10 +9,9 @@
 
 import hashlib
 
-from six import b
-from six.moves.urllib.parse import urlencode
-
 from django import template
+from django.utils.six import b
+from django.utils.six.moves.urllib.parse import urlencode
 
 register = template.Library()
 

--- a/wagtail/wagtailcore/blocks/base.py
+++ b/wagtail/wagtailcore/blocks/base.py
@@ -8,13 +8,12 @@ from importlib import import_module
 
 from django.core import checks
 from django.core.exceptions import ImproperlyConfigured
+from django.utils import six
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
 from django.utils.encoding import force_text
 from django.template.loader import render_to_string
 from django import forms
-
-import six
 
 
 __all__ = ['BaseBlock', 'Block', 'BoundBlock', 'DeclarativeSubBlocksMetaclass', 'BlockWidget', 'BlockField']

--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import, unicode_literals
 
 import datetime
-import six
 
 from django import forms
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.template.loader import render_to_string
+from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.dateparse import parse_date, parse_time, parse_datetime
 from django.utils.functional import cached_property

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -3,9 +3,6 @@ from __future__ import unicode_literals
 import logging
 import json
 
-from six import StringIO
-from six.moves.urllib.parse import urlparse
-
 from modelcluster.models import ClusterableModel, get_all_child_relations
 
 from django.db import models, connection, transaction
@@ -22,6 +19,8 @@ from django.contrib.auth.models import Group
 from django.conf import settings
 from django.template.response import TemplateResponse
 from django.utils import timezone
+from django.utils.six import StringIO
+from django.utils.six.moves.urllib.parse import urlparse
 from django.utils.translation import ugettext_lazy as _
 from django.core.exceptions import ValidationError, ImproperlyConfigured, ObjectDoesNotExist
 from django.utils.functional import cached_property

--- a/wagtail/wagtailcore/tests/test_management_commands.py
+++ b/wagtail/wagtailcore/tests/test_management_commands.py
@@ -1,10 +1,9 @@
 from datetime import timedelta
 
-from six import StringIO
-
 from django.test import TestCase
 from django.core import management
 from django.utils import timezone
+from django.utils.six import StringIO
 from django.db import models
 
 from wagtail.wagtailcore.models import Page, PageRevision

--- a/wagtail/wagtailcore/utils.py
+++ b/wagtail/wagtailcore/utils.py
@@ -1,8 +1,8 @@
 import re
-from six import string_types
 
 from django.db.models import Model
 from django.apps import apps
+from django.utils.six import string_types
 
 
 def camelcase_to_underscore(str):

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-from six import b
 import unittest
 import mock
 from bs4 import BeautifulSoup
@@ -14,6 +13,7 @@ from django.core.urlresolvers import reverse
 from django.core.files.base import ContentFile
 from django.test.utils import override_settings
 from django.conf import settings
+from django.utils.six import b
 
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailcore.models import Page

--- a/wagtail/wagtailembeds/embeds.py
+++ b/wagtail/wagtailembeds/embeds.py
@@ -2,12 +2,10 @@ from datetime import datetime
 import json
 
 # Needs to be imported like this to allow @patch to work in tests
-from six.moves.urllib import request as urllib_request
-
-from six.moves.urllib.request import Request
-from six.moves.urllib.error import URLError
-from six.moves.urllib.parse import urlencode
-
+from django.utils.six.moves.urllib import request as urllib_request
+from django.utils.six.moves.urllib.request import Request
+from django.utils.six.moves.urllib.error import URLError
+from django.utils.six.moves.urllib.parse import urlencode
 from django.utils.module_loading import import_string
 from django.conf import settings
 

--- a/wagtail/wagtailembeds/tests.py
+++ b/wagtail/wagtailembeds/tests.py
@@ -1,5 +1,5 @@
-import six.moves.urllib.request
-from six.moves.urllib.error import URLError
+import django.utils.six.moves.urllib.request
+from django.utils.six.moves.urllib.error import URLError
 
 from mock import patch
 import unittest
@@ -229,11 +229,11 @@ class TestOembed(TestCase):
 
     def test_oembed_invalid_request(self):
         config = {'side_effect': URLError('foo')}
-        with patch.object(six.moves.urllib.request, 'urlopen', **config):
+        with patch.object(django.utils.six.moves.urllib.request, 'urlopen', **config):
             self.assertRaises(EmbedNotFoundException, wagtail_oembed,
                               "http://www.youtube.com/watch/")
 
-    @patch('six.moves.urllib.request.urlopen')
+    @patch('django.utils.six.moves.urllib.request.urlopen')
     @patch('json.loads')
     def test_oembed_photo_request(self, loads, urlopen):
         urlopen.return_value = self.dummy_response
@@ -244,7 +244,7 @@ class TestOembed(TestCase):
         self.assertEqual(result['html'], '<img src="http://www.example.com" />')
         loads.assert_called_with("foo")
 
-    @patch('six.moves.urllib.request.urlopen')
+    @patch('django.utils.six.moves.urllib.request.urlopen')
     @patch('json.loads')
     def test_oembed_return_values(self, loads, urlopen):
         urlopen.return_value = self.dummy_response

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -3,8 +3,6 @@ from __future__ import unicode_literals
 import json
 import re
 
-from six import text_type
-
 from unidecode import unidecode
 
 from django.db import models
@@ -12,6 +10,7 @@ from django.shortcuts import render
 from django.utils.translation import ugettext_lazy as _
 from django.utils.text import slugify
 from django.utils.encoding import python_2_unicode_compatible
+from django.utils.six import text_type
 from django.core.serializers.json import DjangoJSONEncoder
 
 from wagtail.wagtailcore.models import Page, Orderable, UserPagePermissionsProxy, get_page_types

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -5,7 +5,6 @@ import hashlib
 from contextlib import contextmanager
 import warnings
 
-from six import BytesIO, text_type
 
 from taggit.managers import TaggableManager
 from willow.image import Image as WillowImage
@@ -16,6 +15,7 @@ from django.db import models
 from django.db.models.signals import pre_delete, pre_save
 from django.dispatch.dispatcher import receiver
 from django.utils.safestring import mark_safe
+from django.utils.six import BytesIO, text_type
 from django.utils.html import escape, format_html_join
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _

--- a/wagtail/wagtailimages/tests/utils.py
+++ b/wagtail/wagtailimages/tests/utils.py
@@ -1,7 +1,7 @@
 import PIL.Image
-from six import BytesIO
 
 from django.core.files.images import ImageFile
+from django.utils.six import BytesIO
 
 from wagtail.wagtailimages.models import get_image_model
 

--- a/wagtail/wagtailredirects/models.py
+++ b/wagtail/wagtailredirects/models.py
@@ -1,11 +1,10 @@
 from __future__ import unicode_literals
 
 from django.db import models
+from django.utils.six.moves.urllib.parse import urlparse
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel, PageChooserPanel
-
-from six.moves.urllib.parse import urlparse
 
 
 class Redirect(models.Model):

--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -1,8 +1,8 @@
-from six import text_type
 
 from django.db.models.query import QuerySet
 from django.db.models.lookups import Lookup
 from django.db.models.sql.where import SubqueryConstraint, WhereNode
+from django.utils.six import text_type
 
 from wagtail.wagtailsearch.index import class_is_indexed
 

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import json
 
-from six.moves.urllib.parse import urlparse
+from django.utils.six.moves.urllib.parse import urlparse
 
 from elasticsearch import Elasticsearch, NotFoundError
 from elasticsearch.helpers import bulk

--- a/wagtail/wagtailsearch/tests/test_backends.py
+++ b/wagtail/wagtailsearch/tests/test_backends.py
@@ -1,4 +1,3 @@
-from six import StringIO
 import unittest
 import time
 
@@ -6,6 +5,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.conf import settings
 from django.core import management
+from django.utils.six import StringIO
 
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.tests.search import models

--- a/wagtail/wagtailsearch/tests/test_queries.py
+++ b/wagtail/wagtailsearch/tests/test_queries.py
@@ -1,7 +1,7 @@
-from six import StringIO
 
 from django.test import TestCase
 from django.core import management
+from django.utils.six import StringIO
 
 from wagtail.wagtailsearch import models
 from wagtail.tests.utils import WagtailTestUtils

--- a/wagtail/wagtailsites/tests.py
+++ b/wagtail/wagtailsites/tests.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals
 from django.test import TestCase
 from django.core.urlresolvers import reverse
+from django.utils import six
 
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailcore.models import Site, Page
-import six
 
 
 class TestSiteIndexView(TestCase, WagtailTestUtils):

--- a/wagtail/wagtailsnippets/views/chooser.py
+++ b/wagtail/wagtailsnippets/views/chooser.py
@@ -1,10 +1,9 @@
 import json
 from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 
-from six import text_type
-
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404
+from django.utils.six import text_type
 
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 

--- a/wagtail/wagtailusers/tests.py
+++ b/wagtail/wagtailusers/tests.py
@@ -1,12 +1,12 @@
 from __future__ import unicode_literals
 
 import unittest
-import six
 
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
+from django.utils import six
 
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailcore import hooks


### PR DESCRIPTION
No point in installing six as a standalone dependency if it is already bundled with Django.

Fixes #1403
See #1406