### PR TITLE
Support indexing tags in wagtailsearch

### DIFF
--- a/wagtail/tests/search/migrations/0002_searchtest_tags.py
+++ b/wagtail/tests/search/migrations/0002_searchtest_tags.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+import taggit.managers
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taggit', '0001_initial'),
+        ('searchtests', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='searchtest',
+            name='tags',
+            field=taggit.managers.TaggableManager(through='taggit.TaggedItem', verbose_name='Tags', to='taggit.Tag', help_text='A comma-separated list of tags.'),
+        ),
+    ]

--- a/wagtail/tests/search/models.py
+++ b/wagtail/tests/search/models.py
@@ -1,5 +1,7 @@
 from django.db import models
 
+from taggit.managers import TaggableManager
+
 from wagtail.wagtailsearch import index
 
 
@@ -8,9 +10,11 @@ class SearchTest(models.Model, index.Indexed):
     content = models.TextField()
     live = models.BooleanField(default=False)
     published_date = models.DateField(null=True)
+    tags = TaggableManager()
 
     search_fields = [
         index.SearchField('title', partial_match=True),
+        index.SearchField('tags'),
         index.SearchField('content'),
         index.SearchField('callable_indexed_field'),
         index.FilterField('title'),

--- a/wagtail/wagtailadmin/taggable.py
+++ b/wagtail/wagtailadmin/taggable.py
@@ -16,12 +16,8 @@ class TagSearchable(index.Indexed):
 
     search_fields = (
         index.SearchField('title', partial_match=True, boost=10),
-        index.SearchField('get_tags', partial_match=True, boost=10)
+        index.SearchField('tags', partial_match=True, boost=10)
     )
-
-    @property
-    def get_tags(self):
-        return ' '.join([tag.name for tag in self.prefetched_tags()])
 
     @classmethod
     def get_indexed_objects(cls):

--- a/wagtail/wagtailsearch/backends/db.py
+++ b/wagtail/wagtailsearch/backends/db.py
@@ -1,5 +1,7 @@
 from django.db import models
 
+from taggit.managers import TaggableManager
+
 from wagtail.wagtailsearch.backends.base import BaseSearch, BaseSearchQuery, BaseSearchResults
 
 
@@ -43,7 +45,11 @@ class DBSearchQuery(BaseSearchQuery):
                 for field_name in fields:
                     # Check if the field exists (this will filter out indexed callables)
                     try:
-                        model._meta.get_field(field_name)
+                        field = model._meta.get_field(field_name)
+
+                        if isinstance(field, TaggableManager):
+                            # TODO: Searching on tags in database backend not currently supported
+                            continue
                     except models.fields.FieldDoesNotExist:
                         continue
 

--- a/wagtail/wagtailsearch/index.py
+++ b/wagtail/wagtailsearch/index.py
@@ -1,6 +1,8 @@
 from django.db import models
 from django.apps import apps
 
+from taggit.managers import _TaggableManager
+
 
 class Indexed(object):
     @classmethod
@@ -114,13 +116,21 @@ class BaseField(object):
         try:
             field = self.get_field(obj.__class__)
             value = field._get_val_from_obj(obj)
+
+            if isinstance(value, _TaggableManager):
+                value = [tag.name for tag in value.all()]
+
             if hasattr(field, 'get_searchable_content'):
                 value = field.get_searchable_content(value)
+
             return value
+
         except models.fields.FieldDoesNotExist:
             value = getattr(obj, self.field_name, None)
+
             if hasattr(value, '__call__'):
                 value = value()
+
             return value
 
     def __repr__(self):

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -542,6 +542,7 @@ class TestElasticSearchMapping(TestCase):
         # Create ES document
         self.obj = models.SearchTest(title="Hello")
         self.obj.save()
+        self.obj.tags.add("a tag")
 
     def test_get_document_type(self):
         self.assertEqual(self.es_mapping.get_document_type(), 'searchtests_searchtest')
@@ -562,7 +563,8 @@ class TestElasticSearchMapping(TestCase):
                     'title': {'type': 'string', 'include_in_all': True, 'index_analyzer': 'edgengram_analyzer'},
                     'title_filter': {'index': 'not_analyzed', 'type': 'string', 'include_in_all': False},
                     'content': {'type': 'string', 'include_in_all': True},
-                    'callable_indexed_field': {'type': 'string', 'include_in_all': True}
+                    'callable_indexed_field': {'type': 'string', 'include_in_all': True},
+                    'tags': {'type': 'string', 'include_in_all': True}
                 }
             }
         }
@@ -587,6 +589,7 @@ class TestElasticSearchMapping(TestCase):
             'title_filter': 'Hello',
             'callable_indexed_field': 'Callable',
             'content': '',
+            'tags': ['a tag'],
         }
 
         self.assertDictEqual(document, expected_result)
@@ -614,6 +617,7 @@ class TestElasticSearchMappingInheritance(TestCase):
         # Create ES document
         self.obj = models.SearchTestChild(title="Hello", subtitle="World")
         self.obj.save()
+        self.obj.tags.add("a tag")
 
     def test_get_document_type(self):
         self.assertEqual(self.es_mapping.get_document_type(), 'searchtests_searchtest_searchtests_searchtestchild')
@@ -639,7 +643,8 @@ class TestElasticSearchMappingInheritance(TestCase):
                     'title': {'type': 'string', 'include_in_all': True, 'index_analyzer': 'edgengram_analyzer'},
                     'title_filter': {'index': 'not_analyzed', 'type': 'string', 'include_in_all': False},
                     'content': {'type': 'string', 'include_in_all': True},
-                    'callable_indexed_field': {'type': 'string', 'include_in_all': True}
+                    'callable_indexed_field': {'type': 'string', 'include_in_all': True},
+                    'tags': {'type': 'string', 'include_in_all': True}
                 }
             }
         }
@@ -678,6 +683,7 @@ class TestElasticSearchMappingInheritance(TestCase):
             'title_filter': 'Hello',
             'callable_indexed_field': 'Callable',
             'content': '',
+            'tags': ['a tag'],
         }
 
         self.assertDictEqual(document, expected_result)


### PR DESCRIPTION
This pull request adds basic support for indexing tags in wagtailsearch. They are indexed as a list of strings in the elasticsearch backend.

This makes indexing tag fields simpler for developers and should make it possible to filter results by tags.

TODO:
 - [ ] Look into automatically running ``prefetch_related`` when bulk indexing a model with a tags field
 - [ ] ~~Test filtering on tags~~
 - [ ] ~~Enable filtering on tags while searching in ``contrib.wagtailapi``~~