### PR TITLE
Drone: Build from prebuilt database

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,6 +2,7 @@ image: wagtail-ci
 script:
  - python3.4 setup.py install
  - pip3.4 install -r requirements-dev.txt
- - python3.4 runtests.py --keepdb
+ - env
+ - python3.4 runtests.py --keepdb -v3
 environment:
  - DATABASE_NAME=/base-dbs/wagtail.v1.0.sqlite

--- a/.drone.yml
+++ b/.drone.yml
@@ -2,4 +2,6 @@ image: wagtail-ci
 script:
  - python3.4 setup.py install
  - pip3.4 install -r requirements-dev.txt
- - python3.4 runtests.py
+ - python3.4 runtests.py --keepdb
+environment:
+ - DATABASE_NAME=/base-dbs/wagtail.v1.0.sqlite


### PR DESCRIPTION
Should speed up builds significantly.

I've created a sqlite database based on the schema used in Wagtail 1.0 and built it into the base image (lives at: ``/base-dbs/wagtail.v1.0.sqlite``).