### PR TITLE
Show deprecation warnings for next Wagtail version

### DIFF
--- a/wagtail/utils/deprecation.py
+++ b/wagtail/utils/deprecation.py
@@ -2,5 +2,8 @@ class RemovedInWagtail12Warning(DeprecationWarning):
     pass
 
 
+removed_in_next_version_warning = RemovedInWagtail12Warning
+
+
 class RemovedInWagtail13Warning(PendingDeprecationWarning):
     pass

--- a/wagtail/wagtailcore/__init__.py
+++ b/wagtail/wagtailcore/__init__.py
@@ -1,2 +1,10 @@
 __version__ = '1.1a0'
 default_app_config = 'wagtail.wagtailcore.apps.WagtailCoreAppConfig'
+
+def setup():
+    import warnings
+    from wagtail.utils.deprecation import removed_in_next_version_warning
+
+    warnings.simplefilter("default", removed_in_next_version_warning)
+
+setup()


### PR DESCRIPTION
Deprecation warnings appear in the console when running tests but not when running a project. This pull request tells Django to output deprecation warnings for the next wagtail version in the console.