### PR TITLE
Refactor pagination into a helper

### DIFF
--- a/wagtail/contrib/wagtailstyleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/wagtailstyleguide/templates/wagtailstyleguide/base.html
@@ -224,7 +224,7 @@
 
         <section id="pagination">
             <h2>Pagination</h2>
-            {% include "wagtailadmin/shared/pagination_nav.html" with items=fake_pagination linkurl="wagtailadmin_explore" %}
+            {% paginate example_page %}
         </section>
 
         <section id="buttons">

--- a/wagtail/contrib/wagtailstyleguide/views.py
+++ b/wagtail/contrib/wagtailstyleguide/views.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.shortcuts import render
 from django.utils.translation import ugettext as _
+from django.core.paginator import Paginator
 from wagtail.wagtailadmin import messages
 from django.contrib.auth.decorators import permission_required
 
@@ -58,19 +59,11 @@ def index(request):
         messages.button('', _('Edit'))
     ])
 
-    fake_pagination = {
-        'number': 1,
-        'previous_page_number': 1,
-        'next_page_number': 2,
-        'has_previous': True,
-        'has_next': True,
-        'paginator': {
-            'num_pages': 10,
-        },
-    }
+    paginator = Paginator(list(range(100)), 10)
+    page = paginator.page(2)
 
     return render(request, 'wagtailstyleguide/base.html', {
         'search_form': form,
         'example_form': example_form,
-        'fake_pagination': fake_pagination,
+        'example_page': page,
     })

--- a/wagtail/tests/demosite/models.py
+++ b/wagtail/tests/demosite/models.py
@@ -1,12 +1,12 @@
 from datetime import date
 
 from django.db import models
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 from modelcluster.fields import ParentalKey
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from taggit.models import TaggedItemBase
 
+from wagtail.utils.pagination import paginate
 from wagtail.wagtailcore.models import Page, Orderable
 from wagtail.wagtailcore.fields import RichTextField
 from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel, \
@@ -334,15 +334,7 @@ class BlogIndexPage(Page):
         if tag:
             entries = entries.filter(tags__name=tag)
 
-        # Pagination
-        page = request.GET.get('page')
-        paginator = Paginator(entries, 10)  # Show 10 entries per page
-        try:
-            entries = paginator.page(page)
-        except PageNotAnInteger:
-            entries = paginator.page(1)
-        except EmptyPage:
-            entries = paginator.page(paginator.num_pages)
+        paginator, entries = paginate(request, entries, page_key='page', per_page=10)
 
         # Update template context
         context = super(BlogIndexPage, self).get_context(request)

--- a/wagtail/utils/pagination.py
+++ b/wagtail/utils/pagination.py
@@ -1,7 +1,9 @@
 from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 
 
-def paginate(request, items, page_key='p', per_page=20):
+DEFAULT_PAGE_KEY = 'p'
+
+def paginate(request, items, page_key=DEFAULT_PAGE_KEY, per_page=20):
     page = request.GET.get(page_key, 1)
 
     paginator = Paginator(items, per_page)

--- a/wagtail/utils/pagination.py
+++ b/wagtail/utils/pagination.py
@@ -1,0 +1,15 @@
+from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
+
+
+def paginate(request, items, page_key='p', per_page=20):
+    page = request.GET.get(page_key, 1)
+
+    paginator = Paginator(items, per_page)
+    try:
+        page = paginator.page(page)
+    except PageNotAnInteger:
+        page = paginator.page(1)
+    except EmptyPage:
+        page = paginator.page(paginator.num_pages)
+
+    return paginator, page

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/_browse_results.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/_browse_results.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 <h2>{% trans "Explorer" %}</h2>
 {% include "wagtailadmin/shared/breadcrumb.html" with page=parent_page choosing=1 %}
@@ -7,5 +7,5 @@
     {% include "wagtailadmin/pages/listing/_list_choose.html" with allow_navigation=1 orderable=0 pages=pages parent_page=parent_page %}
 
     {% url 'wagtailadmin_choose_page_child' parent_page.id as pagination_base_url %}
