### PR TITLE
Add update_required flag to search backends

### DIFF
--- a/wagtail/wagtailsearch/backends/__init__.py
+++ b/wagtail/wagtailsearch/backends/__init__.py
@@ -77,12 +77,12 @@ def get_search_backend(backend='default', **kwargs):
     return backend_cls(params)
 
 
-def get_search_backends(with_auto_update=False):
+def get_search_backends(for_auto_update=False):
     if hasattr(settings, 'WAGTAILSEARCH_BACKENDS'):
         for backend, params in settings.WAGTAILSEARCH_BACKENDS.items():
             backend_class = get_search_backend(backend)
 
-            if with_auto_update:
+            if for_auto_update:
                 # Skip backends where auto update has been disabled by the user
                 if params.get('AUTO_UPDATE', True) is False:
                     continue

--- a/wagtail/wagtailsearch/backends/__init__.py
+++ b/wagtail/wagtailsearch/backends/__init__.py
@@ -80,9 +80,17 @@ def get_search_backend(backend='default', **kwargs):
 def get_search_backends(with_auto_update=False):
     if hasattr(settings, 'WAGTAILSEARCH_BACKENDS'):
         for backend, params in settings.WAGTAILSEARCH_BACKENDS.items():
-            if with_auto_update and params.get('AUTO_UPDATE', True) is False:
-                continue
+            backend_class = get_search_backend(backend)
 
-            yield get_search_backend(backend)
+            if with_auto_update:
+                # Skip backends where auto update has been disabled by the user
+                if params.get('AUTO_UPDATE', True) is False:
+                    continue
+
+                # Skip backends where auto update is not necessary
+                if not backend_class.update_required:
+                    continue
+
+            yield backend_class
     else:
         yield get_search_backend('default')

--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -173,6 +173,9 @@ class BaseSearchResults(object):
 
 
 class BaseSearch(object):
+    # Set this to False if this backend doesn't require updating
+    update_required = True
+
     def __init__(self, params):
         pass
 

--- a/wagtail/wagtailsearch/backends/db.py
+++ b/wagtail/wagtailsearch/backends/db.py
@@ -70,6 +70,8 @@ class DBSearchResults(BaseSearchResults):
 
 
 class DBSearch(BaseSearch):
+    update_required = False
+
     def __init__(self, params):
         super(DBSearch, self).__init__(params)
 

--- a/wagtail/wagtailsearch/management/commands/update_index.py
+++ b/wagtail/wagtailsearch/management/commands/update_index.py
@@ -22,6 +22,11 @@ class Command(BaseCommand):
         # Get backend
         backend = get_search_backend(backend_name)
 
+        # Skip backend if it doesn't require update
+        if not backend.update_required:
+            self.stdout.write("Skipping. Backend doesn't require update")
+            return
+
         # Reset the index
         self.stdout.write(backend_name + ": Reseting index")
         backend.reset_index()

--- a/wagtail/wagtailsearch/signal_handlers.py
+++ b/wagtail/wagtailsearch/signal_handlers.py
@@ -20,7 +20,7 @@ def post_save_signal_handler(instance, **kwargs):
     indexed_instance = get_indexed_instance(instance)
 
     if indexed_instance:
-        for backend in get_search_backends(with_auto_update=True):
+        for backend in get_search_backends(for_auto_update=True):
             backend.add(indexed_instance)
 
 
@@ -28,13 +28,13 @@ def post_delete_signal_handler(instance, **kwargs):
     indexed_instance = get_indexed_instance(instance)
 
     if indexed_instance:
-        for backend in get_search_backends(with_auto_update=True):
+        for backend in get_search_backends(for_auto_update=True):
             backend.delete(indexed_instance)
 
 
 def register_signal_handlers():
     # Don't register signal handlers if there are no backends that need them
-    if not list(get_search_backends(with_auto_update=True)):
+    if not list(get_search_backends(for_auto_update=True)):
         return
 
     # Loop through list and register signal handlers for each one

--- a/wagtail/wagtailsearch/signal_handlers.py
+++ b/wagtail/wagtailsearch/signal_handlers.py
@@ -33,6 +33,10 @@ def post_delete_signal_handler(instance, **kwargs):
 
 
 def register_signal_handlers():
+    # Don't register signal handlers if there are no backends that need them
+    if not list(get_search_backends(with_auto_update=True)):
+        return
+
     # Loop through list and register signal handlers for each one
     for model in get_indexed_models():
         post_save.connect(post_save_signal_handler, sender=model)

--- a/wagtail/wagtailsearch/tests/dummy_backend.py
+++ b/wagtail/wagtailsearch/tests/dummy_backend.py
@@ -1,0 +1,12 @@
+from wagtail.wagtailsearch.backends.base import BaseSearch
+
+
+class DummySearch(BaseSearch):
+    pass
+
+
+class NoUpdateSearch(BaseSearch):
+    update_required = False
+
+
+SearchBackend = DummySearch

--- a/wagtail/wagtailsearch/tests/test_backends.py
+++ b/wagtail/wagtailsearch/tests/test_backends.py
@@ -10,7 +10,7 @@ from django.core import management
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.tests.search import models
 from wagtail.wagtailsearch.backends import get_search_backend, get_search_backends, InvalidSearchBackendError
