### PR TITLE
Tweaks to how root pages are rendered in explorer

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list.html
@@ -24,7 +24,11 @@
                     {% endblock %}
                 </td>
                 <td class="updated" valign="bottom">{% if parent_page.latest_revision_created_at %}<div class="human-readable-date" title="{{ parent_page.latest_revision_created_at|date:"d M Y H:i" }}">{{ parent_page.latest_revision_created_at|timesince }} ago</div>{% endif %}</td>
-                <td class="type" valign="bottom">{{ parent_page.content_type.model_class.get_verbose_name }}</td>
+                <td class="type" valign="bottom">
+                    {% if not parent_page.is_root %}
+                        {{ parent_page.content_type.model_class.get_verbose_name }}
+                    {% endif %}
+                </td>
                 <td class="status" valign="bottom">
                     {% if not parent_page.is_root %}
                         {% include "wagtailadmin/shared/page_status_tag.html" with page=parent_page %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_choose.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_choose.html
@@ -5,7 +5,7 @@ Expects a variable 'page', the page instance.
 {% endcomment %}
 
 <h2>
-    {% if page.can_choose %}
+    {% if page.can_choose and not page.is_root %}
         <a class="choose-page" href="#{{ page.id }}" data-id="{{ page.id }}" data-title="{{ page.title }}" data-url="{{ page.url }}" data-edit-url="{% url 'wagtailadmin_pages_edit' page.id %}">{{ page.title }}</a>
     {% else %}
         {{ page.title }}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_choose.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_choose.html
@@ -5,7 +5,7 @@ Expects a variable 'page', the page instance.
 {% endcomment %}
 
 <h2>
-    {% if page.can_choose and not page.is_root %}
+    {% if page.can_choose %}
         <a class="choose-page" href="#{{ page.id }}" data-id="{{ page.id }}" data-title="{{ page.title }}" data-url="{{ page.url }}" data-edit-url="{% url 'wagtailadmin_pages_edit' page.id %}">{{ page.title }}</a>
     {% else %}
         {{ page.title }}

--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -42,11 +42,10 @@ def browse(request, parent_page_id=None):
     if not is_searching:
         if parent_page_id:
             parent_page = get_object_or_404(Page, id=parent_page_id)
-            parent_page.can_choose = issubclass(parent_page.specific_class, desired_class)
         else:
             parent_page = Page.get_first_root_node()
-            parent_page.can_choose = False
 
+        parent_page.can_choose = issubclass(parent_page.specific_class, desired_class) and not parent_page.is_root()
         search_form = SearchForm()
         pages = parent_page.get_children()
 

--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -46,7 +46,7 @@ def browse(request, parent_page_id=None):
         else:
             parent_page = Page.get_first_root_node()
             parent_page.can_choose = False
-        
+
         search_form = SearchForm()
         pages = parent_page.get_children()
 

--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -42,10 +42,11 @@ def browse(request, parent_page_id=None):
     if not is_searching:
         if parent_page_id:
             parent_page = get_object_or_404(Page, id=parent_page_id)
+            parent_page.can_choose = issubclass(parent_page.specific_class, desired_class)
         else:
             parent_page = Page.get_first_root_node()
-
-        parent_page.can_choose = issubclass(parent_page.specific_class, desired_class)
+            parent_page.can_choose = False
+        
         search_form = SearchForm()
         pages = parent_page.get_children()
 


### PR DESCRIPTION
a) to prevent misleading ability to choose root as a page link
b) to prevent page type of root being displayed