### PR TITLE
Added support for indexing relations in Elasticsearch

### DIFF
--- a/docs/topics/search/indexing.rst
+++ b/docs/topics/search/indexing.rst
@@ -111,6 +111,53 @@ Options
 These are added to the search index but are not used for full-text searches. Instead, they allow you to run filters on your search results.
 
 
+``index.RelatedFields``
+-----------------------
+
+This allows you to index fields from related objects. It works on all types of related fields, including their reverse accessors.
+
+For example, if we have a book that has a ``ForeignKey`` to its author, we can nest the authors ``name`` and ``date_of_birth`` fields inside the book:
+
+.. code-block:: python
+
+    class Book(models.Model, indexed.Indexed):
+        ...
+
+        search_fields = [
+            index.SearchField('title'),
+            index.FilterField('published_date'),
+
+            index.RelatedFields('author', [
+                index.SearchField('name'),
+                index.FilterField('date_of_birth'),
+            ]),
+        ]
+
+This will allow you to search for books with their author's name.
+
+It works the other way around as well, you can index an author's books allowing an author to be searched for with the titles of books they've published:
+
+.. code-block:: python
+
+    class Author(models.Model, indexed.Indexed):
+        ...
+
+        search_fields = [
+            index.SearchField('name'),
+            index.FilterField('date_of_birth'),
+
+            index.RelatedFields('books', [
+                index.SearchField('title'),
+                index.FilterField('published_date'),
+            ]),
+        ]
+
+.. topic:: Filtering on ``index.RelatedFields``
+
+    It's not possible to filter on any ``index.FilterFields`` within ``index.RelatedFields`` using the ``QuerySet`` API. Although, the fields are indexed so it should be possible to use them by querying Elasticsearch manually.
+
+    Filtering on ``index.RelatedFields`` with the ``QuerySet`` API is planned for a future release of Wagtail.
+
 .. _wagtailsearch_indexing_callable_fields:
 
 Indexing callables and other attributes

--- a/wagtail/tests/search/migrations/0002_searchtest_tags.py
+++ b/wagtail/tests/search/migrations/0002_searchtest_tags.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+import taggit.managers
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taggit', '0001_initial'),
+        ('searchtests', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='searchtest',
+            name='tags',
+            field=taggit.managers.TaggableManager(through='taggit.TaggedItem', verbose_name='Tags', to='taggit.Tag', help_text='A comma-separated list of tags.'),
+        ),
+    ]

--- a/wagtail/tests/search/migrations/0003_searchtestchild_page.py
+++ b/wagtail/tests/search/migrations/0003_searchtestchild_page.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0001_squashed_0016_change_page_url_path_to_text_field'),
+        ('searchtests', '0002_searchtest_tags'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='searchtestchild',
+            name='page',
+            field=models.ForeignKey(to='wagtailcore.Page', blank=True, null=True),
+        ),
+    ]

--- a/wagtail/tests/search/models.py
+++ b/wagtail/tests/search/models.py
@@ -1,5 +1,7 @@
 from django.db import models
 
+from taggit.managers import TaggableManager
+
 from wagtail.wagtailsearch import index
 
 
@@ -8,9 +10,14 @@ class SearchTest(models.Model, index.Indexed):
     content = models.TextField()
     live = models.BooleanField(default=False)
     published_date = models.DateField(null=True)
