### PR TITLE
Use QuerySet based search API (and deprecate old search APIs)

### DIFF
--- a/wagtail/wagtailadmin/taggable.py
+++ b/wagtail/wagtailadmin/taggable.py
@@ -21,7 +21,7 @@ class TagSearchable(index.Indexed):
 
     @property
     def get_tags(self):
-        return ' '.join([tag.name for tag in self.prefetched_tags()])
+        return ' '.join([tag.name for tag in self.tags.all()])
 
     @classmethod
     def get_indexed_objects(cls):
@@ -47,12 +47,6 @@ class TagSearchable(index.Indexed):
                 return paginator.page(paginator.num_pages)
         else:
             return results
-
-    def prefetched_tags(self):
-        # a hack to do the equivalent of self.tags.all() but take advantage of the
-        # prefetch_related('tagged_items__tag') in the above search method, so that we can
-        # output the list of tags on each result without doing a further query
-        return [tagged_item.tag for tagged_item in self.tagged_items.all()]
 
     @classmethod
     def popular_tags(cls):

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -692,7 +692,7 @@ def search(request):
 
             # page number
             p = request.GET.get("p", 1)
-            pages = Page.search(q, show_unpublished=True, search_title_only=True, prefetch_related=['content_type'])
+            pages = Page.objects.all().prefetch_related('content_type').search(q, fields=['title'])
 
             # Pagination
             paginator = Paginator(pages, 20)

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -637,6 +637,12 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
 
     @classmethod
     def search(cls, query_string, show_unpublished=False, search_title_only=False, extra_filters={}, prefetch_related=[], path=None):
+        # This is deprecated use Page.objects.search() instead
+        warnings.warn(
+            "The Page.search() method is deprecated. "
+            "Please use the Page.objects.search() method instead.",
+            RemovedInWagtail13Warning, stacklevel=2)
+
         # Filters
         filters = extra_filters.copy()
         if not show_unpublished:

--- a/wagtail/wagtailcore/query.py
+++ b/wagtail/wagtailcore/query.py
@@ -202,7 +202,7 @@ class PageQuerySet(MP_NodeQuerySet):
         This runs a search query on all the pages in the QuerySet
         """
         search_backend = get_search_backend(backend)
-        return search_backend.search(query_string, self, fields=None)
+        return search_backend.search(query_string, self, fields=fields)
 
     def unpublish(self):
         """

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -16,6 +16,16 @@ from django.utils.encoding import python_2_unicode_compatible
 from wagtail.wagtailadmin.taggable import TagSearchable
 from wagtail.wagtailadmin.utils import get_object_usage
 from wagtail.wagtailsearch import index
+from wagtail.wagtailsearch.backends import get_search_backend
+
+
+class DocumentQuerySet(models.QuerySet):
+    def search(self, query_string, fields=None, backend='default'):
+        """
+        This runs a search query on all the documents in the QuerySet
+        """
+        search_backend = get_search_backend(backend)
+        return search_backend.search(query_string, self, fields=fields)
 
 
 @python_2_unicode_compatible
@@ -26,6 +36,8 @@ class Document(models.Model, TagSearchable):
     uploaded_by_user = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_('Uploaded by user'), null=True, blank=True, editable=False)
 
     tags = TaggableManager(help_text=None, blank=True, verbose_name=_('Tags'))
