### PR TITLE
Rebuild search indices in chunks

### DIFF
--- a/docs/topics/search/backends.rst
+++ b/docs/topics/search/backends.rst
@@ -41,6 +41,20 @@ The ``AUTO_UPDATE`` setting allows you to disable this on a per-index basis:
 If you have disabled auto update, you must run the :ref:`update_index` command on a regular basis to keep the index in sync with the database.
 
 
+``ATOMIC_REBUILD``
+==================
+
+.. versionadded:: 1.1
+
+By default (when using the Elasticsearch backend), when the ``update_index`` command is run, Wagtail deletes the index and rebuilds it from scratch. This causes the search engine to not return results until the rebuild is complete and is also risky as you can't rollback if an error occurs.
+
+Setting the ``ATOMIC_REBUILD`` setting to ``True`` makes Wagtail rebuild into a separate index while keep the old index active until the new one is fully built. When the rebuild is finished, the indexes are swapped atomically and the old index is deleted.
+
+.. warning:: Experimental feature
+
+    This feature is currently experimental. Please use it with caution.
+
+
 ``BACKEND``
 ===========
 

--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -176,6 +176,9 @@ class BaseSearch(object):
     def __init__(self, params):
         pass
 
+    def get_rebuilder(self):
+        return None
+
     def reset_index(self):
         raise NotImplementedError
 

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -11,6 +11,51 @@ from wagtail.wagtailsearch.backends.base import BaseSearch, BaseSearchQuery, Bas
 from wagtail.wagtailsearch.index import SearchField, FilterField, class_is_indexed
 
 