+    tags = TaggableManager()
 
     search_fields = [
         index.SearchField('title', partial_match=True),
+        index.RelatedFields('tags', [
+            index.SearchField('name', partial_match=True),
+            index.FilterField('slug'),
+        ]),
         index.SearchField('content'),
         index.SearchField('callable_indexed_field'),
         index.FilterField('title'),

--- a/wagtail/tests/search/models.py
+++ b/wagtail/tests/search/models.py
@@ -57,8 +57,14 @@ class SearchTest(models.Model, index.Indexed):
 class SearchTestChild(SearchTest):
     subtitle = models.CharField(max_length=255, null=True, blank=True)
     extra_content = models.TextField()
+    page = models.ForeignKey('wagtailcore.Page', null=True, blank=True)
 
     search_fields = SearchTest.search_fields + [
         index.SearchField('subtitle', partial_match=True),
         index.SearchField('extra_content'),
+        index.RelatedFields('page', [
+            index.SearchField('title', partial_match=True),
+            index.SearchField('search_description'),
+            index.FilterField('live'),
+        ]),
     ]

--- a/wagtail/wagtailadmin/taggable.py
+++ b/wagtail/wagtailadmin/taggable.py
@@ -18,12 +18,10 @@ class TagSearchable(index.Indexed):
 
     search_fields = (
         index.SearchField('title', partial_match=True, boost=10),
-        index.SearchField('get_tags', partial_match=True, boost=10)
+        index.RelatedFields('tags', [
+            index.SearchField('name', partial_match=True, boost=10),
+        ]),
     )
-
-    @property
-    def get_tags(self):
-        return ' '.join([tag.name for tag in self.tags.all()])
 
     @classmethod
     def get_indexed_objects(cls):

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -9,10 +9,11 @@ from django.utils.six.moves.urllib.parse import urlparse
 from elasticsearch import Elasticsearch, NotFoundError
 from elasticsearch.helpers import bulk
 
+from django.db import models
 from django.utils.crypto import get_random_string
 
 from wagtail.wagtailsearch.backends.base import BaseSearch, BaseSearchQuery, BaseSearchResults
-from wagtail.wagtailsearch.index import SearchField, FilterField, class_is_indexed
+from wagtail.wagtailsearch.index import SearchField, FilterField, RelatedFields, class_is_indexed
 from wagtail.utils.deprecation import RemovedInWagtail14Warning
 
 
@@ -95,25 +96,35 @@ class ElasticSearchMapping(object):
         return self.model.indexed_get_content_type()
 
     def get_field_mapping(self, field):
-        mapping = {'type': self.TYPE_MAP.get(field.get_type(self.model), 'string')}
+        if isinstance(field, RelatedFields):
+            mapping = {'type': 'nested', 'properties': {}}
 
-        if isinstance(field, SearchField):
-            if field.boost:
-                mapping['boost'] = field.boost
+            for sub_field in field.fields:
+                sub_field_name, sub_field_mapping = self.get_field_mapping(sub_field)
+                mapping['properties'][sub_field_name] = sub_field_mapping
 
-            if field.partial_match:
-                mapping['index_analyzer'] = 'edgengram_analyzer'
+            return field.get_index_name(self.model), mapping
+        else:
+            mapping = {'type': self.TYPE_MAP.get(field.get_type(self.model), 'string')}
 
-            mapping['include_in_all'] = True
-        elif isinstance(field, FilterField):
-            mapping['index'] = 'not_analyzed'
-            mapping['include_in_all'] = False
+            if isinstance(field, SearchField):
+                if field.boost:
+                    mapping['boost'] = field.boost
 
-        if 'es_extra' in field.kwargs:
-            for key, value in field.kwargs['es_extra'].items():
-                mapping[key] = value
+                if field.partial_match:
+                    mapping['index_analyzer'] = 'edgengram_analyzer'
 
-        return field.get_index_name(self.model), mapping
+                mapping['include_in_all'] = True
+
+            elif isinstance(field, FilterField):
+                mapping['index'] = 'not_analyzed'
+                mapping['include_in_all'] = False
+
+            if 'es_extra' in field.kwargs:
+                for key, value in field.kwargs['es_extra'].items():
+                    mapping[key] = value
+
+            return field.get_index_name(self.model), mapping
 
     def get_mapping(self):
         # Make field list
@@ -136,12 +147,41 @@ class ElasticSearchMapping(object):
     def get_document_id(self, obj):
         return obj.indexed_get_toplevel_content_type() + ':' + str(obj.pk)
 
+    def _get_nested_document(self, fields, obj):
+        doc = {}
+        partials = []
+        model = type(obj)
+
+        for field in fields:
+            value = field.get_value(obj)
+            doc[field.get_index_name(model)] = value
+
+            # Check if this field should be added into _partials
+            if isinstance(field, SearchField) and field.partial_match:
+                partials.append(value)
+
+        return doc, partials
+
     def get_document(self, obj):
         # Build document
         doc = dict(pk=str(obj.pk), content_type=self.model.indexed_get_content_type())
         partials = []
         for field in self.model.get_search_fields():
             value = field.get_value(obj)
+
+            if isinstance(field, RelatedFields):
+                if isinstance(value, models.Manager):
+                    nested_docs = []
+
+                    for nested_obj in value.all():
+                        nested_doc, extra_partials = self._get_nested_document(field.fields, nested_obj)
+                        nested_docs.append(nested_doc)
+                        partials.extend(extra_partials)
+
+                    value = nested_docs
+                elif isinstance(value, models.Model):
+                    value, extra_partials = self._get_nested_document(field.fields, value)
+                    partials.extend(extra_partials)
 
             doc[field.get_index_name(self.model)] = value
 

--- a/wagtail/wagtailsearch/index.py
+++ b/wagtail/wagtailsearch/index.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.db.models.fields.related import RelatedField
 from django.apps import apps
 
 
@@ -136,3 +137,21 @@ class SearchField(BaseField):
 
 class FilterField(BaseField):
     suffix = '_filter'
+
+
+class RelatedFields(object):
+    def __init__(self, field_name, fields):
+        self.field_name = field_name
+        self.fields = fields
+
+    def get_index_name(self, cls):
+        return self.field_name
+
+    def get_field(self, cls):
+        return cls._meta.get_field(self.field_name)
+
+    def get_value(self, obj):
+        field = self.get_field(obj.__class__)
+
+        if isinstance(field, RelatedField):
+            return getattr(obj, self.field_name)

--- a/wagtail/wagtailsearch/index.py
+++ b/wagtail/wagtailsearch/index.py
@@ -166,6 +166,16 @@ class RelatedFields(object):
             return getattr(obj, self.field_name)
 
     def select_on_queryset(self, queryset):
+        """
+        This method runs either prefetch_related or select_related on the queryset
+        to improve indexing speed of the relation.
+
+        It decides which method to call based on the number of related objects:
+         - single (eg ForeignKey, OneToOne), it runs select_related
+         - multiple (eg ManyToMany, reverse ForeignKey) it runs prefetch_related
+
+        This optimisation currently doesn't support reverse relations on Django 1.7.
+        """
         try:
             field = self.get_field(queryset.model)
         except FieldDoesNotExist:

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -682,7 +682,7 @@ class TestElasticSearchMapping(TestCase):
                             'name': {'type': 'string', 'include_in_all': True, 'index_analyzer': 'edgengram_analyzer'},
                             'slug_filter': {'index': 'not_analyzed', 'type': 'string', 'include_in_all': False},
                         }
