### PR TITLE
Add page privacy by user/group

### DIFF
--- a/wagtail/tests/testapp/fixtures/test.json
+++ b/wagtail/tests/testapp/fixtures/test.json
@@ -23,7 +23,7 @@
     "model": "wagtailcore.page",
     "fields": {
         "title": "Welcome to the Wagtail test site!",
-        "numchild": 5,
+        "numchild": 6,
         "show_in_menus": false,
         "live": true,
         "depth": 2,
@@ -344,7 +344,28 @@
         "cost": "free"
     }
 },
-
+{
+    "pk": 13,
+    "model": "wagtailcore.page",
+    "fields": {
+        "title": "Other secret plans",
+        "numchild": 0,
+        "show_in_menus": true,
+        "live": true,
+        "depth": 3,
+        "content_type": ["tests", "simplepage"],
+        "path": "000100010006",
+        "url_path": "/home/other-secret-plans/",
+        "slug": "other-secret-plans"
+    }
+},
+{
+    "pk": 13,
+    "model": "tests.simplepage",
+    "fields": {
+        "content": "<p>Other secret plans</p>"
+    }
+},
 {
     "pk": 1,
     "model": "wagtailcore.site",
@@ -624,7 +645,21 @@
     "model": "wagtailcore.pageviewrestriction",
     "fields": {
         "page": 11,
-        "password": "swordfish"
+        "password": "swordfish",
+        "restriction_type": "password"
+    }
+},
+{
+    "pk": 2,
+    "model": "wagtailcore.pageviewrestriction",
+    "fields": {
+        "page": 13,
+        "password": "",
+        "restriction_type": "users_groups",
+        "groups": [
+            ["Event editors"]
+        ],
+        "users": [5]
     }
 },
 {

--- a/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy.html
@@ -10,7 +10,10 @@
             {% include "wagtailadmin/shared/field_as_li.html" with field=form.restriction_type %}
             {% include "wagtailadmin/shared/field_as_li.html" with field=form.password li_classes="password-field" %}
         </ul>
+        <ul class="fields" id="users-groups-fields">
+            {% include "wagtailadmin/shared/field_as_li.html" with field=form.users %}
+            {% include "wagtailadmin/shared/field_as_li.html" with field=form.groups %}
+        </ul>
         <input type="submit" value="Save" />
     </form>
-    
 </div>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy.js
@@ -4,13 +4,21 @@ function(modal) {
         return false;
     });
 
-    var restrictionTypePasswordField = $("input[name='restriction_type'][value='password']", modal.body);
-    var passwordField = $("#id_password", modal.body);
+    var restrictionTypePasswordField = $("input[name='restriction_type'][value='password']", modal.body),
+        restrictionTypeUsersGroups = $("input[name='restriction_type'][value='users_groups']", modal.body),
+        passwordField = $(".password-field", modal.body),
+        usersGroupsFields = $('#users-groups-fields', modal.body);
+
     function refreshFormFields() {
         if (restrictionTypePasswordField.is(':checked')) {
-            passwordField.removeAttr('disabled');
+            passwordField.show();
+            usersGroupsFields.hide();
+        } else if (restrictionTypeUsersGroups.is(':checked')){
+            passwordField.hide();
+            usersGroupsFields.show();
         } else {
-            passwordField.attr('disabled', true);
+            passwordField.hide();
+            usersGroupsFields.hide();
         }
     }
     refreshFormFields();

--- a/wagtail/wagtailadmin/views/page_privacy.py
+++ b/wagtail/wagtailadmin/views/page_privacy.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
 
-from wagtail.wagtailcore.models import Page, PageViewRestriction
+from wagtail.wagtailcore.models import Page
 from wagtail.wagtailadmin.forms import PageViewRestrictionForm
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 
@@ -22,20 +22,16 @@ def set_privacy(request, page_id):
         restriction_exists_on_ancestor = False
 
     if request.POST:
-        form = PageViewRestrictionForm(request.POST)
+        form = PageViewRestrictionForm(request.POST, instance=restriction)
         if form.is_valid() and not restriction_exists_on_ancestor:
             if form.cleaned_data['restriction_type'] == 'none':
                 # remove any existing restriction
                 if restriction:
                     restriction.delete()
-            else:  # restriction_type = 'password'
-                if restriction:
-                    restriction.password = form.cleaned_data['password']
-                    restriction.save()
-                else:
-                    # create a new restriction object
-                    PageViewRestriction.objects.create(
-                        page=page, password=form.cleaned_data['password'])
+            else:
+                restriction = form.save(commit=False)
+                restriction.page = page
+                form.save()
 
             return render_modal_workflow(
                 request, None, 'wagtailadmin/page_privacy/set_privacy_done.js', {
@@ -46,9 +42,7 @@ def set_privacy(request, page_id):
     else:  # request is a GET
         if not restriction_exists_on_ancestor:
             if restriction:
-                form = PageViewRestrictionForm(initial={
-                    'restriction_type': 'password', 'password': restriction.password
-                })
+                form = PageViewRestrictionForm(instance=restriction)
             else:
                 # no current view restrictions on this page
                 form = PageViewRestrictionForm(initial={

--- a/wagtail/wagtailcore/migrations/0002_auto_20150628_1705.py
+++ b/wagtail/wagtailcore/migrations/0002_auto_20150628_1705.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0001_initial'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('wagtailcore', '0001_squashed_0016_change_page_url_path_to_text_field'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='pageviewrestriction',
+            name='groups',
+            field=models.ManyToManyField(blank=True, null=True, to='auth.Group'),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='pageviewrestriction',
+            name='restriction_type',
+            field=models.CharField(default='password', choices=[('none', 'Public'), ('password', 'Private, accessible with the following password'), ('users_groups', 'Private, visible to specific users and groups')], max_length=20),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='pageviewrestriction',
+            name='users',
+            field=models.ManyToManyField(blank=True, null=True, to=settings.AUTH_USER_MODEL),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='pageviewrestriction',
+            name='password',
+            field=models.CharField(blank=True, verbose_name='Password', max_length=255),
+            preserve_default=True,
+        ),
+    ]

--- a/wagtail/wagtailcore/templates/wagtailcore/user_group_restricted.html
+++ b/wagtail/wagtailcore/templates/wagtailcore/user_group_restricted.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <title>User/Group Restricted</title>
+    </head>
+    <body>
+        <h1>User/Group Restricted</h1>
+        <p>This page can only be viewed by selected users and groups.
+           Please ensure that you are logged in as a user with
+           the ability to view this page.
+        </p>
+    </body>
+</html>


### PR DESCRIPTION
Fixes #257.

Adds an extra option to the page privacy settings which allows the user to choose which users and user groups can view the live page.