+INDEX_SETTINGS = {
+    'settings': {
+        'analysis': {
+            'analyzer': {
+                'ngram_analyzer': {
+                    'type': 'custom',
+                    'tokenizer': 'lowercase',
+                    'filter': ['asciifolding', 'ngram']
+                },
+                'edgengram_analyzer': {
+                    'type': 'custom',
+                    'tokenizer': 'lowercase',
+                    'filter': ['asciifolding', 'edgengram']
+                }
+            },
+            'tokenizer': {
+                'ngram_tokenizer': {
+                    'type': 'nGram',
+                    'min_gram': 3,
+                    'max_gram': 15,
+                },
+                'edgengram_tokenizer': {
+                    'type': 'edgeNGram',
+                    'min_gram': 2,
+                    'max_gram': 15,
+                    'side': 'front'
+                }
+            },
+            'filter': {
+                'ngram': {
+                    'type': 'nGram',
+                    'min_gram': 3,
+                    'max_gram': 15
+                },
+                'edgengram': {
+                    'type': 'edgeNGram',
+                    'min_gram': 1,
+                    'max_gram': 15
+                }
+            }
+        }
+    }
+}
+
+
 class ElasticSearchMapping(object):
     TYPE_MAP = {
         'AutoField': 'integer',
@@ -352,51 +397,6 @@ class ElasticSearch(BaseSearch):
             self.es.indices.delete(self.es_index)
         except NotFoundError:
             pass
-
-        # Settings
-        INDEX_SETTINGS = {
-            'settings': {
-                'analysis': {
-                    'analyzer': {
-                        'ngram_analyzer': {
-                            'type': 'custom',
-                            'tokenizer': 'lowercase',
-                            'filter': ['asciifolding', 'ngram']
-                        },
-                        'edgengram_analyzer': {
-                            'type': 'custom',
-                            'tokenizer': 'lowercase',
-                            'filter': ['asciifolding', 'edgengram']
-                        }
-                    },
-                    'tokenizer': {
-                        'ngram_tokenizer': {
-                            'type': 'nGram',
-                            'min_gram': 3,
-                            'max_gram': 15,
-                        },
-                        'edgengram_tokenizer': {
-                            'type': 'edgeNGram',
-                            'min_gram': 2,
-                            'max_gram': 15,
-                            'side': 'front'
-                        }
-                    },
-                    'filter': {
-                        'ngram': {
-                            'type': 'nGram',
-                            'min_gram': 3,
-                            'max_gram': 15
-                        },
-                        'edgengram': {
-                            'type': 'edgeNGram',
-                            'min_gram': 1,
-                            'max_gram': 15
-                        }
-                    }
-                }
-            }
-        }
 
         # Create new index
         self.es.indices.create(self.es_index, INDEX_SETTINGS)

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -458,7 +458,7 @@ class ElasticSearchAtomicIndexRebuilder(ElasticSearchIndexRebuilder):
             self.es.indices.put_alias(name=self.alias_name, index=self.index_name)
 
             # Delete old index
-            # es.indicies.get_alias can return multiple indicies. Delete them all
+            # es.indices.get_alias can return multiple indices. Delete them all
             if old_index:
                 try:
                     self.es.indices.delete(','.join(old_index))

--- a/wagtail/wagtailsearch/management/commands/update_index.py
+++ b/wagtail/wagtailsearch/management/commands/update_index.py
@@ -2,6 +2,7 @@ from optparse import make_option
 
 from django.core.management.base import BaseCommand
 from django.conf import settings
+from django.db import transaction
 
 from wagtail.wagtailsearch.index import get_indexed_models
 from wagtail.wagtailsearch.backends import get_search_backend
@@ -46,44 +47,13 @@ class Command(BaseCommand):
             rebuilder.add_model(model)
 
             # Add items (1000 at a time)
-            i = 0
             count = 0
-            self.stdout.write(INDENT, ending='')
-            while True:
-                # Get next batch of items
-                items = list(queryset[i * 1000:][:1000])
-                i += 1
+            for chunk in self.progress(self.queryset_chunks(queryset)):
+                rebuilder.add_items(model, chunk)
+                count += len(chunk)
 
-                # Exit loop if there are no items left to index
-                if not items:
-                    self.stdout.write('')
-                    self.stdout.write(INDENT + "Indexed %d %s" % (
-                        count,
-                        model._meta.verbose_name_plural,
-                    ))
-                    self.stdout.write('')
-
-                    break
-
-                # Add the items
-                rebuilder.add_items(model, items)
-
-                # Increment count
-                count += len(items)
-
-                # Print a progress dot
-                self.stdout.write('.', ending='')
-
-                # Print space after every 10 dots
-                if i % 10 == 0:
-                    self.stdout.write(' ', ending='')
-
-                # Print newline after every 50 dots
-                if i % 50 == 0:
-                    self.stdout.write('')
-                    self.stdout.write(INDENT, ending='')
-
-                self.stdout.flush()
+            self.stdout.write(INDENT + "Indexed %d %s" % (
+                count, model._meta.verbose_name_plural))
 
         # Finish rebuild
         self.stdout.write(backend_name + ": Finishing rebuild")
@@ -116,3 +86,44 @@ class Command(BaseCommand):
         # Update backends
         for backend_name in backend_names:
             self.update_backend(backend_name, object_list)
+
+    def progress(self, iterable, gap=10, new_line=5, indent=INDENT):
+        """
+        Print a progress meter while iterating over an iterable. Use it as part
+        of a ``for`` loop::
+
+            for item in self.progress(big_long_list):
+                self.do_expensive_computation(item)
+
+        A ``.`` character is printed for every value in the iterable,
+        a space every ``gap`` items, and a new line every ``new_line`` gaps.
+        Each line of output is prefixed with ``indent``
+        """
+        self.stdout.write(indent, ending='')
+        for i, value in enumerate(iterable, start=1):
+            yield value
+            self.stdout.write('.', ending='')
+            if i % (gap * new_line) == 0:
+                self.stdout.write('')
+                self.stdout.write(indent, ending='')
+            elif i % gap == 0:
+                self.stdout.write(' ', ending='')
+            self.stdout.flush()
+        self.stdout.write('')
+
+    # Atomic so the count of models doesnt change as it is iterated
+    @transaction.atomic
+    def queryset_chunks(self, qs, chunk_size=1000):
+        """
+        Yield a queryset in chunks of at most ``chunk_size``. The chunk yeilded
+        will be a list, not a queryset. Iterating over the chunks is done in a
+        transaction so that the order and count of items in the queryset
+        remains stable.
+        """
+        i = 0
+        while True:
+            items = list(qs[i * chunk_size:][:chunk_size])
+            if not items:
+                break
+            yield items
+            i += 1

--- a/wagtail/wagtailsearch/management/commands/update_index.py
+++ b/wagtail/wagtailsearch/management/commands/update_index.py
@@ -93,7 +93,7 @@ class Command(BaseCommand):
         Print a progress meter while iterating over an iterable. Use it as part
         of a ``for`` loop::
 
-            for item in self.progress(big_long_list):
+            for item in self.print_iter_progress(big_long_list):
                 self.do_expensive_computation(item)
 
         A ``.`` character is printed for every value in the iterable,
@@ -116,7 +116,7 @@ class Command(BaseCommand):
     @transaction.atomic
     def queryset_chunks(self, qs, chunk_size=1000):
         """
-        Yield a queryset in chunks of at most ``chunk_size``. The chunk yeilded
+        Yield a queryset in chunks of at most ``chunk_size``. The chunk yielded
         will be a list, not a queryset. Iterating over the chunks is done in a
         transaction so that the order and count of items in the queryset
         remains stable.


### PR DESCRIPTION
Wagtail currently reindexes each model in one go. If a model is very large, this can quick fill up the RAM. There is also no indication of progress

This pull request makes Wagtail index 1000 objects at a time and output a '.' in the console for each 1000 objects indexed.