### PR TITLE
Add requirements.txt to project template

### DIFF
--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -27,6 +27,7 @@ This will create a new folder ``mysite``, based on a template containing all you
 
 Inside your ``mysite`` folder, we now just run the setup steps necessary for any Django project::
 
+    pip install -r requirements.txt
     ./manage.py migrate
     ./manage.py createsuperuser
     ./manage.py runserver

--- a/docs/getting_started/tutorial.rst
+++ b/docs/getting_started/tutorial.rst
@@ -1,13 +1,14 @@
 Your first Wagtail site
 =======================
 
-1. Install Wagtail and its dependencies:
+1. Install Wagtail and its dependencies::
 
-   ``pip install wagtail``
+    pip install wagtail
 
-2. Start your site:
+2. Start your site::
 
-   ``wagtail start mysite``
+    wagtail start mysite
+    cd mysite
 
    Wagtail provides a ``start`` command similar to
    ``django-admin.py startproject``. Running ``wagtail start mysite`` in
@@ -16,18 +17,24 @@ Your first Wagtail site
    "home" app with a blank ``HomePage`` model and basic templates and a sample
    "search" app.
 
-3. Create the database:
+3. Install project dependencies::
 
-   ``python manage.py migrate``
+    pip install -r requirements.txt
+
+   This ensures that you have the relevant version of Django for the project you've just created.
+
+4. Create the database::
+
+    python manage.py migrate
 
    If you haven't updated the project settings, this will be a SQLite
    database file in the project directory.
 
-4. Create an admin user:
+5. Create an admin user::
 
-   ``python manage.py createsuperuser``.
+    python manage.py createsuperuser
 
-5. ``python manage.py runserver`` If everything worked,
+6. ``python manage.py runserver`` If everything worked,
    http://127.0.0.1:8000 will show you a welcome page
 
    .. figure:: ../_static/images/tutorial/tutorial_1.png

--- a/wagtail/project_template/requirements.txt
+++ b/wagtail/project_template/requirements.txt
@@ -1,0 +1,2 @@
+Django>=1.8,<1.9
+wagtail==1.0b2


### PR DESCRIPTION
While the project template is intended to be as generic as possible, and not everyone will want to use requirements.txt (some would prefer to use setup.py to define requirements, for example), we need some way to formally indicate that the project template is specific to Django 1.8.