-from wagtail.wagtailsearch.backends.db import DBSearch
+from wagtail.wagtailsearch.tests.dummy_backend import DummySearch
 
 
 class BackendTests(WagtailTestUtils):
@@ -134,21 +134,21 @@ class BackendTests(WagtailTestUtils):
 
 @override_settings(
     WAGTAILSEARCH_BACKENDS={
-        'default': {'BACKEND': 'wagtail.wagtailsearch.backends.db'}
+        'default': {'BACKEND': 'wagtail.wagtailsearch.tests.dummy_backend'}
     }
 )
 class TestBackendLoader(TestCase):
     def test_import_by_name(self):
         db = get_search_backend(backend='default')
-        self.assertIsInstance(db, DBSearch)
+        self.assertIsInstance(db, DummySearch)
 
     def test_import_by_path(self):
-        db = get_search_backend(backend='wagtail.wagtailsearch.backends.db')
-        self.assertIsInstance(db, DBSearch)
+        db = get_search_backend(backend='wagtail.wagtailsearch.tests.dummy_backend')
+        self.assertIsInstance(db, DummySearch)
 
     def test_import_by_full_path(self):
-        db = get_search_backend(backend='wagtail.wagtailsearch.backends.db.DBSearch')
-        self.assertIsInstance(db, DBSearch)
+        db = get_search_backend(backend='wagtail.wagtailsearch.tests.dummy_backend.DummySearch')
+        self.assertIsInstance(db, DummySearch)
 
     def test_nonexistent_backend_import(self):
         self.assertRaises(InvalidSearchBackendError, get_search_backend, backend='wagtail.wagtailsearch.backends.doesntexist')
@@ -160,15 +160,15 @@ class TestBackendLoader(TestCase):
         backends = list(get_search_backends())
 
         self.assertEqual(len(backends), 1)
-        self.assertIsInstance(backends[0], DBSearch)
+        self.assertIsInstance(backends[0], DummySearch)
 
     @override_settings(
         WAGTAILSEARCH_BACKENDS={
             'default': {
-                'BACKEND': 'wagtail.wagtailsearch.backends.db'
+                'BACKEND': 'wagtail.wagtailsearch.tests.dummy_backend'
             },
             'another-backend': {
-                'BACKEND': 'wagtail.wagtailsearch.backends.db'
+                'BACKEND': 'wagtail.wagtailsearch.tests.dummy_backend'
             },
         }
     )
@@ -185,8 +185,22 @@ class TestBackendLoader(TestCase):
 
     @override_settings(
         WAGTAILSEARCH_BACKENDS={
+            # This backend has the update_required flag set to false
+            'no-auto-update': {
+                'BACKEND': 'wagtail.wagtailsearch.tests.dummy_backend.NoUpdateSearch'
+            },
+        }
+    )
+    def test_get_search_backends_with_auto_update_update_not_required(self):
+        backends = list(get_search_backends(with_auto_update=True))
+
+        # Backends where the update_required flag is set to False should be filtered out
+        self.assertEqual(len(backends), 0)
+
+    @override_settings(
+        WAGTAILSEARCH_BACKENDS={
             'default': {
-                'BACKEND': 'wagtail.wagtailsearch.backends.db',
+                'BACKEND': 'wagtail.wagtailsearch.tests.dummy_backend',
                 'AUTO_UPDATE': False,
             },
         }
@@ -199,7 +213,7 @@ class TestBackendLoader(TestCase):
     @override_settings(
         WAGTAILSEARCH_BACKENDS={
             'default': {
-                'BACKEND': 'wagtail.wagtailsearch.backends.db',
+                'BACKEND': 'wagtail.wagtailsearch.tests.dummy_backend',
                 'AUTO_UPDATE': False,
             },
         }

--- a/wagtail/wagtailsearch/tests/test_backends.py
+++ b/wagtail/wagtailsearch/tests/test_backends.py
@@ -177,8 +177,8 @@ class TestBackendLoader(TestCase):
 
         self.assertEqual(len(backends), 2)
 
-    def test_get_search_backends_with_auto_update(self):
-        backends = list(get_search_backends(with_auto_update=True))
+    def test_get_search_backends_for_auto_update(self):
+        backends = list(get_search_backends(for_auto_update=True))
 
         # Auto update is the default
         self.assertEqual(len(backends), 1)
@@ -191,8 +191,8 @@ class TestBackendLoader(TestCase):
             },
         }
     )
-    def test_get_search_backends_with_auto_update_update_not_required(self):
-        backends = list(get_search_backends(with_auto_update=True))
+    def test_get_search_backends_for_auto_update_update_not_required(self):
+        backends = list(get_search_backends(for_auto_update=True))
 
         # Backends where the update_required flag is set to False should be filtered out
         self.assertEqual(len(backends), 0)
@@ -205,8 +205,8 @@ class TestBackendLoader(TestCase):
             },
         }
     )
-    def test_get_search_backends_with_auto_update_disabled(self):
-        backends = list(get_search_backends(with_auto_update=True))
+    def test_get_search_backends_for_auto_update_disabled(self):
+        backends = list(get_search_backends(for_auto_update=True))
 
         self.assertEqual(len(backends), 0)
 


### PR DESCRIPTION
The database backend doesn't require updating using signal handlers or update_index. Signal handlers still get registered and update_index still pretends to do something.

This PR makes Wagtail no longer register signal handlers if no backends require auto update (or if auto update has been disabled in all indexes by the user).