+
+    objects = DocumentQuerySet.as_manager()
 
     search_fields = TagSearchable.search_fields + (
         index.FilterField('uploaded_by_user'),

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -25,6 +25,16 @@ from wagtail.wagtaildocs import models
 from wagtail.wagtaildocs.rich_text import DocumentLinkHandler
 
 
+class TestImageQuerySet(TestCase):
+    def test_search_method(self):
+        # Make a test document
+        document = models.Document.objects.create(title="Test document")
+
+        # Search for it
+        results = models.Document.objects.search("Test")
+        self.assertEqual(list(results), [document])
+
+
 class TestDocumentPermissions(TestCase):
     def setUp(self):
         # Create some user accounts for testing permissions

--- a/wagtail/wagtaildocs/views/chooser.py
+++ b/wagtail/wagtaildocs/views/chooser.py
@@ -41,27 +41,22 @@ def chooser(request):
         if searchform.is_valid():
             q = searchform.cleaned_data['q']
 
-            # page number
-            p = request.GET.get("p", 1)
-
-            documents = Document.search(q, results_per_page=10, prefetch_tags=True)
-
+            documents = Document.objects.search(q)
             is_searching = True
-
         else:
             documents = Document.objects.order_by('-created_at')
-
-            p = request.GET.get("p", 1)
-            paginator = Paginator(documents, 10)
-
-            try:
-                documents = paginator.page(p)
-            except PageNotAnInteger:
-                documents = paginator.page(1)
-            except EmptyPage:
-                documents = paginator.page(paginator.num_pages)
-
             is_searching = False
+
+        # Pagination
+        p = request.GET.get("p", 1)
+        paginator = Paginator(documents, 10)
+
+        try:
+            documents = paginator.page(p)
+        except PageNotAnInteger:
+            documents = paginator.page(1)
+        except EmptyPage:
+            documents = paginator.page(paginator.num_pages)
 
         return render(request, "wagtaildocs/chooser/results.html", {
             'documents': documents,

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -38,11 +38,7 @@ def index(request):
         form = SearchForm(request.GET, placeholder=_("Search documents"))
         if form.is_valid():
             query_string = form.cleaned_data['q']
-            if not request.user.has_perm('wagtaildocs.change_document'):
-                # restrict to the user's own documents
-                documents = Document.search(query_string, filters={'uploaded_by_user_id': request.user.id})
-            else:
-                documents = Document.search(query_string)
+            documents = documents.search(query_string)
     else:
         form = SearchForm(placeholder=_("Search documents"))
 

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -29,6 +29,7 @@ from unidecode import unidecode
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailadmin.taggable import TagSearchable
 from wagtail.wagtailsearch import index
+from wagtail.wagtailsearch.backends import get_search_backend
 from wagtail.wagtailimages.rect import Rect
 from wagtail.wagtailimages.exceptions import InvalidFilterSpecError
 from wagtail.wagtailadmin.utils import get_object_usage
@@ -41,6 +42,15 @@ class SourceImageIOError(IOError):
     Custom exception to distinguish IOErrors that were thrown while opening the source image
     """
     pass
+
+
+class ImageQuerySet(models.QuerySet):
+    def search(self, query_string, fields=None, backend='default'):
+        """
+        This runs a search query on all the images in the QuerySet
+        """
+        search_backend = get_search_backend(backend)
+        return search_backend.search(query_string, self, fields=fields)
 
 
 def get_upload_to(instance, filename):
@@ -76,6 +86,8 @@ class AbstractImage(models.Model, TagSearchable):
     focal_point_height = models.PositiveIntegerField(null=True, blank=True)
 
     file_size = models.PositiveIntegerField(null=True, editable=False)
+
+    objects = ImageQuerySet.as_manager()
 
     def is_stored_locally(self):
         """

--- a/wagtail/wagtailimages/tests/test_models.py
+++ b/wagtail/wagtailimages/tests/test_models.py
@@ -87,6 +87,19 @@ class TestImage(TestCase):
         self.assertFalse(self.image.is_stored_locally())
 
 
+class TestImageQuerySet(TestCase):
+    def test_search_method(self):
+        # Create an image for running tests on
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(),
+        )
+
+        # Search for it
+        results = Image.objects.search("Test")
+        self.assertEqual(list(results), [image])
+
+
 class TestImagePermissions(TestCase):
     def setUp(self):
         # Create some user accounts for testing permissions

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -48,26 +48,22 @@ def chooser(request):
         if searchform.is_valid():
             q = searchform.cleaned_data['q']
 
-            # page number
-            p = request.GET.get("p", 1)
-
-            images = Image.search(q, results_per_page=12, page=p)
-
+            images = Image.objects.search(q)
             is_searching = True
-
         else:
             images = Image.objects.order_by('-created_at')
-            p = request.GET.get("p", 1)
-            paginator = Paginator(images, 12)
-
-            try:
-                images = paginator.page(p)
-            except PageNotAnInteger:
-                images = paginator.page(1)
-            except EmptyPage:
-                images = paginator.page(paginator.num_pages)
-
             is_searching = False
+
+        # Pagination
+        page_number = request.GET.get("p", 1)
+        paginator = Paginator(images, 12)
+
+        try:
+            images = paginator.page(page_number)
+        except PageNotAnInteger:
+            images = paginator.page(1)
+        except EmptyPage:
+            images = paginator.page(paginator.num_pages)
 
         return render(request, "wagtailimages/chooser/results.html", {
             'images': images,

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -40,11 +40,7 @@ def index(request):
         if form.is_valid():
             query_string = form.cleaned_data['q']
 
-            if not request.user.has_perm('wagtailimages.change_image'):
-                # restrict to the user's own images
-                images = Image.search(query_string, filters={'uploaded_by_user_id': request.user.id})
-            else:
-                images = Image.search(query_string)
+            images = images.search(query_string)
     else:
         form = SearchForm(placeholder=_("Search images"))
 


### PR DESCRIPTION
Also, fixes #1 

Previously, the Page, Image and Document models all had a search method. This pull request deprecates these and replaces them with a QuerySet method instead.

The main advantage of the QuerySet API is filtering is much easier.

Before:
```
images = Image.search(query_string, filters={'uploaded_by_user_id': request.user.id})
```
After:
```
Images = Images.objects.filter(uploaded_by_user=request.user).search(query_string)
```

Any Image, Document or Page QuerySet can be searched like this which should improve code reuse