### PR TITLE
Add file_size field to Image

### DIFF
--- a/wagtail/tests/testapp/migrations/0005_image_file_size.py
+++ b/wagtail/tests/testapp/migrations/0005_image_file_size.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tests', '0004_streammodel_richtext'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='customimagewithadminformfields',
+            name='file_size',
+            field=models.PositiveIntegerField(null=True, editable=False),
+        ),
+        migrations.AddField(
+            model_name='customimagewithoutadminformfields',
+            name='file_size',
+            field=models.PositiveIntegerField(null=True, editable=False),
+        ),
+    ]

--- a/wagtail/wagtailimages/migrations/0007_image_file_size.py
+++ b/wagtail/wagtailimages/migrations/0007_image_file_size.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailimages', '0006_add_verbose_names'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='image',
+            name='file_size',
+            field=models.PositiveIntegerField(editable=False, null=True),
+        ),
+    ]

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -71,6 +71,20 @@ class AbstractImage(models.Model, TagSearchable):
     focal_point_width = models.PositiveIntegerField(null=True, blank=True)
     focal_point_height = models.PositiveIntegerField(null=True, blank=True)
 
+    file_size = models.PositiveIntegerField(null=True, editable=False)
+
+    def get_file_size(self):
+        if self.file_size is None:
+            try:
+                self.file_size = self.file.size
+            except OSError:
+                # File doesn't exist
+                return
+
+            self.save(update_fields=['file_size'])
+
+        return self.file_size
+
     def get_usage(self):
         return get_object_usage(self)
 

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -118,21 +118,11 @@ def edit(request, image_id):
     except NoReverseMatch:
         url_generator_enabled = False
 
-    # Get file size
-    try:
-        filesize = image.file.size
-    except OSError:
-        # File doesn't exist
-        filesize = None
-        messages.error(request, _("The source image file could not be found. Please change the source or delete the image.").format(image.title), buttons=[
-            messages.button(reverse('wagtailimages_delete_image', args=(image.id,)), _('Delete'))
-        ])
-
     return render(request, "wagtailimages/images/edit.html", {
         'image': image,
         'form': form,
         'url_generator_enabled': url_generator_enabled,
-        'filesize': filesize,
+        'filesize': image.get_file_size(),
     })
 
 

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -1,3 +1,4 @@
+import os
 import json
 
 from django.shortcuts import render, redirect, get_object_or_404
@@ -117,6 +118,19 @@ def edit(request, image_id):
         url_generator_enabled = True
     except NoReverseMatch:
         url_generator_enabled = False
+
+    try:
+        local_path = image.file.path
+    except NotImplementedError:
+        # Image is hosted externally (eg, S3)
+        local_path = None
+
+    if local_path:
+        # Give error if image file doesn't exist
+        if not os.path.isfile(local_path):
+            messages.error(request, _("The source image file could not be found. Please change the source or delete the image.").format(image.title), buttons=[
+                messages.button(reverse('wagtailimages_delete_image', args=(image.id,)), _('Delete'))
+            ])
 
     return render(request, "wagtailimages/images/edit.html", {
         'image': image,

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -97,6 +97,10 @@ def edit(request, image_id):
                 # which definitely isn't what we want...
                 original_file.storage.delete(original_file.name)
                 image.renditions.all().delete()
+
+                # Set new image file size
+                image.file_size = image.file.size
+
             form.save()
 
             # Reindex the image to make sure all tags are indexed
@@ -238,6 +242,9 @@ def add(request):
         image = ImageModel(uploaded_by_user=request.user)
         form = ImageForm(request.POST, request.FILES, instance=image)
         if form.is_valid():
+            # Set image file size
+            image.file_size = image.file.size
+
             form.save()
 
             # Reindex the image to make sure all tags are indexed

--- a/wagtail/wagtailimages/views/multiple.py
+++ b/wagtail/wagtailimages/views/multiple.py
@@ -62,6 +62,7 @@ def add(request):
             # Save it
             image = form.save(commit=False)
             image.uploaded_by_user = request.user
+            image.file_size = image.file.size
             image.save()
 
             # Success! Send back an edit form for this image to the user


### PR DESCRIPTION
Addresses part of #977 

This pull request adds a  ``file_size`` field to ``AbstractImage``. It also removes the "image file exists" check when an external file storage is in use (such as S3).