### PR TITLE
WIP: Swappable permissions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,7 +25,7 @@ Changelog
  * Allowed user page permissions proxy to be customized by swapping out
 
 
-1.0 (xx.xx.xxxx)
+1.0 (16.07.2015)
 ~~~~~~~~~~~~~~~~
 
  * Added StreamField, a model field for freeform page content

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,9 +22,10 @@ Changelog
  * Fix: Text areas in the non-default tab of the page editor now resize to the correct height
  * Fix: Tabs in "insert link" modal in the rich text editor no longer disappear (Tim Heap)
  * Fix: H2 elements in rich text fields were accidentally given a click() binding when put insite a collapsible multi field panel
+ * Allowed user page permissions proxy to be customized by swapping out
 
 
-1.0 (16.07.2015)
+1.0 (xx.xx.xxxx)
 ~~~~~~~~~~~~~~~~
 
  * Added StreamField, a model field for freeform page content

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -58,6 +58,7 @@ Contributors
 * Mitchel Cabuloy
 * Piet Delport
 * Tom Christie
+* Richard Mitchell (Isotoma Limited)
 
 Translators
 ===========

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -1,5 +1,5 @@
 Authors
-================
+=======
 
 * Matthew Westcott matthew.westcott@torchbox.com twitter: @gasmanic
 * David Cranwell david.cranwell@torchbox.com twitter: @davecranwell

--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -239,6 +239,15 @@ Private Pages
 This is the path to the Django template which will be used to display the "password required" form when a user accesses a private page. For more details, see the :ref:`private_pages` documentation.
 
 
+Authorization
+-------------
+
+.. code-block:: python
+
+  WAGTAILCORE_USER_PERMISSIONS_PROXY = 'wagtail.wagtailcore.models.UserPagePermissionsProxy'
+
+This is the permissions proxy class used by Wagtail to determine user permissions on pages.
+
 Other Django Settings Used by Wagtail
 -------------------------------------
 

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -6,7 +6,7 @@ from django.contrib.humanize.templatetags.humanize import intcomma
 from django.template.defaultfilters import stringfilter
 
 from wagtail.wagtailcore import hooks
-from wagtail.wagtailcore.models import get_navigation_menu_items, UserPagePermissionsProxy, PageViewRestriction
+from wagtail.wagtailcore.models import get_navigation_menu_items, get_user_permissions, PageViewRestriction
 from wagtail.wagtailcore.utils import camelcase_to_underscore, escape_script
 from wagtail.wagtailcore.utils import cautious_slugify as _cautious_slugify
 from wagtail.wagtailadmin.menu import admin_menu
@@ -92,10 +92,10 @@ def page_permissions(context, page):
     Sets the variable 'page_perms' to a PagePermissionTester object that can be queried to find out
     what actions the current logged-in user can perform on the given page.
     """
-    # Create a UserPagePermissionsProxy object to represent the user's global permissions, and
+    # Create a user permissions proxy object to represent the user's global permissions, and
     # cache it in the context for the duration of the page request, if one does not exist already
     if 'user_page_permissions' not in context:
-        context['user_page_permissions'] = UserPagePermissionsProxy(context['request'].user)
+        context['user_page_permissions'] = get_user_permissions(context['request'].user)
 
     # Now retrieve a PagePermissionTester from it, specific to the given page
     return context['user_page_permissions'].for_page(page)

--- a/wagtail/wagtailadmin/views/account.py
+++ b/wagtail/wagtailadmin/views/account.py
@@ -11,11 +11,11 @@ from django.views.decorators.cache import never_cache
 from wagtail.wagtailadmin import forms
 from wagtail.wagtailusers.forms import NotificationPreferencesForm
 from wagtail.wagtailusers.models import UserProfile
-from wagtail.wagtailcore.models import UserPagePermissionsProxy
+from wagtail.wagtailcore.models import get_user_permissions
 
 
 def account(request):
-    user_perms = UserPagePermissionsProxy(request.user)
+    user_perms = get_user_permissions(request.user)
     show_notification_preferences = user_perms.can_edit_pages() or user_perms.can_publish_pages()
 
     return render(request, 'wagtailadmin/account/account.html', {

--- a/wagtail/wagtailadmin/views/home.py
+++ b/wagtail/wagtailadmin/views/home.py
@@ -2,7 +2,7 @@ from django.shortcuts import render
 from django.conf import settings
 
 from wagtail.wagtailcore import hooks
-from wagtail.wagtailcore.models import PageRevision, UserPagePermissionsProxy
+from wagtail.wagtailcore.models import PageRevision, get_user_permissions
 from wagtail.utils.compat import render_to_string
 
 from wagtail.wagtailadmin.site_summary import SiteSummaryPanel
@@ -30,7 +30,7 @@ class PagesForModerationPanel(object):
 
     def __init__(self, request):
         self.request = request
-        user_perms = UserPagePermissionsProxy(request.user)
+        user_perms = get_user_permissions(request.user)
         self.page_revisions_for_moderation = user_perms.revisions_for_moderation().select_related('page', 'user').order_by('-created_at')
 
     def render(self):

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -13,7 +13,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.six import text_type
 from django.core.serializers.json import DjangoJSONEncoder
 
-from wagtail.wagtailcore.models import Page, Orderable, UserPagePermissionsProxy, get_page_types
+from wagtail.wagtailcore.models import Page, Orderable, get_user_permissions, get_page_types
 from wagtail.wagtailadmin.edit_handlers import FieldPanel
 from wagtail.wagtailadmin.utils import send_mail
 
@@ -121,7 +121,7 @@ def get_forms_for_user(user):
     """
     Return a queryset of form pages that this user is allowed to access the submissions for
     """
-    editable_pages = UserPagePermissionsProxy(user).editable_pages()
+    editable_pages = get_user_permissions(user).editable_pages()
     return editable_pages.filter(content_type__in=get_form_types())
 
 

--- a/wagtail/wagtailusers/forms.py
+++ b/wagtail/wagtailusers/forms.py
@@ -7,7 +7,7 @@ from django.forms.models import inlineformset_factory
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailadmin.widgets import AdminPageChooser
 from wagtail.wagtailusers.models import UserProfile
-from wagtail.wagtailcore.models import UserPagePermissionsProxy, GroupPagePermission
+from wagtail.wagtailcore.models import get_user_permissions, GroupPagePermission
 
 
 User = get_user_model()
@@ -264,7 +264,7 @@ GroupPagePermissionFormSet = inlineformset_factory(
 class NotificationPreferencesForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(NotificationPreferencesForm, self).__init__(*args, **kwargs)
-        user_perms = UserPagePermissionsProxy(self.instance.user)
+        user_perms = get_user_permissions(self.instance.user)
         if not user_perms.can_publish_pages():
             del self.fields['submitted_notifications']
         if not user_perms.can_edit_pages():


### PR DESCRIPTION
Allows the user page permissions proxy implementation to be customized by swapping it out in settings.

This is a workaround for the way Wagtail implements permissions checking. Compare with the ability to add permissions backends in stock Django.

This is a work in progress.