-                    }
+                    },
                 }
             }
         }
@@ -742,7 +742,7 @@ class TestElasticSearchMappingInheritance(TestCase):
         self.es_mapping = ElasticSearchMapping(models.SearchTestChild)
 
         # Create ES document
-        self.obj = models.SearchTestChild(title="Hello", subtitle="World")
+        self.obj = models.SearchTestChild(title="Hello", subtitle="World", page_id=1)
         self.obj.save()
         self.obj.tags.add("a tag")
 
@@ -760,6 +760,14 @@ class TestElasticSearchMappingInheritance(TestCase):
                     # New
                     'extra_content': {'type': 'string', 'include_in_all': True},
                     'subtitle': {'type': 'string', 'include_in_all': True, 'index_analyzer': 'edgengram_analyzer'},
+                    'page': {
+                        'type': 'nested',
+                        'properties': {
+                            'title': {'type': 'string', 'include_in_all': True, 'index_analyzer': 'edgengram_analyzer'},
+                            'search_description': {'type': 'string', 'include_in_all': True},
+                            'live_filter': {'index': 'not_analyzed', 'type': 'boolean', 'include_in_all': False},
+                        }
+                    },
 
                     # Inherited
                     'pk': {'index': 'not_analyzed', 'type': 'string', 'store': 'yes', 'include_in_all': False},
@@ -777,7 +785,7 @@ class TestElasticSearchMappingInheritance(TestCase):
                             'name': {'type': 'string', 'include_in_all': True, 'index_analyzer': 'edgengram_analyzer'},
                             'slug_filter': {'index': 'not_analyzed', 'type': 'string', 'include_in_all': False},
                         }
-                    }
+                    },
                 }
             }
         }
@@ -803,13 +811,18 @@ class TestElasticSearchMappingInheritance(TestCase):
             # New
             'extra_content': '',
             'subtitle': 'World',
+            'page': {
+                'title': 'Root',
+                'search_description': '',
+                'live_filter': True,
+            },
 
             # Changed
             'content_type': 'searchtests_searchtest_searchtests_searchtestchild',
 
             # Inherited
             'pk': str(self.obj.pk),
-            '_partials': ['Hello', 'World', 'a tag'],
+            '_partials': ['Hello', 'Root', 'World', 'a tag'],
             'live_filter': False,
             'published_date_filter': None,
             'title': 'Hello',

