### PR TITLE
Calling block.super in extra_js and extra_css.

### DIFF
--- a/wagtail/contrib/wagtailstyleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/wagtailstyleguide/templates/wagtailstyleguide/base.html
@@ -2,6 +2,8 @@
 {% load wagtailadmin_tags compress i18n static gravatar %}
 
 {% block extra_css %}
+    {{ block.super }}
+
     {% compress css %}
         <link rel="stylesheet" href="{% static 'wagtailstyleguide/css/styleguide.css' %}" type="text/css" />
     {% endcompress %}
@@ -567,6 +569,8 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
+
     {% include "wagtailadmin/pages/_editor_js.html" %}
     <script>
         $(function(){

--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/complete.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/complete.html
@@ -4,6 +4,8 @@
 {% block bodyclass %}login{% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
+
     {% compress css %}
         <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
     {% endcompress %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/confirm.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/confirm.html
@@ -4,6 +4,8 @@
 {% block bodyclass %}login{% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
+
     {% compress css %}
         <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
     {% endcompress %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/done.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/done.html
@@ -4,6 +4,8 @@
 {% block bodyclass %}login{% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
+
     {% compress css %}
         <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
     {% endcompress %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/form.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/form.html
@@ -4,6 +4,8 @@
 {% block bodyclass %}login{% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
+
     {% compress css %}
         <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
     {% endcompress %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/home.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/home.html
@@ -4,6 +4,8 @@
 {% block bodyclass %}homepage{% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
+
     {% compress css %}
         <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/home.css' %}" type="text/css" />
     {% endcompress %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/login.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/login.html
@@ -4,6 +4,8 @@
 {% block bodyclass %}login{% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
+
     {% compress css %}
         <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
     {% endcompress %}
@@ -64,6 +66,7 @@
 {% endblock %}
 
 {% block extra_js %}
+{{ block.super }}
 <script>
     $(function(){
         $('form input[name=username]').focus();

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/copy.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/copy.html
@@ -30,5 +30,6 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 {% endblock %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
@@ -62,9 +62,11 @@
 {% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
 {% endblock %}
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 
     <script>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -91,8 +91,10 @@
 {% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
 {% endblock %}
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 {% endblock %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/index.html
@@ -19,6 +19,8 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
+
     {% comment %} modal-workflow is required by the view restrictions interface {% endcomment %}
     <script src="{% static 'wagtailadmin/js/modal-workflow.js' %}"></script>
     <script src="{% static 'wagtailadmin/js/privacy-switch.js' %}"></script>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/search.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/search.html
@@ -3,6 +3,8 @@
 {% block titletag %}{% trans 'Search' %}{% endblock %}
 {% block bodyclass %}menu-search{% endblock %}
 {% block extra_js %}
+    {{ block.super }}
+
     <script>
         window.headerSearch = {
             url: "{% url 'wagtailadmin_pages_search' %}",

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/add.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/add.html
@@ -4,10 +4,12 @@
 {% block titletag %}{% trans "Add a document" %}{% endblock %}
 {% block bodyclass %}menu-documents{% endblock %}
 {% block extra_css %}
+    {{ block.super }}
     {% include "wagtailadmin/shared/tag_field_css.html" %}
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/shared/tag_field_js.html" %}
 {% endblock %}
 

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
@@ -4,10 +4,12 @@
 {% block titletag %}{% blocktrans with title=document.title %}Editing {{ title }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}menu-documents{% endblock %}
 {% block extra_css %}
+    {{ block.super }}
     {% include "wagtailadmin/shared/tag_field_css.html" %}
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/shared/tag_field_js.html" %}
 {% endblock %}
 

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/index.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/index.html
@@ -3,6 +3,7 @@
 {% block titletag %}Documents{% endblock %}
 {% block bodyclass %}menu-documents{% endblock %}
 {% block extra_js %}
+    {{ block.super }}
     <script>
         window.headerSearch = {
             url: "{% url 'wagtaildocs_index' %}",

--- a/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
@@ -3,6 +3,7 @@
 {% block titletag %}{% blocktrans with form_title=form_page.title|capfirst %}Submissions of {{ form_title }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}menu-forms{% endblock %}
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/shared/datetimepicker_translations.html" %}
 
     <script>

--- a/wagtail/wagtailimages/templates/wagtailimages/images/add.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/add.html
@@ -4,10 +4,12 @@
 {% block titletag %}{% trans "Add an image" %}{% endblock %}
 {% block bodyclass %}menu-images{% endblock %}
 {% block extra_css %}
+    {{ block.super }}
     {% include "wagtailadmin/shared/tag_field_css.html" %}
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/shared/tag_field_js.html" %}
 {% endblock %}
 

--- a/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
@@ -3,6 +3,8 @@
 {% block titletag %}{% blocktrans with title=image.title %}Editing image {{ title }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}menu-images{% endblock %}
 {% block extra_css %}
+    {{ block.super }}
+
     {% include "wagtailadmin/shared/tag_field_css.html" %}
 
     <!-- Focal point chooser -->
@@ -13,6 +15,8 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
+
     {% include "wagtailadmin/shared/tag_field_js.html" %}
 
     <!-- Focal point chooser -->

--- a/wagtail/wagtailimages/templates/wagtailimages/images/index.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/index.html
@@ -5,6 +5,7 @@
 {% block titletag %}{% trans "Images" %}{% endblock %}
 {% block bodyclass %}menu-images{% endblock %}
 {% block extra_js %}
+    {{ block.super }}
     <script>
         window.headerSearch = {
             url: "{% url 'wagtailimages_index' %}",

--- a/wagtail/wagtailimages/templates/wagtailimages/images/url_generator.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/url_generator.html
@@ -37,6 +37,7 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     {% compress js %}
         <script src="{% static 'wagtailadmin/js/vendor/jquery.ba-throttle-debounce.min.js' %}"></script>
         <script src="{% static 'wagtailimages/js/image-url-generator.js' %}"></script>

--- a/wagtail/wagtailimages/templates/wagtailimages/multiple/add.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/multiple/add.html
@@ -3,6 +3,8 @@
 {% block titletag %}{% trans "Add multiple images" %}{% endblock %}
 {% block bodyclass %}menu-images{% endblock %}
 {% block extra_css %}
+    {{ block.super }}
+
     {% compress css %}
         <link rel="stylesheet" href="{% static 'wagtailimages/css/add-multiple.css' %}" type="text/css" />
     {% endcompress %}
@@ -54,6 +56,8 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
+
     {% compress js %}
         <!-- this exact order of plugins is vital -->
         <script src="{% static 'wagtailimages/js/vendor/load-image.min.js' %}"></script>

--- a/wagtail/wagtailredirects/templates/wagtailredirects/add.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/add.html
@@ -18,5 +18,6 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 {% endblock %}

--- a/wagtail/wagtailredirects/templates/wagtailredirects/edit.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/edit.html
@@ -19,5 +19,6 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 {% endblock %}

--- a/wagtail/wagtailredirects/templates/wagtailredirects/index.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/index.html
@@ -4,6 +4,7 @@
 {% block bodyclass %}menu-redirects{% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     <script>
         window.headerSearch = {
             url: "{% url 'wagtailredirects_index' %}",

--- a/wagtail/wagtailsearch/templates/wagtailsearch/editorspicks/add.html
+++ b/wagtail/wagtailsearch/templates/wagtailsearch/editorspicks/add.html
@@ -32,9 +32,11 @@
 {% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
 {% endblock %}
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 
     <script type="text/javascript">

--- a/wagtail/wagtailsearch/templates/wagtailsearch/editorspicks/edit.html
+++ b/wagtail/wagtailsearch/templates/wagtailsearch/editorspicks/edit.html
@@ -24,9 +24,11 @@
 {% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
 {% endblock %}
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 
     <script type="text/javascript">

--- a/wagtail/wagtailsearch/templates/wagtailsearch/editorspicks/index.html
+++ b/wagtail/wagtailsearch/templates/wagtailsearch/editorspicks/index.html
@@ -4,6 +4,7 @@
 {% block bodyclass %}menu-editorspicks{% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     <script>
         window.headerSearch = {
             url: "{% url 'wagtailsearch_editorspicks_index' %}",

--- a/wagtail/wagtailsites/templates/wagtailsites/create.html
+++ b/wagtail/wagtailsites/templates/wagtailsites/create.html
@@ -24,5 +24,6 @@
     </form>
 {% endblock %}
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 {% endblock %}

--- a/wagtail/wagtailsites/templates/wagtailsites/edit.html
+++ b/wagtail/wagtailsites/templates/wagtailsites/edit.html
@@ -31,5 +31,6 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 {% endblock %}

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/create.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/create.html
@@ -24,8 +24,10 @@
 {% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
 {% endblock %}
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 {% endblock %}

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
@@ -28,8 +28,10 @@
 {% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
 {% endblock %}
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 {% endblock %}

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/create.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/create.html
@@ -5,6 +5,8 @@
 {% block bodyclass %}menu-groups{% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
+
     {% compress css %}
         <link rel="stylesheet" href="{% static 'wagtailusers/css/groups_edit.css' %}" type="text/css" />
     {% endcompress %}
@@ -34,6 +36,8 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
+
     {% include "wagtailadmin/pages/_editor_js.html" %}
 
     <script>

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/edit.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/edit.html
@@ -5,6 +5,7 @@
 {% block bodyclass %}menu-groups{% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
     {% compress css %}
         <link rel="stylesheet" href="{% static 'wagtailusers/css/groups_edit.css' %}" type="text/css" />
     {% endcompress %}
@@ -42,6 +43,8 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
+
     {% include "wagtailadmin/pages/_editor_js.html" %}
 
     <script>

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/index.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/index.html
@@ -4,6 +4,7 @@
 {% block titletag %}{% trans "groups" %}{% endblock %}
 {% block bodyclass %}menu-groups{% endblock %}
 {% block extra_js %}
+    {{ block.super }}
     <script>
         window.headerSearch = {
             url: "{% url 'wagtailusers_groups_index' %}",

--- a/wagtail/wagtailusers/templates/wagtailusers/users/index.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/index.html
@@ -4,6 +4,7 @@
 {% block titletag %}{% trans "Users" %}{% endblock %}
 {% block bodyclass %}menu-users{% endblock %}
 {% block extra_js %}
+    {{ block.super }}
     <script>
         window.headerSearch = {
             url: "{% url 'wagtailusers_users_index' %}",


### PR DESCRIPTION
The specific use case is if you'd globally like to inject css and js
then you can via django overextending `wagtailadmin/base.html`.

Why not just use the `insert_editor_js` and `insert_editor_css` hooks?

- It isn't global across the admin, only on editor pages.
- In my opinion, this stuff shouldn't be in python.

Why not overextend `wagtailadmin/admin_base.html`?

- Can't use super if you need to insert code after loading vendor libs
  like jquery, bootstrap etc but before extra_js. So you then have to
  copy-paste a ton of code from the parent - this goes against the
  open closed principle and should be avoided.

So given the current build process for front end admin/dashboard assets
in wagtail, this seems like the best solution for now.