### PR TITLE
Allow SQLite database location to be changed with DATABASE_NAME

### DIFF
--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -17,6 +17,10 @@ DATABASES = {
         'USER': os.environ.get('DATABASE_USER', None),
         'PASSWORD': os.environ.get('DATABASE_PASS', None),
         'HOST': os.environ.get('DATABASE_HOST', None),
+
+        'TEST': {
+            'NAME': os.environ.get('DATABASE_NAME', None),
+        }
     }
 }
 


### PR DESCRIPTION
SQLite runs in memory by default so it always gets destroyed regardless of whether you wanted to keep it between test runs using --keepdb

Setting up the database seems to take a significant amount of time now, so I think it's a good idea to have using a database file as an option:

Example: ``DATABASE_NAME=/wagtail.sqlite python runtests.py --keepdb``

This PR will probably break the postgres/mysql tests on Travis so best to wait and see what it says and fix before merging.