-    {% include "wagtailadmin/pages/listing/_pagination.html" with page=pages base_url=pagination_base_url query_params=querystring classnames="navigate-pages" only %}
+    {% paginate pages base_url=pagination_base_url classnames="navigate-pages" %}
 {% endif %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/email_link.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/email_link.html
@@ -1,11 +1,11 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 {% trans "Add an email link" as email_str %}
 {% include "wagtailadmin/shared/header.html" with title=email_str %}
 
 <div class="nice-padding">
     {% include 'wagtailadmin/chooser/_link_types.html' with current='email' %}
 
-    <form action="{% url 'wagtailadmin_choose_page_email_link' %}?{{ querystring }}" method="post">
+    <form action="{% url 'wagtailadmin_choose_page_email_link' %}?{% querystring %}" method="post">
         {% csrf_token %}
         <ul class="fields">
             {% for field in form %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link.html
@@ -1,11 +1,11 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 {% trans "Add an external link" as add_str %}
 {% include "wagtailadmin/shared/header.html" with title=add_str %}
 
 <div class="nice-padding">
     {% include 'wagtailadmin/chooser/_link_types.html' with current='external' %}
 
-    <form action="{% url 'wagtailadmin_choose_page_external_link' %}?{{ querystring }}" method="post">
+    <form action="{% url 'wagtailadmin_choose_page_external_link' %}?{% querystring %}" method="post">
         {% csrf_token %}
         <ul class="fields">
             {% for field in form %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/index.html
@@ -16,8 +16,10 @@
         {% page_permissions parent_page as parent_page_perms %}
         {% include "wagtailadmin/pages/listing/_list_explore.html" with sortable=1 allow_navigation=1 full_width=1 parent_page=parent_page orderable=parent_page_perms.can_reorder_children %}
 
-        {% url 'wagtailadmin_explore' parent_page.id as pagination_base_url %}
-        {% include "wagtailadmin/pages/listing/_pagination.html" with page=pages base_url=pagination_base_url query_params=pagination_query_params only %}
+        {% if do_paginate %}
+            {% url 'wagtailadmin_explore' parent_page.id as pagination_base_url %}
+            {% paginate pages base_url=pagination_base_url %}
+        {% endif %}
     </form>
 {% endblock %}
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_navigation_choose.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_navigation_choose.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 {% comment %}
 Navigation controls for the page listing in 'choose' mode
@@ -6,6 +6,6 @@ Navigation controls for the page listing in 'choose' mode
 
 <td class="{% if allow_navigation and page.can_descend %}children{% endif %}">
     {% if allow_navigation and page.can_descend %}
-        <a href="{% url 'wagtailadmin_choose_page_child' page.id %}?{{ querystring }}" class="icon text-replace icon-arrow-right navigate-pages" title="{% blocktrans with title=page.title %}Explore subpages of '{{ title }}'{% endblocktrans %}">{% trans 'Explore' %}</a>
+        <a href="{% url 'wagtailadmin_choose_page_child' page.id %}?{% querystring page=None %}" class="icon text-replace icon-arrow-right navigate-pages" title="{% blocktrans with title=page.title %}Explore subpages of '{{ title }}'{% endblocktrans %}">{% trans 'Explore' %}</a>
     {% endif %}
 </td>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_pagination.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_pagination.html
@@ -1,32 +1,22 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 {% comment %}
-Pagination include for page listings.
-
-Accepts the following parameters:
-
-page - a django.core.pagination Page object
-base_url - a URL string that we can append ?p=page_number to
-query_params - any additional query params to include in the link
-    (urlencoded but not html-escaped, and without the joining '&')
-classnames - additional classnames to put on the <a> element
-
-TODO: Port all existing uses of shared/_pagination_nav.html over to this new API (extending the API as necessary to cover special cases), so that this can become a replacement for shared/_pagination_nav.html.
+Pagination for page listings. Used by the `{% paginate %}` template tag.
 {% endcomment %}
 
 <div class="pagination">
-    <p>{% blocktrans with page_number=page.number num_pages=page.paginator.num_pages %}
+    <p>{% blocktrans with page_number=page.number num_pages=paginator.num_pages %}
         Page {{ page_number }} of {{ num_pages }}.
     {% endblocktrans %}</p>
     <ul>
         <li class="prev">
             {% if page.has_previous %}
-                <a href="{{ base_url }}?p={{ page.previous_page_number }}{% if query_params %}&amp;{{ query_params }}{% endif %}" class="icon icon-arrow-left {{ classnames }}">{% trans "Previous" %}</a>
+                <a data-page="{{ page.previous_page_number }}" href="{{ base_url }}{% pagination_querystring page.previous_page_number page_key=page_key %}" class="icon icon-arrow-left {{ classnames }}">{% trans "Previous" %}</a>
             {% endif %}
         </li>
         <li class="next">
             {% if page.has_next %}
-                <a href="{{ base_url }}?p={{ page.next_page_number }}{% if query_params %}&amp;{{ query_params }}{% endif %}" class="icon icon-arrow-right-after {{ classnames }}">{% trans 'Next' %}</a>
+                <a data-page="{{ page.next_page_number }}" href="{{ base_url }}{% pagination_querystring page.next_page_number page_key=page_key %}" class="icon icon-arrow-right-after {{ classnames }}">{% trans "Next" %}</a>
             {% endif %}
         </li>
     </ul>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/search_results.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/search_results.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 <div class="nice-padding">
     {% if pages %}
         <h2>
@@ -21,7 +21,7 @@
         {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 allow_navigation=0 %}
 
         {% url 'wagtailadmin_pages_search' as pagination_base_url %}
-        {% include "wagtailadmin/pages/listing/_pagination.html" with page=pages base_url=pagination_base_url query_params=pagination_query_params only %}
+        {% paginate pages base_url=pagination_base_url %}
     {% else %}
         {% if query_string %}
             <p>{% blocktrans %}Sorry, no pages match <em>"{{ query_string }}"</em>{% endblocktrans %}</p>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/usage_results.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/usage_results.html
@@ -1,10 +1,10 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 <div class="nice-padding">
     {% if pages %}
         {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 allow_navigation=0 %}
 
         {% url 'wagtailadmin_pages_type_use' app_name content_type.model as pagination_base_url %}
-        {% include "wagtailadmin/pages/listing/_pagination.html" with page=pages base_url=pagination_base_url only %}
+        {% paginate pages base_url=pagination_base_url %}
     {% else %}
         <p>{% trans 'No pages use' %}<em>"{{ page_class.get_verbose_name }}"</em>.</p>
     {% endif %}

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -9,6 +9,8 @@ from wagtail.wagtailcore.models import get_navigation_menu_items, UserPagePermis
 from wagtail.wagtailcore.utils import camelcase_to_underscore, escape_script
 from wagtail.wagtailadmin.menu import admin_menu
 
+from wagtail.utils.pagination import DEFAULT_PAGE_KEY
+
 
 register = template.Library()
 
@@ -183,3 +185,78 @@ def has_unrendered_errors(bound_field):
     the widget does not support the render_with_errors method
     """
     return bound_field.errors and not hasattr(bound_field.field.widget, 'render_with_errors')
+
+
+@register.simple_tag(takes_context=True)
+def querystring(context, **kwargs):
+    """
+    Print out the current querystring. Any keyword arguments to this template
+    tag will be added to the querystring before it is printed out.
+
+        <a href="/page/{% querystring key='value' %}">
+
+    Will result in something like:
+
+        <a href="/page/?foo=bar&key=value">
+    """
+    request = context['request']
+    querydict = request.GET.copy()
+    # Can't do querydict.update(kwargs), because QueryDict.update() appends to
+    # the list of values, instead of replacing the values.
+    for key, value in kwargs.items():
+        if value is None:
+            # Remove the key if the value is None
+            querydict.pop(key, None)
+        else:
+            # Set the key otherwise
+            querydict[key] = value
+
+    return '?' + querydict.urlencode()
+
+
+@register.simple_tag(takes_context=True)
+def pagination_querystring(context, page_number, page_key=DEFAULT_PAGE_KEY):
+    """
+    Print out a querystring with an updated page number:
+
+        {% if page.has_next_page %}
+            <a href="{% pagination_link page.next_page_number %}">Next page</a>
+        {% endif %}
+    """
+    return querystring(context, **{page_key: page_number})
+
+
+@register.inclusion_tag("wagtailadmin/pages/listing/_pagination.html",
+                        takes_context=True)
+def paginate(context, page, base_url='', page_key=DEFAULT_PAGE_KEY,
+             classnames=''):
+    """
+    Print pagination previous/next links, and the page count. Take the
+    following arguments:
+
+    page
+        The current page of results. This should be a Django pagination `Page`
+        instance
+
+    base_url
+        The base URL of the next/previous page, with no querystring.
+        This is optional, and defaults to the current page by just printing the
+        querystring for the next/previous page.
+
+    page_key
+        The name of the page variable in the query string. Defaults to the same
+        name as used in the :func:`~wagtail.utils.pagination.paginate`
+        function.
+
+    classnames
+        Extra classes to add to the next/previous links.
+    """
+    request = context['request']
+    return {
+        'base_url': base_url,
+        'classnames': classnames,
+        'request': request,
+        'page': page,
+        'page_key': page_key,
+        'paginator': page.paginator,
+    }

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -5,8 +5,7 @@ from django.test import TestCase
 from django.core.urlresolvers import reverse
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
-from django.core import mail
-from django.core.paginator import Paginator
+from django.core import mail, paginator
 from django.db.models.signals import pre_delete, post_delete
 from django.utils import timezone
 
@@ -80,7 +79,7 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
         self.assertEqual(response.context['ordering'], 'ord')
 
         # Pages must not be paginated
-        self.assertNotIsInstance(response.context['pages'], Paginator)
+        self.assertNotIsInstance(response.context['pages'], paginator.Page)
 
     def make_pages(self):
         for i in range(150):

--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -1,22 +1,12 @@
 from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import get_object_or_404, render
 from django.http import Http404
-from django.utils.http import urlencode
 
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 from wagtail.wagtailadmin.forms import SearchForm, ExternalLinkChooserForm, ExternalLinkChooserWithLinkTextForm, EmailLinkChooserForm, EmailLinkChooserWithLinkTextForm
 
 from wagtail.wagtailcore.models import Page
-
-
-def get_querystring(request):
-    return urlencode({
-        'page_type': request.GET.get('page_type', ''),
-        'allow_external_link': request.GET.get('allow_external_link', ''),
-        'allow_email_link': request.GET.get('allow_email_link', ''),
-        'prompt_for_link_text': request.GET.get('prompt_for_link_text', ''),
-    })
 
 
 def browse(request, parent_page_id=None):
@@ -67,7 +57,6 @@ def browse(request, parent_page_id=None):
     return render_modal_workflow(request, 'wagtailadmin/chooser/browse.html', 'wagtailadmin/chooser/browse.js', {
         'allow_external_link': request.GET.get('allow_external_link'),
         'allow_email_link': request.GET.get('allow_email_link'),
-        'querystring': get_querystring(request),
         'parent_page': parent_page,
         'pages': pages,
         'search_form': search_form,
@@ -101,7 +90,6 @@ def search(request, parent_page_id=None):
         shown_pages.append(page)
 
     return render(request, 'wagtailadmin/chooser/_search_results.html', {
-        'querystring': get_querystring(request),
         'searchform': search_form,
         'pages': shown_pages,
     })
@@ -133,7 +121,6 @@ def external_link(request):
         request,
         'wagtailadmin/chooser/external_link.html', 'wagtailadmin/chooser/external_link.js',
         {
-            'querystring': get_querystring(request),
             'allow_email_link': request.GET.get('allow_email_link'),
             'form': form,
         }
@@ -166,7 +153,6 @@ def email_link(request):
         request,
         'wagtailadmin/chooser/email_link.html', 'wagtailadmin/chooser/email_link.js',
         {
-            'querystring': get_querystring(request),
             'allow_external_link': request.GET.get('allow_external_link'),
             'form': form,
         }

--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -1,9 +1,9 @@
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import get_object_or_404, render
 from django.http import Http404
 from django.utils.http import urlencode
 
+from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 from wagtail.wagtailadmin.forms import SearchForm, ExternalLinkChooserForm, ExternalLinkChooserWithLinkTextForm, EmailLinkChooserForm, EmailLinkChooserWithLinkTextForm
 
@@ -43,14 +43,7 @@ def browse(request, parent_page_id=None):
     if desired_class == Page:
         # apply pagination first, since we know that the page listing won't
         # have to be filtered, and that saves us walking the entire list
-        p = request.GET.get('p', 1)
-        paginator = Paginator(pages, ITEMS_PER_PAGE)
-        try:
-            pages = paginator.page(p)
-        except PageNotAnInteger:
-            pages = paginator.page(1)
-        except EmptyPage:
-            pages = paginator.page(paginator.num_pages)
+        paginator, pages = paginate(request, pages, per_page=ITEMS_PER_PAGE)
 
         for page in pages:
             page.can_choose = True
@@ -69,15 +62,7 @@ def browse(request, parent_page_id=None):
             if page.can_choose or page.can_descend:
                 shown_pages.append(page)
 
-        # Apply pagination
-        p = request.GET.get('p', 1)
-        paginator = Paginator(shown_pages, ITEMS_PER_PAGE)
-        try:
-            pages = paginator.page(p)
-        except PageNotAnInteger:
-            pages = paginator.page(1)
-        except EmptyPage:
-            pages = paginator.page(paginator.num_pages)
+        paginator, pages = paginate(request, shown_pages, per_page=ITEMS_PER_PAGE)
 
     return render_modal_workflow(request, 'wagtailadmin/chooser/browse.html', 'wagtailadmin/chooser/browse.js', {
         'allow_external_link': request.GET.get('allow_external_link'),

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -43,12 +43,12 @@ def index(request, parent_page_id=None):
         ordering = '-latest_revision_created_at'
 
     # Pagination
-    if ordering != 'ord':
-        ordering_no_minus = ordering
-        if ordering_no_minus.startswith('-'):
-            ordering_no_minus = ordering[1:]
+    # Don't paginate if sorting by page order - all pages must be shown to
+    # allow drag-and-drop reordering
+    do_paginate = ordering != 'ord'
+    if do_paginate:
+        ordering_no_minus = ordering.lstrip('-')
         pages = pages.order_by(ordering).annotate(null_position=Count(ordering_no_minus)).order_by('-null_position', ordering)
-
         paginator, pages = paginate(request, pages, per_page=50)
 
     return render(request, 'wagtailadmin/pages/index.html', {
@@ -56,6 +56,7 @@ def index(request, parent_page_id=None):
         'ordering': ordering,
         'pagination_query_params': "ordering=%s" % ordering,
         'pages': pages,
+        'do_paginate': do_paginate,
     })
 
 

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -2,7 +2,6 @@ from django.http import Http404, HttpResponse
 from django.shortcuts import render, redirect, get_object_or_404
 from django.core.exceptions import ValidationError, PermissionDenied
 from django.contrib.contenttypes.models import ContentType
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.urlresolvers import reverse
 from django.utils import timezone
 from django.utils.translation import ugettext as _
@@ -11,6 +10,7 @@ from django.views.decorators.http import require_GET, require_POST
 from django.views.decorators.vary import vary_on_headers
 from django.db.models import Count
 
+from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.edit_handlers import TabbedInterface, ObjectList
 from wagtail.wagtailadmin.forms import SearchForm, CopyForm
 from wagtail.wagtailadmin.utils import send_notification
@@ -49,14 +49,7 @@ def index(request, parent_page_id=None):
             ordering_no_minus = ordering[1:]
         pages = pages.order_by(ordering).annotate(null_position=Count(ordering_no_minus)).order_by('-null_position', ordering)
 
-        p = request.GET.get('p', 1)
-        paginator = Paginator(pages, 50)
-        try:
-            pages = paginator.page(p)
-        except PageNotAnInteger:
-            pages = paginator.page(1)
-        except EmptyPage:
-            pages = paginator.page(paginator.num_pages)
+        paginator, pages = paginate(request, pages, per_page=50)
 
     return render(request, 'wagtailadmin/pages/index.html', {
         'parent_page': parent_page,
@@ -93,8 +86,6 @@ def content_type_use(request, content_type_app_name, content_type_model_name):
     except ContentType.DoesNotExist:
         raise Http404
 
-    p = request.GET.get("p", 1)
-
     page_class = content_type.model_class()
 
     # page_class must be a Page type and not some other random model
@@ -103,14 +94,7 @@ def content_type_use(request, content_type_app_name, content_type_model_name):
 
     pages = page_class.objects.all()
 
-    paginator = Paginator(pages, 10)
-
-    try:
-        pages = paginator.page(p)
-    except PageNotAnInteger:
-        pages = paginator.page(1)
-    except EmptyPage:
-        pages = paginator.page(paginator.num_pages)
+    paginator, pages = paginate(request, pages, per_page=10)
 
     return render(request, 'wagtailadmin/pages/content_type_use.html', {
         'pages': pages,
@@ -690,18 +674,8 @@ def search(request):
         if form.is_valid():
             q = form.cleaned_data['q']
 
-            # page number
-            p = request.GET.get("p", 1)
             pages = Page.search(q, show_unpublished=True, search_title_only=True, prefetch_related=['content_type'])
-
-            # Pagination
-            paginator = Paginator(pages, 20)
-            try:
-                pages = paginator.page(p)
-            except PageNotAnInteger:
-                pages = paginator.page(1)
-            except EmptyPage:
-                pages = paginator.page(paginator.num_pages)
+            paginator, pages = paginate(request, pages)
     else:
         form = SearchForm()
 

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -1,11 +1,11 @@
 from django.shortcuts import render, redirect, get_object_or_404
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.contrib.auth.decorators import permission_required
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 from django.core.urlresolvers import reverse
 
+from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailsearch.backends import get_search_backends
 from wagtail.wagtailadmin import messages
@@ -47,15 +47,7 @@ def index(request):
         form = SearchForm(placeholder=_("Search documents"))
 
     # Pagination
-    p = request.GET.get('p', 1)
-    paginator = Paginator(documents, 20)
-
-    try:
-        documents = paginator.page(p)
-    except PageNotAnInteger:
-        documents = paginator.page(1)
-    except EmptyPage:
-        documents = paginator.page(paginator.num_pages)
+    paginator, documents = paginate(request, documents)
 
     # Create response
     if request.is_ajax():
@@ -174,16 +166,7 @@ def delete(request, document_id):
 def usage(request, document_id):
     doc = get_object_or_404(Document, id=document_id)
 
-    # Pagination
-    p = request.GET.get('p', 1)
-    paginator = Paginator(doc.get_usage(), 20)
-
-    try:
-        used_by = paginator.page(p)
-    except PageNotAnInteger:
-        used_by = paginator.page(1)
-    except EmptyPage:
-        used_by = paginator.page(paginator.num_pages)
+    paginator, used_by = paginate(request, doc.get_usage())
 
     return render(request, "wagtaildocs/documents/usage.html", {
         'document': doc,

--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -2,30 +2,21 @@ import datetime
 
 import csv
 
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.utils.encoding import smart_str
 
+from wagtail.utils.pagination import paginate
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailforms.models import FormSubmission, get_forms_for_user
 from wagtail.wagtailforms.forms import SelectDateForm
 
 
 def index(request):
-    p = request.GET.get("p", 1)
-
     form_pages = get_forms_for_user(request.user)
 
-    paginator = Paginator(form_pages, 20)
-
-    try:
-        form_pages = paginator.page(p)
-    except PageNotAnInteger:
-        form_pages = paginator.page(1)
-    except EmptyPage:
-        form_pages = paginator.page(paginator.num_pages)
+    paginator, form_pages = paginate(request, form_pages)
 
     return render(request, 'wagtailforms/index.html', {
         'form_pages': form_pages,
@@ -78,15 +69,7 @@ def list_submissions(request, page_id):
             writer.writerow(data_row)
         return response
 
-    p = request.GET.get('p', 1)
-    paginator = Paginator(submissions, 20)
-
-    try:
-        submissions = paginator.page(p)
-    except PageNotAnInteger:
-        submissions = paginator.page(1)
-    except EmptyPage:
-        submissions = paginator.page(paginator.num_pages)
+    paginator, submissions = paginate(request, submissions)
 
     data_headings = [label for name, label in data_fields]
     data_rows = []

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -2,9 +2,9 @@ import json
 
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404, render
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.contrib.auth.decorators import permission_required
 
+from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailsearch.backends import get_search_backends
@@ -57,15 +57,7 @@ def chooser(request):
 
         else:
             images = Image.objects.order_by('-created_at')
-            p = request.GET.get("p", 1)
-            paginator = Paginator(images, 10)
-
-            try:
-                images = paginator.page(p)
-            except PageNotAnInteger:
-                images = paginator.page(1)
-            except EmptyPage:
-                images = paginator.page(paginator.num_pages)
+            paginator, images = paginate(request, images, per_page=10)
 
             is_searching = False
 
@@ -79,15 +71,7 @@ def chooser(request):
         searchform = SearchForm()
 
         images = Image.objects.order_by('-created_at')
-        p = request.GET.get("p", 1)
-        paginator = Paginator(images, 10)
-
-        try:
-            images = paginator.page(p)
-        except PageNotAnInteger:
-            images = paginator.page(1)
-        except EmptyPage:
-            images = paginator.page(paginator.num_pages)
+        paginator, images = paginate(request, images, per_page=10)
 
     return render_modal_workflow(request, 'wagtailimages/chooser/chooser.html', 'wagtailimages/chooser/chooser.js', {
         'images': images,

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -1,7 +1,6 @@
 import json
 
 from django.shortcuts import render, redirect, get_object_or_404
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.contrib.auth.decorators import permission_required
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import ugettext as _
@@ -9,6 +8,7 @@ from django.views.decorators.vary import vary_on_headers
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.http import HttpResponse
 
+from wagtail.utils.pagination import paginate
 from wagtail.wagtailcore.models import Site
 from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailadmin import messages
@@ -48,16 +48,7 @@ def index(request):
     else:
         form = SearchForm(placeholder=_("Search images"))
 
-    # Pagination
-    p = request.GET.get('p', 1)
-    paginator = Paginator(images, 20)
-
-    try:
-        images = paginator.page(p)
-    except PageNotAnInteger:
-        images = paginator.page(1)
-    except EmptyPage:
-        images = paginator.page(paginator.num_pages)
+    paginator, images = paginate(request, images)
 
     # Create response
     if request.is_ajax():
@@ -257,16 +248,7 @@ def add(request):
 def usage(request, image_id):
     image = get_object_or_404(get_image_model(), id=image_id)
 
-    # Pagination
-    p = request.GET.get('p', 1)
-    paginator = Paginator(image.get_usage(), 20)
-
-    try:
-        used_by = paginator.page(p)
-    except PageNotAnInteger:
-        used_by = paginator.page(1)
-    except EmptyPage:
-        used_by = paginator.page(paginator.num_pages)
+    paginator, used_by = paginate(request, image.get_usage())
 
     return render(request, "wagtailimages/images/usage.html", {
         'image': image,

--- a/wagtail/wagtailredirects/views.py
+++ b/wagtail/wagtailredirects/views.py
@@ -1,14 +1,13 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import permission_required
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 from django.core.urlresolvers import reverse
 
+from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.edit_handlers import ObjectList
 from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailadmin import messages
-
 from wagtail.wagtailredirects import models
 
 
@@ -18,7 +17,6 @@ REDIRECT_EDIT_HANDLER = ObjectList(models.Redirect.content_panels).bind_to_model
 @permission_required('wagtailredirects.change_redirect')
 @vary_on_headers('X-Requested-With')
 def index(request):
-    page = request.GET.get('p', 1)
     query_string = request.GET.get('q', "")
     ordering = request.GET.get('ordering', 'old_path')
 
@@ -36,13 +34,7 @@ def index(request):
         redirects = redirects.order_by(ordering)
 
     # Pagination
-    paginator = Paginator(redirects, 20)
-    try:
-        redirects = paginator.page(page)
-    except PageNotAnInteger:
-        redirects = paginator.page(1)
-    except EmptyPage:
-        redirects = paginator.page(paginator.num_pages)
+    paginator, redirects = paginate(request, redirects)
 
     # Render template
     if request.is_ajax():

--- a/wagtail/wagtailsearch/templates/wagtailsearch/queries/chooser/results.html
+++ b/wagtail/wagtailsearch/templates/wagtailsearch/queries/chooser/results.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 <table class="listing chooser">
     <col width="50%"/>
     <col width="50%"/>
@@ -24,4 +24,4 @@
     </tbody>
 </table>
 
-{% include "wagtailadmin/shared/pagination_nav.html" with items=queries is_ajax=1 %}
+{% paginate queries %}

--- a/wagtail/wagtailsearch/tests/test_queries.py
+++ b/wagtail/wagtailsearch/tests/test_queries.py
@@ -130,7 +130,6 @@ class TestQueryChooserView(TestCase, WagtailTestUtils):
     def test_search(self):
         response = self.get({'q': "Hello"})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context['query_string'], "Hello")
 
     def test_pagination(self):
         pages = ['0', '1', '-1', '9999', 'Not a page']

--- a/wagtail/wagtailsearch/views/queries.py
+++ b/wagtail/wagtailsearch/views/queries.py
@@ -28,13 +28,11 @@ def chooser(request, get_results=False):
     if get_results:
         return render(request, "wagtailsearch/queries/chooser/results.html", {
             'queries': queries,
-            'query_string': query_string,
         })
     else:
         return render_modal_workflow(request, 'wagtailsearch/queries/chooser/chooser.html', 'wagtailsearch/queries/chooser/chooser.js', {
             'queries': queries,
             'searchform': searchform,
-            'query_string': query_string,
         })
 
 

--- a/wagtail/wagtailsearch/views/queries.py
+++ b/wagtail/wagtailsearch/views/queries.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
+from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 from wagtail.wagtailadmin.forms import SearchForm
 
@@ -22,16 +22,7 @@ def chooser(request, get_results=False):
     else:
         searchform = SearchForm()
 
-    # Pagination
-    p = request.GET.get('p', 1)
-
-    paginator = Paginator(queries, 10)
-    try:
-        queries = paginator.page(p)
-    except PageNotAnInteger:
-        queries = paginator.page(1)
-    except EmptyPage:
-        queries = paginator.page(paginator.num_pages)
+    paginator, queries = paginate(request, queries, per_page=10)
 
     # Render
     if get_results:

--- a/wagtail/wagtailsnippets/views/chooser.py
+++ b/wagtail/wagtailsnippets/views/chooser.py
@@ -1,10 +1,10 @@
 import json
-from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404
 from django.utils.six import text_type
 
+from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 
 from wagtail.wagtailsnippets.views.snippets import get_content_type_from_url_params, get_snippet_type_name
@@ -17,15 +17,7 @@ def choose(request, content_type_app_name, content_type_model_name):
 
     items = model.objects.all()
 
-    p = request.GET.get("p", 1)
-    paginator = Paginator(items, 25)
-
-    try:
-        paginated_items = paginator.page(p)
-    except PageNotAnInteger:
-        paginated_items = paginator.page(1)
-    except EmptyPage:
-        paginated_items = paginator.page(paginator.num_pages)
+    paginator, paginated_items = paginate(request, items, per_page=25)
 
     return render_modal_workflow(
         request,

--- a/wagtail/wagtailsnippets/views/snippets.py
+++ b/wagtail/wagtailsnippets/views/snippets.py
@@ -6,8 +6,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
+from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.edit_handlers import ObjectList, extract_panel_definitions_from_model_class
 
 from wagtail.wagtailsnippets.models import get_snippet_content_types
@@ -94,16 +94,7 @@ def list(request, content_type_app_name, content_type_model_name):
 
     items = model.objects.all()
 
-    # Pagination
-    p = request.GET.get('p', 1)
-    paginator = Paginator(items, 20)
-
-    try:
-        paginated_items = paginator.page(p)
-    except PageNotAnInteger:
-        paginated_items = paginator.page(1)
-    except EmptyPage:
-        paginated_items = paginator.page(paginator.num_pages)
+    paginator, paginated_items = paginate(request, items)
 
     return render(request, 'wagtailsnippets/snippets/type_index.html', {
         'content_type': content_type,
@@ -233,16 +224,7 @@ def usage(request, content_type_app_name, content_type_model_name, id):
     model = content_type.model_class()
     instance = get_object_or_404(model, id=id)
 
-    # Pagination
-    p = request.GET.get('p', 1)
-    paginator = Paginator(instance.get_usage(), 20)
-
-    try:
-        used_by = paginator.page(p)
-    except PageNotAnInteger:
-        used_by = paginator.page(1)
-    except EmptyPage:
-        used_by = paginator.page(paginator.num_pages)
+    paginator, used_by = paginate(request, instance.get_usage())
 
     return render(request, "wagtailsnippets/snippets/usage.html", {
         'instance': instance,

--- a/wagtail/wagtailusers/views/groups.py
+++ b/wagtail/wagtailusers/views/groups.py
@@ -1,11 +1,11 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.models import Group
 from django.contrib.auth.decorators import permission_required, user_passes_test
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 
+from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin import messages
 from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailusers.forms import GroupForm, GroupPagePermissionFormSet
@@ -22,7 +22,6 @@ def user_has_group_model_perm(user):
 @vary_on_headers('X-Requested-With')
 def index(request):
     q = None
-    p = request.GET.get("p", 1)
     is_searching = False
 
     if 'q' in request.GET:
@@ -49,14 +48,7 @@ def index(request):
     else:
         ordering = 'name'
 
-    paginator = Paginator(groups, 20)
-
-    try:
-        groups = paginator.page(p)
-    except PageNotAnInteger:
-        groups = paginator.page(1)
-    except EmptyPage:
-        groups = paginator.page(paginator.num_pages)
+    paginator, groups = paginate(request, groups)
 
     if request.is_ajax():
         return render(request, "wagtailusers/groups/results.html", {

--- a/wagtail/wagtailusers/views/users.py
+++ b/wagtail/wagtailusers/views/users.py
@@ -1,12 +1,12 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import permission_required
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.urlresolvers import reverse
 from django.db.models import Q
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 
+from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin import messages
 from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailusers.forms import UserCreationForm, UserEditForm
@@ -24,7 +24,6 @@ change_user_perm = "{0}.change_{1}".format(AUTH_USER_APP_LABEL, AUTH_USER_MODEL_
 @vary_on_headers('X-Requested-With')
 def index(request):
     q = None
-    p = request.GET.get("p", 1)
     is_searching = False
 
     if 'q' in request.GET:
@@ -55,14 +54,7 @@ def index(request):
     else:
         ordering = 'name'
 
-    paginator = Paginator(users, 20)
-
-    try:
-        users = paginator.page(p)
-    except PageNotAnInteger:
-        users = paginator.page(1)
-    except EmptyPage:
-        users = paginator.page(paginator.num_pages)
+    paginator, users = paginate(request, users)
 
     if request.is_ajax():
         return render(request, "wagtailusers/users/results.html", {


### PR DESCRIPTION
Pagination is done almost exactly the same across all of Wagtail. Moving
the repeated code in to one spot ensures mistakes are not made, and
means that pagination is always done consistently.

There are some locations where the pagination helper has not been used,
as there is no request available or something similar. These instances
are special enough that refactoring them does not make sense at this
point.