### PR TITLE
Atomic index rebuilding for Elasticsearch

### DIFF
--- a/docs/topics/search/backends.rst
+++ b/docs/topics/search/backends.rst
@@ -41,6 +41,20 @@ The ``AUTO_UPDATE`` setting allows you to disable this on a per-index basis:
 If you have disabled auto update, you must run the :ref:`update_index` command on a regular basis to keep the index in sync with the database.
 
 
+``ATOMIC_REBUILD``
+==================
+
+.. versionadded:: 1.1
+
+By default (when using the Elasticsearch backend), when the ``update_index`` command is run, Wagtail deletes the index and rebuilds it from scratch. This causes the search engine to not return results until the rebuild is complete and is also risky as you can't rollback if an error occurs.
+
+Setting the ``ATOMIC_REBUILD`` setting to ``True`` makes Wagtail rebuild into a separate index while keep the old index active until the new one is fully built. When the rebuild is finished, the indexes are swapped atomically and the old index is deleted.
+
+.. warning:: Experimental feature
+
+    This feature is currently experimental. Please use it with caution.
+
+
 ``BACKEND``
 ===========
 

--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -176,6 +176,9 @@ class BaseSearch(object):
     def __init__(self, params):
         pass
 
+    def get_rebuilder(self):
+        return None
+
     def reset_index(self):
         raise NotImplementedError
 

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -11,6 +11,51 @@ from wagtail.wagtailsearch.backends.base import BaseSearch, BaseSearchQuery, Bas
 from wagtail.wagtailsearch.index import SearchField, FilterField, class_is_indexed
 
 
+INDEX_SETTINGS = {
+    'settings': {
+        'analysis': {
+            'analyzer': {
+                'ngram_analyzer': {
+                    'type': 'custom',
+                    'tokenizer': 'lowercase',
+                    'filter': ['asciifolding', 'ngram']
+                },
+                'edgengram_analyzer': {
+                    'type': 'custom',
+                    'tokenizer': 'lowercase',
+                    'filter': ['asciifolding', 'edgengram']
+                }
+            },
+            'tokenizer': {
+                'ngram_tokenizer': {
+                    'type': 'nGram',
+                    'min_gram': 3,
+                    'max_gram': 15,
+                },
+                'edgengram_tokenizer': {
+                    'type': 'edgeNGram',
+                    'min_gram': 2,
+                    'max_gram': 15,
+                    'side': 'front'
+                }
+            },
+            'filter': {
+                'ngram': {
+                    'type': 'nGram',
+                    'min_gram': 3,
+                    'max_gram': 15
+                },
+                'edgengram': {
+                    'type': 'edgeNGram',
+                    'min_gram': 1,
+                    'max_gram': 15
+                }
+            }
+        }
+    }
+}
+
+
 class ElasticSearchMapping(object):
     TYPE_MAP = {
         'AutoField': 'integer',
@@ -352,51 +397,6 @@ class ElasticSearch(BaseSearch):
             self.es.indices.delete(self.es_index)
         except NotFoundError:
             pass
-
-        # Settings
-        INDEX_SETTINGS = {
-            'settings': {
-                'analysis': {
-                    'analyzer': {
-                        'ngram_analyzer': {
-                            'type': 'custom',
-                            'tokenizer': 'lowercase',
-                            'filter': ['asciifolding', 'ngram']
-                        },
-                        'edgengram_analyzer': {
-                            'type': 'custom',
-                            'tokenizer': 'lowercase',
-                            'filter': ['asciifolding', 'edgengram']
-                        }
-                    },
-                    'tokenizer': {
-                        'ngram_tokenizer': {
-                            'type': 'nGram',
-                            'min_gram': 3,
-                            'max_gram': 15,
-                        },
-                        'edgengram_tokenizer': {
-                            'type': 'edgeNGram',
-                            'min_gram': 2,
-                            'max_gram': 15,
-                            'side': 'front'
-                        }
-                    },
-                    'filter': {
-                        'ngram': {
-                            'type': 'nGram',
-                            'min_gram': 3,
-                            'max_gram': 15
-                        },
-                        'edgengram': {
-                            'type': 'edgeNGram',
-                            'min_gram': 1,
-                            'max_gram': 15
-                        }
-                    }
-                }
-            }
-        }
 
         # Create new index
         self.es.indices.create(self.es_index, INDEX_SETTINGS)

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -458,7 +458,7 @@ class ElasticSearchAtomicIndexRebuilder(ElasticSearchIndexRebuilder):
             self.es.indices.put_alias(name=self.alias_name, index=self.index_name)
 
             # Delete old index
-            # es.indicies.get_alias can return multiple indicies. Delete them all
+            # es.indices.get_alias can return multiple indices. Delete them all
             if old_index:
                 try:
                     self.es.indices.delete(','.join(old_index))


### PR DESCRIPTION
This pull request implements an "atomic index rebuilder" that can be enabled on a per-index basis with the "ATOMIC_REBUILD" option in ``WAGTAILSEARCH_BACKENDS``.

The "basic" index rebuilder (current behaviour) deletes the index and reloads everything again from scratch. This leads to users having to use a half-populated index during the rebuild and can also cause problems like #1320.

The new "atomic" index rebuilder creates a separate index and loads everything into that. The old index will continue to be used until the new one is fully rebuilt. When the rebuild is complete, the indices are atomically swapped then the old index is deleted. This is implemented using Elasticsearch aliases.

https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html

Index aliases are supported by searchly (and of course, self-hosted instances too) so this shouldn't be an issue for most users.

This feature is switched off by default and should be considered "experimental" for a couple of releases so we can make sure any issues are properly ironed out.