### PR TITLE
Adding Willow to the dev requirements 

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ mock>=1.0.0
 python-dateutil>=2.2
 pytz>=2014.7
 Pillow>=2.7.0
+Willow==0.2
 
 # For coverage and PEP8 linting
 coverage>=3.7.0


### PR DESCRIPTION
Adding Willow to the dev requirements  as the runtests.py script errors without it installed.