--- a/wagtail/wagtailsearch/tests/test_related_fields.py
+++ b/wagtail/wagtailsearch/tests/test_related_fields.py
@@ -1,0 +1,92 @@
+import unittest
+
+import django
+from django.test import TestCase
+
+from wagtail.wagtailsearch import index
+from wagtail.tests.search.models import SearchTest, SearchTestChild
+from wagtail.tests.testapp.models import ManyToManyBlogPage, Advert
+
+
+class TestSelectOnQuerySet(TestCase):
+    def test_select_on_queryset_with_foreign_key(self):
+        fields = index.RelatedFields('page', [
+            index.SearchField('title'),
+        ])
+
+        queryset = fields.select_on_queryset(SearchTestChild.objects.all())
+
+        # ForeignKey should be select_related
+        self.assertFalse(queryset._prefetch_related_lookups)
+        self.assertIn('page', queryset.query.select_related)
+
+    def test_select_on_queryset_with_one_to_one(self):
+        fields = index.RelatedFields('searchtest_ptr', [
+            index.SearchField('title'),
+        ])
+
+        queryset = fields.select_on_queryset(SearchTestChild.objects.all())
+
+        # OneToOneField should be select_related
+        self.assertFalse(queryset._prefetch_related_lookups)
+        self.assertIn('searchtest_ptr', queryset.query.select_related)
+
+    def test_select_on_queryset_with_many_to_many(self):
+        fields = index.RelatedFields('adverts', [
+            index.SearchField('title'),
+        ])
+
+        queryset = fields.select_on_queryset(ManyToManyBlogPage.objects.all())
+
+        # ManyToManyField should be prefetch_related
+        self.assertIn('adverts', queryset._prefetch_related_lookups)
+        self.assertFalse(queryset.query.select_related)
+
+    @unittest.skipIf(django.VERSION < (1, 8), "Reverse relations not supported on Django 1.7")
+    def test_select_on_queryset_with_reverse_foreign_key(self):
+        fields = index.RelatedFields('categories', [
+            index.RelatedFields('category', [
+                index.SearchField('name')
+            ])
+        ])
+
+        queryset = fields.select_on_queryset(ManyToManyBlogPage.objects.all())
+
+        # reverse ForeignKey should be prefetch_related
+        self.assertIn('categories', queryset._prefetch_related_lookups)
+        self.assertFalse(queryset.query.select_related)
+
+    @unittest.skipIf(django.VERSION < (1, 8), "Reverse relations not supported on Django 1.7")
+    def test_select_on_queryset_with_reverse_one_to_one(self):
+        fields = index.RelatedFields('searchtestchild', [
+            index.SearchField('subtitle'),
+        ])
+
+        queryset = fields.select_on_queryset(SearchTest.objects.all())
+
+        # reverse OneToOneField should be select_related
+        self.assertFalse(queryset._prefetch_related_lookups)
+        self.assertIn('searchtestchild', queryset.query.select_related)
+
+    @unittest.skipIf(django.VERSION < (1, 8), "Reverse relations not supported on Django 1.7")
+    def test_select_on_queryset_with_reverse_many_to_many(self):
+        fields = index.RelatedFields('manytomanyblogpage', [
+            index.SearchField('title'),
+        ])
+
+        queryset = fields.select_on_queryset(Advert.objects.all())
+
+        # reverse ManyToManyField should be prefetch_related
+        self.assertIn('manytomanyblogpage', queryset._prefetch_related_lookups)
+        self.assertFalse(queryset.query.select_related)
+
+    def test_select_on_queryset_with_taggable_manager(self):
+        fields = index.RelatedFields('tags', [
+            index.SearchField('name'),
+        ])
+
+        queryset = fields.select_on_queryset(SearchTestChild.objects.all())
+
+        # Tags should be prefetch_related
+        self.assertIn('tags', queryset._prefetch_related_lookups)
+        self.assertFalse(queryset.query.select_related)


### PR DESCRIPTION
This pull request implements the new syntax as descibed in #459 which allows related objects to be indexed in Elasticsearch.

This is useful for indexing tags, "child objects", foreign keys, etc. A relation can be indexed from both sides.

It uses Elasticsearch's "nested type": https://www.elastic.co/guide/en/elasticsearch/reference/1.6/mapping-nested-type.html

This doesn't implement the ability to filter search results across relationships. ``FilterField``s can be indexed but you'll need to come up with a custom query to use them for the moment. This will be implemented in a later pull request.