### PR TITLE
Rationalise URL names

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/_preview_button_on_create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/_preview_button_on_create.html
@@ -1,4 +1,4 @@
 <button class="action-preview {% if icon %}icon icon-view{% endif %}"
-    data-action="{% url 'wagtailadmin_pages:preview_on_create' content_type.app_label content_type.model parent_page.id %}{% if mode %}?mode={{ mode|urlencode }}{% endif %}"
+    data-action="{% url 'wagtailadmin_pages:preview_on_add' content_type.app_label content_type.model parent_page.id %}{% if mode %}?mode={{ mode|urlencode }}{% endif %}"
     data-placeholder="{% url 'wagtailadmin_pages:preview' %}"
     data-windowname="wagtail_preview_{{ parent_page.id }}_child">{{ label }}</button>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/add_subpage.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/add_subpage.html
@@ -18,7 +18,7 @@
                     <li>
                         <div class="row row-flush">
                             <div class="col6">
-                                <a href="{% url 'wagtailadmin_pages:create' content_type.app_label content_type.model parent_page.id %}" class="icon icon-plus-inverse icon-larger">{{ content_type.model_class.get_verbose_name }}</a>
+                                <a href="{% url 'wagtailadmin_pages:add' content_type.app_label content_type.model parent_page.id %}" class="icon icon-plus-inverse icon-larger">{{ content_type.model_class.get_verbose_name }}</a>
                             </div>
 
                             <small class="col6" style="text-align:right">

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
@@ -17,7 +17,7 @@
         </div>
     </header>
 
-    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:create' content_type.app_label content_type.model parent_page.id %}" method="POST">
+    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:add' content_type.app_label content_type.model parent_page.id %}" method="POST">
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
 

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -157,7 +157,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 404)
 
     def test_create_simplepage(self):
-        response = self.client.get(reverse('wagtailadmin_pages:create', args=('tests', 'simplepage', self.root_page.id)))
+        response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '<a href="#content" class="active">Content</a>')
         self.assertContains(response, '<a href="#promote" class="">Promote</a>')
@@ -166,7 +166,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         """
         Test that the Promote tab is not rendered for page classes that define it as empty
         """
-        response = self.client.get(reverse('wagtailadmin_pages:create', args=('tests', 'standardindex', self.root_page.id)))
+        response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'standardindex', self.root_page.id)))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '<a href="#content" class="active">Content</a>')
         self.assertNotContains(response, '<a href="#promote" class="">Promote</a>')
@@ -175,7 +175,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         """
         Test that custom edit handlers are rendered
         """
-        response = self.client.get(reverse('wagtailadmin_pages:create', args=('tests', 'standardchild', self.root_page.id)))
+        response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'standardchild', self.root_page.id)))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '<a href="#content" class="active">Content</a>')
         self.assertContains(response, '<a href="#promote" class="">Promote</a>')
@@ -190,7 +190,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         self.user.save()
 
         # Get page
-        response = self.client.get(reverse('wagtailadmin_pages:create', args=('tests', 'simplepage', self.root_page.id, )))
+        response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id, )))
 
         # Check that the user recieved a 403 response
         self.assertEqual(response.status_code, 403)
@@ -201,7 +201,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
             'content': "Some content",
             'slug': 'hello-world',
         }
-        response = self.client.post(reverse('wagtailadmin_pages:create', args=('tests', 'simplepage', self.root_page.id)), post_data)
+        response = self.client.post(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)), post_data)
 
         # Find the page and check it
         page = Page.objects.get(path__startswith=self.root_page.path, slug='hello-world').specific
@@ -227,7 +227,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
             'go_live_at': submittable_timestamp(go_live_at),
             'expire_at': submittable_timestamp(expire_at),
         }
-        response = self.client.post(reverse('wagtailadmin_pages:create', args=('tests', 'simplepage', self.root_page.id)), post_data)
+        response = self.client.post(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)), post_data)
 
         # Should be redirected to explorer page
         self.assertEqual(response.status_code, 302)
@@ -250,7 +250,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
             'go_live_at': submittable_timestamp(timezone.now() + timedelta(days=2)),
             'expire_at': submittable_timestamp(timezone.now() + timedelta(days=1)),
         }
-        response = self.client.post(reverse('wagtailadmin_pages:create', args=('tests', 'simplepage', self.root_page.id)), post_data)
+        response = self.client.post(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)), post_data)
 
         self.assertEqual(response.status_code, 200)
 
@@ -265,7 +265,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
             'slug': 'hello-world',
             'expire_at': submittable_timestamp(timezone.now() + timedelta(days=-1)),
         }
-        response = self.client.post(reverse('wagtailadmin_pages:create', args=('tests', 'simplepage', self.root_page.id)), post_data)
+        response = self.client.post(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)), post_data)
 
         self.assertEqual(response.status_code, 200)
 
@@ -284,7 +284,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
             'slug': 'hello-world',
             'action-publish': "Publish",
         }
-        response = self.client.post(reverse('wagtailadmin_pages:create', args=('tests', 'simplepage', self.root_page.id)), post_data)
+        response = self.client.post(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)), post_data)
 
         # Find the page and check it
         page = Page.objects.get(path__startswith=self.root_page.path, slug='hello-world').specific
@@ -319,7 +319,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
             'go_live_at': submittable_timestamp(go_live_at),
             'expire_at': submittable_timestamp(expire_at),
         }
-        response = self.client.post(reverse('wagtailadmin_pages:create', args=('tests', 'simplepage', self.root_page.id)), post_data)
+        response = self.client.post(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)), post_data)
 
         # Should be redirected to explorer page
         self.assertEqual(response.status_code, 302)
@@ -348,7 +348,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
             'slug': 'hello-world',
             'action-submit': "Submit",
         }
-        response = self.client.post(reverse('wagtailadmin_pages:create', args=('tests', 'simplepage', self.root_page.id)), post_data)
+        response = self.client.post(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)), post_data)
 
         # Find the page and check it
         page = Page.objects.get(path__startswith=self.root_page.path, slug='hello-world').specific
@@ -385,7 +385,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
             'slug': 'hello-world',
             'action-publish': "Publish",
         }
-        response = self.client.post(reverse('wagtailadmin_pages:create', args=('tests', 'simplepage', self.root_page.id)), post_data)
+        response = self.client.post(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)), post_data)
 
         # Should not be redirected (as the save should fail)
         self.assertEqual(response.status_code, 200)
@@ -394,11 +394,11 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         self.assertFormError(response, 'form', 'slug', "This slug is already in use")
 
     def test_create_nonexistantparent(self):
-        response = self.client.get(reverse('wagtailadmin_pages:create', args=('tests', 'simplepage', 100000)))
+        response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', 100000)))
         self.assertEqual(response.status_code, 404)
 
     def test_create_nonpagetype(self):
-        response = self.client.get(reverse('wagtailadmin_pages:create', args=('wagtailimages', 'image', self.root_page.id)))
+        response = self.client.get(reverse('wagtailadmin_pages:add', args=('wagtailimages', 'image', self.root_page.id)))
         self.assertEqual(response.status_code, 404)
 
     def test_preview_on_create(self):
@@ -408,7 +408,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
             'slug': 'hello-world',
             'action-submit': "Submit",
         }
-        response = self.client.post(reverse('wagtailadmin_pages:preview_on_create', args=('tests', 'simplepage', self.root_page.id)), post_data)
+        response = self.client.post(reverse('wagtailadmin_pages:preview_on_add', args=('tests', 'simplepage', self.root_page.id)), post_data)
 
         # Check the response
         self.assertEqual(response.status_code, 200)
@@ -428,7 +428,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
             'action-submit': "Submit",
             'seo_title': '\t',
         }
-        response = self.client.post(reverse('wagtailadmin_pages:create', args=('tests', 'simplepage', self.root_page.id)), post_data)
+        response = self.client.post(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)), post_data)
 
         # Check that a form error was raised
         self.assertFormError(response, 'form', 'title', "Value cannot be entirely whitespace characters")
@@ -444,7 +444,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
                     'hello-world-hello-world-hello-world-hello-world-hello-world-hello-world',
             'action-submit': "Submit",
         }
-        response = self.client.post(reverse('wagtailadmin_pages:create', args=('tests', 'simplepage', self.root_page.id)), post_data)
+        response = self.client.post(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)), post_data)
 
         # Check that a form error was raised
         self.assertEqual(response.status_code, 200)
@@ -1759,25 +1759,25 @@ class TestSubpageBusinessRules(TestCase, WagtailTestUtils):
 
     def test_cannot_add_invalid_subpage_type(self):
         # cannot add StandardChild as a child of BusinessIndex, as StandardChild is not present in subpage_types
-        response = self.client.get(reverse('wagtailadmin_pages:create', args=('tests', 'standardchild', self.business_index.id)))
+        response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'standardchild', self.business_index.id)))
         self.assertEqual(response.status_code, 403)
 
         # likewise for BusinessChild which has an empty subpage_types list
-        response = self.client.get(reverse('wagtailadmin_pages:create', args=('tests', 'standardchild', self.business_child.id)))
+        response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'standardchild', self.business_child.id)))
         self.assertEqual(response.status_code, 403)
 
         # cannot add BusinessChild to StandardIndex, as BusinessChild restricts is parent page types
-        response = self.client.get(reverse('wagtailadmin_pages:create', args=('tests', 'businesschild', self.standard_index.id)))
+        response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'businesschild', self.standard_index.id)))
         self.assertEqual(response.status_code, 403)
 
         # but we can add a BusinessChild to BusinessIndex
-        response = self.client.get(reverse('wagtailadmin_pages:create', args=('tests', 'businesschild', self.business_index.id)))
+        response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'businesschild', self.business_index.id)))
         self.assertEqual(response.status_code, 200)
 
     def test_not_prompted_for_page_type_when_only_one_choice(self):
         response = self.client.get(reverse('wagtailadmin_pages:add_subpage', args=(self.business_subindex.id, )))
         # BusinessChild is the only valid subpage type of BusinessSubIndex, so redirect straight there
-        self.assertRedirects(response, reverse('wagtailadmin_pages:create', args=('tests', 'businesschild', self.business_subindex.id)))
+        self.assertRedirects(response, reverse('wagtailadmin_pages:add', args=('tests', 'businesschild', self.business_subindex.id)))
 
 
 class TestNotificationPreferences(TestCase, WagtailTestUtils):
@@ -2159,7 +2159,7 @@ class TestChildRelationsOnSuperclass(TestCase, WagtailTestUtils):
         self.login()
 
     def test_get_create_form(self):
-        response = self.client.get(reverse('wagtailadmin_pages:create', args=('tests', 'standardindex', self.root_page.id)))
+        response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'standardindex', self.root_page.id)))
         self.assertEqual(response.status_code, 200)
         # Response should include an advert_placements formset labelled Adverts
         self.assertContains(response, "Adverts")
@@ -2176,7 +2176,7 @@ class TestChildRelationsOnSuperclass(TestCase, WagtailTestUtils):
             'advert_placements-0-colour': 'yellow',
             'advert_placements-0-id': '',
         }
-        response = self.client.post(reverse('wagtailadmin_pages:create', args=('tests', 'standardindex', self.root_page.id)), post_data)
+        response = self.client.post(reverse('wagtailadmin_pages:add', args=('tests', 'standardindex', self.root_page.id)), post_data)
 
         # Find the page and check it
         page = Page.objects.get(path__startswith=self.root_page.path, slug='new-index').specific

--- a/wagtail/wagtailadmin/tests/tests.py
+++ b/wagtail/wagtailadmin/tests/tests.py
@@ -44,7 +44,7 @@ class TestEditorHooks(TestCase, WagtailTestUtils):
         self.login()
 
     def test_editor_css_and_js_hooks_on_add(self):
-        response = self.client.get(reverse('wagtailadmin_pages:create', args=('tests', 'simplepage', self.homepage.id)))
+        response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.homepage.id)))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '<link rel="stylesheet" href="/path/to/my/custom.css">')
         self.assertContains(response, '<script src="/path/to/my/custom.js"></script>')

--- a/wagtail/wagtailadmin/urls.py
+++ b/wagtail/wagtailadmin/urls.py
@@ -21,8 +21,8 @@ urlpatterns = [
     url(r'^pages/(\d+)/$', pages.index, name='wagtailadmin_explore'),
 
     url(r'^pages/', include([
-        url(r'^new/(\w+)/(\w+)/(\d+)/$', pages.create, name='create'),
-        url(r'^new/(\w+)/(\w+)/(\d+)/preview/$', pages.preview_on_create, name='preview_on_create'),
+        url(r'^add/(\w+)/(\w+)/(\d+)/$', pages.create, name='add'),
+        url(r'^add/(\w+)/(\w+)/(\d+)/preview/$', pages.preview_on_create, name='preview_on_add'),
         url(r'^usage/(\w+)/(\w+)/$', pages.content_type_use, name='type_use'),
 
         url(r'^(\d+)/edit/$', pages.edit, name='edit'),

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -79,7 +79,7 @@ def add_subpage(request, parent_page_id):
         # Only one page type is available - redirect straight to the create form rather than
         # making the user choose
         content_type = page_types[0]
-        return redirect('wagtailadmin_pages:create', content_type.app_label, content_type.model, parent_page.id)
+        return redirect('wagtailadmin_pages:add', content_type.app_label, content_type.model, parent_page.id)
 
     return render(request, 'wagtailadmin/pages/add_subpage.html', {
         'parent_page': parent_page,

--- a/wagtail/wagtaildocs/admin_urls.py
+++ b/wagtail/wagtaildocs/admin_urls.py
@@ -4,7 +4,7 @@ from wagtail.wagtaildocs.views import documents, chooser
 
 urlpatterns = [
     url(r'^$', documents.index, name='index'),
-    url(r'^add/$', documents.add, name='add_document'),
+    url(r'^add/$', documents.add, name='add'),
     url(r'^edit/(\d+)/$', documents.edit, name='edit_document'),
     url(r'^delete/(\d+)/$', documents.delete, name='delete_document'),
 

--- a/wagtail/wagtaildocs/admin_urls.py
+++ b/wagtail/wagtaildocs/admin_urls.py
@@ -6,7 +6,7 @@ urlpatterns = [
     url(r'^$', documents.index, name='index'),
     url(r'^add/$', documents.add, name='add'),
     url(r'^edit/(\d+)/$', documents.edit, name='edit'),
-    url(r'^delete/(\d+)/$', documents.delete, name='delete_document'),
+    url(r'^delete/(\d+)/$', documents.delete, name='delete'),
 
     url(r'^chooser/$', chooser.chooser, name='chooser'),
     url(r'^chooser/(\d+)/$', chooser.document_chosen, name='document_chosen'),

--- a/wagtail/wagtaildocs/admin_urls.py
+++ b/wagtail/wagtaildocs/admin_urls.py
@@ -5,7 +5,7 @@ from wagtail.wagtaildocs.views import documents, chooser
 urlpatterns = [
     url(r'^$', documents.index, name='index'),
     url(r'^add/$', documents.add, name='add'),
-    url(r'^edit/(\d+)/$', documents.edit, name='edit_document'),
+    url(r'^edit/(\d+)/$', documents.edit, name='edit'),
     url(r'^delete/(\d+)/$', documents.delete, name='delete_document'),
 
     url(r'^chooser/$', chooser.chooser, name='chooser'),

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/add.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/add.html
@@ -16,7 +16,7 @@
     {% include "wagtailadmin/shared/header.html" with title=add_str icon="doc-full-inverse" %}
 
     <div class="nice-padding">
-        <form action="{% url 'wagtaildocs:add_document' %}" method="POST" enctype="multipart/form-data">
+        <form action="{% url 'wagtaildocs:add' %}" method="POST" enctype="multipart/form-data">
             {% csrf_token %}
             <ul class="fields">
                 {% for field in form %}

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/confirm_delete.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/confirm_delete.html
@@ -8,7 +8,7 @@
 
     <div class="nice-padding">
         <p>{% trans "Are you sure you want to delete this document?" %}</p>
-        <form action="{% url 'wagtaildocs:delete_document' document.id %}" method="POST">
+        <form action="{% url 'wagtaildocs:delete' document.id %}" method="POST">
             {% csrf_token %}
             <input type="submit" value='{% trans "Yes, delete" %}' class="serious" />
         </form>

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
@@ -28,7 +28,7 @@
                             {% include "wagtailadmin/shared/field_as_li.html" %}
                         {% endif %}
                     {% endfor %}
-                    <li><input type="submit" value="{% trans 'Save' %}" /> <a href="{% url 'wagtaildocs:delete_document' document.id %}" class="button button-secondary no">{% trans "Delete document" %}</a></li>
+                    <li><input type="submit" value="{% trans 'Save' %}" /> <a href="{% url 'wagtaildocs:delete' document.id %}" class="button button-secondary no">{% trans "Delete document" %}</a></li>
                 </ul>
             </form>
         </div>

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
@@ -18,7 +18,7 @@
     <div class="row row-flush nice-padding">
 
         <div class="col10 divider-after">
-            <form action="{% url 'wagtaildocs:edit_document' document.id %}" method="POST" enctype="multipart/form-data">
+            <form action="{% url 'wagtaildocs:edit' document.id %}" method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
                 <ul class="fields">
                     {% for field in form %}

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/index.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/index.html
@@ -15,7 +15,7 @@
 {% block content %}
     {% trans "Documents" as doc_str %}
     {% trans "Add a document" as add_doc_str %}
-    {% include "wagtailadmin/shared/header.html" with title=doc_str add_link="wagtaildocs:add_document" icon="doc-full-inverse" add_text=add_doc_str search_url="wagtaildocs:index" %}
+    {% include "wagtailadmin/shared/header.html" with title=doc_str add_link="wagtaildocs:add" icon="doc-full-inverse" add_text=add_doc_str search_url="wagtaildocs:index" %}
 
     <div class="nice-padding">
         <div id="document-results" class="documents">

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/list.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/list.html
@@ -33,7 +33,7 @@
                     {% if choosing %}
                         <h2><a href="{% url 'wagtaildocs:document_chosen' doc.id %}" class="document-choice">{{ doc.title }}</a></h2>
                     {% else %}
-                        <h2><a href="{% url 'wagtaildocs:edit_document' doc.id %}">{{ doc.title }}</a></h2>
+                        <h2><a href="{% url 'wagtaildocs:edit' doc.id %}">{{ doc.title }}</a></h2>
                     {% endif %}
                 </td>
                 <td><a href="{{ doc.url }}" class="nolink">{{ doc.filename }}</a></td>

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/results.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/results.html
@@ -17,7 +17,7 @@
     {% if is_searching %}
          <p>{% blocktrans %}Sorry, no documents match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
     {% else %}
-        {% url 'wagtaildocs:add_document' as wagtaildocs_add_document_url %}
+        {% url 'wagtaildocs:add' as wagtaildocs_add_document_url %}
         <p>{% blocktrans %}You haven't uploaded any documents. Why not <a href="{{ wagtaildocs_add_document_url }}">upload one now</a>?{% endblocktrans %}</p>
     {% endif %}
 {% endif %}

--- a/wagtail/wagtaildocs/templates/wagtaildocs/widgets/document_chooser.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/widgets/document_chooser.html
@@ -5,4 +5,4 @@
     <span class="title">{{ document.title }}</span>
 {% endblock %}
 
-{% block edit_chosen_item_url %}{% if document %}{% url 'wagtaildocs:edit_document' document.id %}{% endif %}{% endblock %}
+{% block edit_chosen_item_url %}{% if document %}{% url 'wagtaildocs:edit' document.id %}{% endif %}{% endblock %}

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -159,7 +159,7 @@ class TestDocumentEditView(TestCase, WagtailTestUtils):
         self.document = models.Document.objects.create(title="Test document", file=fake_file)
 
     def test_simple(self):
-        response = self.client.get(reverse('wagtaildocs:edit_document', args=(self.document.id,)))
+        response = self.client.get(reverse('wagtaildocs:edit', args=(self.document.id,)))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtaildocs/documents/edit.html')
 
@@ -173,7 +173,7 @@ class TestDocumentEditView(TestCase, WagtailTestUtils):
             'title': "Test document changed!",
             'file': fake_file,
         }
-        response = self.client.post(reverse('wagtaildocs:edit_document', args=(self.document.id,)), post_data)
+        response = self.client.post(reverse('wagtaildocs:edit', args=(self.document.id,)), post_data)
 
         # User should be redirected back to the index
         self.assertRedirects(response, reverse('wagtaildocs:index'))
@@ -190,7 +190,7 @@ class TestDocumentEditView(TestCase, WagtailTestUtils):
         document = models.Document.objects.create(title="Test missing source document", file=fake_file)
         document.file.delete(False)
 
-        response = self.client.get(reverse('wagtaildocs:edit_document', args=(document.id,)), {})
+        response = self.client.get(reverse('wagtaildocs:edit', args=(document.id,)), {})
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtaildocs/documents/edit.html')
 
@@ -372,7 +372,7 @@ class TestUsageCount(TestCase, WagtailTestUtils):
         event_page_related_link.page = page
         event_page_related_link.link_document = doc
         event_page_related_link.save()
-        response = self.client.get(reverse('wagtaildocs:edit_document',
+        response = self.client.get(reverse('wagtaildocs:edit',
                                            args=(1,)))
         self.assertNotContains(response, 'Used 1 time')
 
@@ -384,13 +384,13 @@ class TestUsageCount(TestCase, WagtailTestUtils):
         event_page_related_link.page = page
         event_page_related_link.link_document = doc
         event_page_related_link.save()
-        response = self.client.get(reverse('wagtaildocs:edit_document',
+        response = self.client.get(reverse('wagtaildocs:edit',
                                            args=(1,)))
         self.assertContains(response, 'Used 1 time')
 
     @override_settings(WAGTAIL_USAGE_COUNT_ENABLED=True)
     def test_usage_count_zero_appears(self):
-        response = self.client.get(reverse('wagtaildocs:edit_document',
+        response = self.client.get(reverse('wagtaildocs:edit',
                                            args=(1,)))
         self.assertContains(response, 'Used 0 times')
 
@@ -498,7 +498,7 @@ class TestIssue613(TestCase, WagtailTestUtils):
             'file': another_fake_file,
         }
         post_data.update(params)
-        response = self.client.post(reverse('wagtaildocs:edit_document', args=(document.id,)), post_data)
+        response = self.client.post(reverse('wagtaildocs:edit', args=(document.id,)), post_data)
 
         # User should be redirected back to the index
         self.assertRedirects(response, reverse('wagtaildocs:index'))

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -205,7 +205,7 @@ class TestDocumentDeleteView(TestCase, WagtailTestUtils):
         self.document = models.Document.objects.create(title="Test document")
 
     def test_simple(self):
-        response = self.client.get(reverse('wagtaildocs:delete_document', args=(self.document.id,)))
+        response = self.client.get(reverse('wagtaildocs:delete', args=(self.document.id,)))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtaildocs/documents/confirm_delete.html')
 
@@ -214,7 +214,7 @@ class TestDocumentDeleteView(TestCase, WagtailTestUtils):
         post_data = {
             'foo': 'bar'
         }
-        response = self.client.post(reverse('wagtaildocs:delete_document', args=(self.document.id,)), post_data)
+        response = self.client.post(reverse('wagtaildocs:delete', args=(self.document.id,)), post_data)
 
         # User should be redirected back to the index
         self.assertRedirects(response, reverse('wagtaildocs:index'))

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -124,7 +124,7 @@ class TestDocumentAddView(TestCase, WagtailTestUtils):
         self.login()
 
     def test_simple(self):
-        response = self.client.get(reverse('wagtaildocs:add_document'))
+        response = self.client.get(reverse('wagtaildocs:add'))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtaildocs/documents/add.html')
 
@@ -138,7 +138,7 @@ class TestDocumentAddView(TestCase, WagtailTestUtils):
             'title': "Test document",
             'file': fake_file,
         }
-        response = self.client.post(reverse('wagtaildocs:add_document'), post_data)
+        response = self.client.post(reverse('wagtaildocs:add'), post_data)
 
         # User should be redirected back to the index
         self.assertRedirects(response, reverse('wagtaildocs:index'))
@@ -470,7 +470,7 @@ class TestIssue613(TestCase, WagtailTestUtils):
             'file': fake_file,
         }
         post_data.update(params)
-        response = self.client.post(reverse('wagtaildocs:add_document'), post_data)
+        response = self.client.post(reverse('wagtaildocs:add'), post_data)
 
         # User should be redirected back to the index
         self.assertRedirects(response, reverse('wagtaildocs:index'))

--- a/wagtail/wagtaildocs/views/chooser.py
+++ b/wagtail/wagtaildocs/views/chooser.py
@@ -21,7 +21,7 @@ def get_document_json(document):
     return json.dumps({
         'id': document.id,
         'title': document.title,
-        'edit_link': reverse('wagtaildocs:edit_document', args=(document.id,)),
+        'edit_link': reverse('wagtaildocs:edit', args=(document.id,)),
     })
 
 

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -145,7 +145,7 @@ def edit(request, document_id):
 
     if not filesize:
         messages.error(request, _("The file could not be found. Please change the source or delete the document"), buttons=[
-            messages.button(reverse('wagtaildocs:delete_document', args=(doc.id,)), _('Delete'))
+            messages.button(reverse('wagtaildocs:delete', args=(doc.id,)), _('Delete'))
         ])
 
     return render(request, "wagtaildocs/documents/edit.html", {

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -90,7 +90,7 @@ def add(request):
                 backend.add(doc)
 
             messages.success(request, _("Document '{0}' added.").format(doc.title), buttons=[
-                messages.button(reverse('wagtaildocs:edit_document', args=(doc.id,)), _('Edit'))
+                messages.button(reverse('wagtaildocs:edit', args=(doc.id,)), _('Edit'))
             ])
             return redirect('wagtaildocs:index')
         else:
@@ -125,7 +125,7 @@ def edit(request, document_id):
                 backend.add(doc)
 
             messages.success(request, _("Document '{0}' updated").format(doc.title), buttons=[
-                messages.button(reverse('wagtaildocs:edit_document', args=(doc.id,)), _('Edit'))
+                messages.button(reverse('wagtaildocs:edit', args=(doc.id,)), _('Edit'))
             ])
             return redirect('wagtaildocs:index')
         else:

--- a/wagtail/wagtailimages/admin_urls.py
+++ b/wagtail/wagtailimages/admin_urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     url(r'^(\d+)/generate_url/$', images.url_generator, name='url_generator'),
     url(r'^(\d+)/generate_url/(.*)/$', images.generate_url, name='generate_url'),
     url(r'^(\d+)/preview/(.*)/$', images.preview, name='preview'),
-    url(r'^add/$', images.add, name='add_image'),
+    url(r'^add/$', images.add, name='add'),
     url(r'^usage/(\d+)/$', images.usage, name='image_usage'),
 
     url(r'^multiple/add/$', multiple.add, name='add_multiple'),

--- a/wagtail/wagtailimages/admin_urls.py
+++ b/wagtail/wagtailimages/admin_urls.py
@@ -6,7 +6,7 @@ from wagtail.wagtailimages.views import images, chooser, multiple
 urlpatterns = [
     url(r'^$', images.index, name='index'),
     url(r'^(\d+)/$', images.edit, name='edit'),
-    url(r'^(\d+)/delete/$', images.delete, name='delete_image'),
+    url(r'^(\d+)/delete/$', images.delete, name='delete'),
     url(r'^(\d+)/generate_url/$', images.url_generator, name='url_generator'),
     url(r'^(\d+)/generate_url/(.*)/$', images.generate_url, name='generate_url'),
     url(r'^(\d+)/preview/(.*)/$', images.preview, name='preview'),

--- a/wagtail/wagtailimages/admin_urls.py
+++ b/wagtail/wagtailimages/admin_urls.py
@@ -5,7 +5,7 @@ from wagtail.wagtailimages.views import images, chooser, multiple
 
 urlpatterns = [
     url(r'^$', images.index, name='index'),
-    url(r'^(\d+)/$', images.edit, name='edit_image'),
+    url(r'^(\d+)/$', images.edit, name='edit'),
     url(r'^(\d+)/delete/$', images.delete, name='delete_image'),
     url(r'^(\d+)/generate_url/$', images.url_generator, name='url_generator'),
     url(r'^(\d+)/generate_url/(.*)/$', images.generate_url, name='generate_url'),

--- a/wagtail/wagtailimages/templates/wagtailimages/images/add.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/add.html
@@ -16,7 +16,7 @@
     {% include "wagtailadmin/shared/header.html" with title=add_str icon="image" %}
 
     <div class="nice-padding">
-        <form action="{% url 'wagtailimages:add_image' %}" method="POST" enctype="multipart/form-data">
+        <form action="{% url 'wagtailimages:add' %}" method="POST" enctype="multipart/form-data">
             {% csrf_token %}
             <ul class="fields">
                 {% for field in form %}

--- a/wagtail/wagtailimages/templates/wagtailimages/images/confirm_delete.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/confirm_delete.html
@@ -14,7 +14,7 @@
         </div>
         <div class="col6">
             <p>{% trans "Are you sure you want to delete this image?" %}</p>
-            <form action="{% url 'wagtailimages:delete_image' image.id %}" method="POST">
+            <form action="{% url 'wagtailimages:delete' image.id %}" method="POST">
                 {% csrf_token %}
                 <input type="submit" value="{% trans 'Yes, delete' %}" class="serious" />
             </form>

--- a/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
@@ -42,7 +42,7 @@
                         {% endif %}
 
                     {% endfor %}
-                    <li><input type="submit" value="{% trans 'Save' %}" /><a href="{% url 'wagtailimages:delete_image' image.id %}" class="button button-secondary no">{% trans "Delete image" %}</a></li>
+                    <li><input type="submit" value="{% trans 'Save' %}" /><a href="{% url 'wagtailimages:delete' image.id %}" class="button button-secondary no">{% trans "Delete image" %}</a></li>
                 </ul>
             </form>
         </div>

--- a/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
@@ -28,7 +28,7 @@
     <div class="row row-flush nice-padding">
 
         <div class="col5">
-            <form action="{% url 'wagtailimages:edit_image' image.id %}" method="POST" enctype="multipart/form-data">
+            <form action="{% url 'wagtailimages:edit' image.id %}" method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
                 <ul class="fields">
                     {% for field in form %}

--- a/wagtail/wagtailimages/templates/wagtailimages/images/results.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/results.html
@@ -16,7 +16,7 @@
     <ul class="listing horiz images">
         {% for image in images %}
             <li>
-                <a class="image-choice" href="{% url 'wagtailimages:edit_image' image.id %}">
+                <a class="image-choice" href="{% url 'wagtailimages:edit' image.id %}">
                     <div class="image">{% image image max-165x165 class="show-transparency" %}</div>
                     <h3>{{ image.title|ellipsistrim:60 }}</h3>
                 </a>

--- a/wagtail/wagtailimages/templates/wagtailimages/multiple/add.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/multiple/add.html
@@ -72,7 +72,7 @@
     {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
     <script>
         window.fileupload_opts = {
-            simple_upload_url: "{% url 'wagtailimages:add_image' %}",
+            simple_upload_url: "{% url 'wagtailimages:add' %}",
             accepted_file_types: /\.({{ allowed_extensions|join:"|" }})$/i, //must be regex
             max_file_size: {{ max_filesize|stringformat:"s"|default:"null" }}, //numeric format
             errormessages: {

--- a/wagtail/wagtailimages/templates/wagtailimages/widgets/image_chooser.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/widgets/image_chooser.html
@@ -13,4 +13,4 @@
     </div>
 {% endblock %}
 
-{% block edit_chosen_item_url %}{% if image %}{% url 'wagtailimages:edit_image' image.id %}{% endif %}{% endblock %}
+{% block edit_chosen_item_url %}{% if image %}{% url 'wagtailimages:edit' image.id %}{% endif %}{% endblock %}

--- a/wagtail/wagtailimages/tests/test_admin_views.py
+++ b/wagtail/wagtailimages/tests/test_admin_views.py
@@ -132,10 +132,10 @@ class TestImageEditView(TestCase, WagtailTestUtils):
         )
 
     def get(self, params={}):
-        return self.client.get(reverse('wagtailimages:edit_image', args=(self.image.id,)), params)
+        return self.client.get(reverse('wagtailimages:edit', args=(self.image.id,)), params)
 
     def post(self, post_data={}):
-        return self.client.post(reverse('wagtailimages:edit_image', args=(self.image.id,)), post_data)
+        return self.client.post(reverse('wagtailimages:edit', args=(self.image.id,)), post_data)
 
     def test_simple(self):
         response = self.get()

--- a/wagtail/wagtailimages/tests/test_admin_views.py
+++ b/wagtail/wagtailimages/tests/test_admin_views.py
@@ -192,10 +192,10 @@ class TestImageDeleteView(TestCase, WagtailTestUtils):
         )
 
     def get(self, params={}):
-        return self.client.get(reverse('wagtailimages:delete_image', args=(self.image.id,)), params)
+        return self.client.get(reverse('wagtailimages:delete', args=(self.image.id,)), params)
 
     def post(self, post_data={}):
-        return self.client.post(reverse('wagtailimages:delete_image', args=(self.image.id,)), post_data)
+        return self.client.post(reverse('wagtailimages:delete', args=(self.image.id,)), post_data)
 
     def test_simple(self):
         response = self.get()

--- a/wagtail/wagtailimages/tests/test_admin_views.py
+++ b/wagtail/wagtailimages/tests/test_admin_views.py
@@ -58,10 +58,10 @@ class TestImageAddView(TestCase, WagtailTestUtils):
         self.login()
 
     def get(self, params={}):
-        return self.client.get(reverse('wagtailimages:add_image'), params)
+        return self.client.get(reverse('wagtailimages:add'), params)
 
     def post(self, post_data={}):
-        return self.client.post(reverse('wagtailimages:add_image'), post_data)
+        return self.client.post(reverse('wagtailimages:add'), post_data)
 
     def test_simple(self):
         response = self.get()

--- a/wagtail/wagtailimages/tests/test_models.py
+++ b/wagtail/wagtailimages/tests/test_models.py
@@ -335,7 +335,7 @@ class TestIssue613(TestCase, WagtailTestUtils):
             'title': "Edited",
         }
         post_data.update(params)
-        response = self.client.post(reverse('wagtailimages:edit_image', args=(self.image.id,)), post_data)
+        response = self.client.post(reverse('wagtailimages:edit', args=(self.image.id,)), post_data)
 
         # Should redirect back to index
         self.assertRedirects(response, reverse('wagtailimages:index'))

--- a/wagtail/wagtailimages/tests/test_models.py
+++ b/wagtail/wagtailimages/tests/test_models.py
@@ -307,7 +307,7 @@ class TestIssue613(TestCase, WagtailTestUtils):
             'file': SimpleUploadedFile('test.png', get_test_image_file().file.getvalue()),
         }
         post_data.update(params)
-        response = self.client.post(reverse('wagtailimages:add_image'), post_data)
+        response = self.client.post(reverse('wagtailimages:add'), post_data)
 
         # Should redirect back to index
         self.assertRedirects(response, reverse('wagtailimages:index'))

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -23,7 +23,7 @@ def get_image_json(image):
 
     return json.dumps({
         'id': image.id,
-        'edit_link': reverse('wagtailimages:edit_image', args=(image.id,)),
+        'edit_link': reverse('wagtailimages:edit', args=(image.id,)),
         'title': image.title,
         'preview': {
             'url': preview_image.url,
@@ -166,7 +166,7 @@ def chooser_select_format(request, image_id):
                 'format': format.name,
                 'alt': form.cleaned_data['alt_text'],
                 'class': format.classnames,
-                'edit_link': reverse('wagtailimages:edit_image', args=(image.id,)),
+                'edit_link': reverse('wagtailimages:edit', args=(image.id,)),
                 'preview': {
                     'url': preview_image.url,
                     'width': preview_image.width,

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -133,7 +133,7 @@ def edit(request, image_id):
         # Give error if image file doesn't exist
         if not os.path.isfile(local_path):
             messages.error(request, _("The source image file could not be found. Please change the source or delete the image.").format(image.title), buttons=[
-                messages.button(reverse('wagtailimages:delete_image', args=(image.id,)), _('Delete'))
+                messages.button(reverse('wagtailimages:delete', args=(image.id,)), _('Delete'))
             ])
 
     return render(request, "wagtailimages/images/edit.html", {

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -108,7 +108,7 @@ def edit(request, image_id):
                 backend.add(image)
 
             messages.success(request, _("Image '{0}' updated.").format(image.title), buttons=[
-                messages.button(reverse('wagtailimages:edit_image', args=(image.id,)), _('Edit again'))
+                messages.button(reverse('wagtailimages:edit', args=(image.id,)), _('Edit again'))
             ])
             return redirect('wagtailimages:index')
         else:
@@ -252,7 +252,7 @@ def add(request):
                 backend.add(image)
 
             messages.success(request, _("Image '{0}' added.").format(image.title), buttons=[
-                messages.button(reverse('wagtailimages:edit_image', args=(image.id,)), _('Edit'))
+                messages.button(reverse('wagtailimages:edit', args=(image.id,)), _('Edit'))
             ])
             return redirect('wagtailimages:index')
         else:

--- a/wagtail/wagtailredirects/templates/wagtailredirects/add.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/add.html
@@ -6,7 +6,7 @@
     {% trans "Add redirect" as add_red_str %}
     {% include "wagtailadmin/shared/header.html" with title=add_red_str icon="redirect" %}
 
-    <form action="{% url 'wagtailredirects:add_redirect' %}" method="POST" class="nice-padding">
+    <form action="{% url 'wagtailredirects:add' %}" method="POST" class="nice-padding">
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
 

--- a/wagtail/wagtailredirects/templates/wagtailredirects/confirm_delete.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/confirm_delete.html
@@ -8,7 +8,7 @@
 
     <div class="row row-flush nice-padding">       
         <p>{% trans "Are you sure you want to delete this redirect?" %}</p>
-        <form action="{% url 'wagtailredirects:delete_redirect' redirect.id %}" method="POST">
+        <form action="{% url 'wagtailredirects:delete' redirect.id %}" method="POST">
             {% csrf_token %}
             <input type="submit" value="{% trans 'Yes, delete' %}" class="serious" />
         </form>

--- a/wagtail/wagtailredirects/templates/wagtailredirects/edit.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/edit.html
@@ -6,7 +6,7 @@
     {% trans "Editing" as editing_str %}
     {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=redirect.title icon="redirect" %}
 
-    <form action="{% url 'wagtailredirects:edit_redirect' redirect.id %}" method="POST" class="nice-padding">
+    <form action="{% url 'wagtailredirects:edit' redirect.id %}" method="POST" class="nice-padding">
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
 

--- a/wagtail/wagtailredirects/templates/wagtailredirects/edit.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/edit.html
@@ -12,7 +12,7 @@
 
         <div>
             <input type="submit" value="{% trans 'Save' %}" />
-            <a href="{% url 'wagtailredirects:delete_redirect' redirect.id %}" class="button button-secondary no">{% trans "Delete redirect" %}</a>
+            <a href="{% url 'wagtailredirects:delete' redirect.id %}" class="button button-secondary no">{% trans "Delete redirect" %}</a>
         </div>
     </form>
     

--- a/wagtail/wagtailredirects/templates/wagtailredirects/index.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/index.html
@@ -16,7 +16,7 @@
 {% block content %}
     {% trans "Redirects" as redirects_str %}
     {% trans "Add redirect" as add_str %}
-    {% include "wagtailadmin/shared/header.html" with title=redirects_str icon="redirect" add_link="wagtailredirects:add_redirect" add_text=add_str search_url="wagtailredirects:index" %}
+    {% include "wagtailadmin/shared/header.html" with title=redirects_str icon="redirect" add_link="wagtailredirects:add" add_text=add_str search_url="wagtailredirects:index" %}
 
     <div class="nice-padding">
         <div id="redirects-results" class="redirects">

--- a/wagtail/wagtailredirects/templates/wagtailredirects/list.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/list.html
@@ -22,7 +22,7 @@
         {% for redirect in redirects %}
             <tr>
                 <td class="title">
-                    <h2><a href="{% url 'wagtailredirects:edit_redirect' redirect.id %}" title="{% trans 'Edit this redirect' %}">{{ redirect.title }}</a></h2>
+                    <h2><a href="{% url 'wagtailredirects:edit' redirect.id %}" title="{% trans 'Edit this redirect' %}">{{ redirect.title }}</a></h2>
                 </td>
                 <td>
                     {% if redirect.redirect_page %}

--- a/wagtail/wagtailredirects/templates/wagtailredirects/results.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/results.html
@@ -17,7 +17,7 @@
      {% if query_string %}
          <p>{% blocktrans %}Sorry, no redirects match "<em>{{ query_string }}</em>"{% endblocktrans %}
      {% else %}
-        {% url 'wagtailredirects:add_redirect' as wagtailredirects_add_redirect_url %}
+        {% url 'wagtailredirects:add' as wagtailredirects_add_redirect_url %}
         <p>{% blocktrans %}No redirects have been created. Why not <a href="{{ wagtailredirects_add_redirect_url }}">add one</a>?{% endblocktrans %}</p>
     {% endif %}
 {% endif %}

--- a/wagtail/wagtailredirects/tests.py
+++ b/wagtail/wagtailredirects/tests.py
@@ -95,10 +95,10 @@ class TestRedirectsAddView(TestCase, WagtailTestUtils):
         self.login()
 
     def get(self, params={}):
-        return self.client.get(reverse('wagtailredirects:add_redirect'), params)
+        return self.client.get(reverse('wagtailredirects:add'), params)
 
     def post(self, post_data={}):
-        return self.client.post(reverse('wagtailredirects:add_redirect'), post_data)
+        return self.client.post(reverse('wagtailredirects:add'), post_data)
 
     def test_simple(self):
         response = self.get()

--- a/wagtail/wagtailredirects/tests.py
+++ b/wagtail/wagtailredirects/tests.py
@@ -141,10 +141,10 @@ class TestRedirectsEditView(TestCase, WagtailTestUtils):
         self.login()
 
     def get(self, params={}, redirect_id=None):
-        return self.client.get(reverse('wagtailredirects:edit_redirect', args=(redirect_id or self.redirect.id, )), params)
+        return self.client.get(reverse('wagtailredirects:edit', args=(redirect_id or self.redirect.id, )), params)
 
     def post(self, post_data={}, redirect_id=None):
-        return self.client.post(reverse('wagtailredirects:edit_redirect', args=(redirect_id or self.redirect.id, )), post_data)
+        return self.client.post(reverse('wagtailredirects:edit', args=(redirect_id or self.redirect.id, )), post_data)
 
     def test_simple(self):
         response = self.get()

--- a/wagtail/wagtailredirects/tests.py
+++ b/wagtail/wagtailredirects/tests.py
@@ -189,10 +189,10 @@ class TestRedirectsDeleteView(TestCase, WagtailTestUtils):
         self.login()
 
     def get(self, params={}, redirect_id=None):
-        return self.client.get(reverse('wagtailredirects:delete_redirect', args=(redirect_id or self.redirect.id, )), params)
+        return self.client.get(reverse('wagtailredirects:delete', args=(redirect_id or self.redirect.id, )), params)
 
     def post(self, post_data={}, redirect_id=None):
-        return self.client.post(reverse('wagtailredirects:delete_redirect', args=(redirect_id or self.redirect.id, )), post_data)
+        return self.client.post(reverse('wagtailredirects:delete', args=(redirect_id or self.redirect.id, )), post_data)
 
     def test_simple(self):
         response = self.get()

--- a/wagtail/wagtailredirects/urls.py
+++ b/wagtail/wagtailredirects/urls.py
@@ -6,5 +6,5 @@ urlpatterns = [
     url(r'^$', views.index, name='index'),
     url(r'^add/$', views.add, name='add'),
     url(r'^(\d+)/$', views.edit, name='edit'),
-    url(r'^(\d+)/delete/$', views.delete, name='delete_redirect'),
+    url(r'^(\d+)/delete/$', views.delete, name='delete'),
 ]

--- a/wagtail/wagtailredirects/urls.py
+++ b/wagtail/wagtailredirects/urls.py
@@ -5,6 +5,6 @@ from wagtail.wagtailredirects import views
 urlpatterns = [
     url(r'^$', views.index, name='index'),
     url(r'^add/$', views.add, name='add'),
-    url(r'^(\d+)/$', views.edit, name='edit_redirect'),
+    url(r'^(\d+)/$', views.edit, name='edit'),
     url(r'^(\d+)/delete/$', views.delete, name='delete_redirect'),
 ]

--- a/wagtail/wagtailredirects/urls.py
+++ b/wagtail/wagtailredirects/urls.py
@@ -4,7 +4,7 @@ from wagtail.wagtailredirects import views
 
 urlpatterns = [
     url(r'^$', views.index, name='index'),
+    url(r'^add/$', views.add, name='add'),
     url(r'^(\d+)/$', views.edit, name='edit_redirect'),
     url(r'^(\d+)/delete/$', views.delete, name='delete_redirect'),
-    url(r'^add/$', views.add, name='add_redirect'),
 ]

--- a/wagtail/wagtailredirects/views.py
+++ b/wagtail/wagtailredirects/views.py
@@ -70,7 +70,7 @@ def edit(request, redirect_id):
         if form.is_valid():
             form.save()
             messages.success(request, _("Redirect '{0}' updated.").format(theredirect.title), buttons=[
-                messages.button(reverse('wagtailredirects:edit_redirect', args=(theredirect.id,)), _('Edit'))
+                messages.button(reverse('wagtailredirects:edit', args=(theredirect.id,)), _('Edit'))
             ])
             return redirect('wagtailredirects:index')
         else:
@@ -113,7 +113,7 @@ def add(request):
             theredirect.save()
 
             messages.success(request, _("Redirect '{0}' added.").format(theredirect.title), buttons=[
-                messages.button(reverse('wagtailredirects:edit_redirect', args=(theredirect.id,)), _('Edit'))
+                messages.button(reverse('wagtailredirects:edit', args=(theredirect.id,)), _('Edit'))
             ])
             return redirect('wagtailredirects:index')
         else:

--- a/wagtail/wagtailsites/templates/wagtailsites/create.html
+++ b/wagtail/wagtailsites/templates/wagtailsites/create.html
@@ -9,7 +9,7 @@
     {% trans "Add site" as add_site_str %}
     {% include "wagtailadmin/shared/header.html" with title=add_site_str icon="site" %}
 
-    <form action="{% url 'wagtailsites:create' %}" method="POST">
+    <form action="{% url 'wagtailsites:add' %}" method="POST">
         {% csrf_token %}
         <div class="nice-padding">
             <ul class="fields">

--- a/wagtail/wagtailsites/templates/wagtailsites/index.html
+++ b/wagtail/wagtailsites/templates/wagtailsites/index.html
@@ -5,7 +5,7 @@
     {% trans "Sites" as sites_str %}
     {% if perms.site.add_site %}
         {% trans "Add a site" as add_a_site_str %}
-        {% include "wagtailadmin/shared/header.html" with title=sites_str add_link="wagtailsites:create" add_text=add_a_site_str icon="site" %}
+        {% include "wagtailadmin/shared/header.html" with title=sites_str add_link="wagtailsites:add" add_text=add_a_site_str icon="site" %}
     {% else %}
         {% include "wagtailadmin/shared/header.html" with title=sites_str icon="site" %}
     {% endif %}

--- a/wagtail/wagtailsites/tests.py
+++ b/wagtail/wagtailsites/tests.py
@@ -34,10 +34,10 @@ class TestSiteCreateView(TestCase, WagtailTestUtils):
         self.localhost = Site.objects.all()[0]
 
     def get(self, params={}):
-        return self.client.get(reverse('wagtailsites:create'), params)
+        return self.client.get(reverse('wagtailsites:add'), params)
 
     def post(self, post_data={}):
-        return self.client.post(reverse('wagtailsites:create'), post_data)
+        return self.client.post(reverse('wagtailsites:add'), post_data)
 
     def create_site(self, hostname='testsite', port=80, is_default_site=False, root_page=None):
         root_page = root_page or self.home_page

--- a/wagtail/wagtailsites/urls.py
+++ b/wagtail/wagtailsites/urls.py
@@ -2,10 +2,8 @@ from django.conf.urls import url
 from wagtail.wagtailsites import views
 
 urlpatterns = [
-
     url(r'^$', views.index, name='index'),
-    url(r'^new/$', views.create, name='create'),
+    url(r'^add/$', views.create, name='add'),
     url(r'^(\d+)/$', views.edit, name='edit'),
     url(r'^(\d+)/delete/$', views.delete, name='delete'),
-
 ]

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/chooser/choose.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/chooser/choose.html
@@ -6,7 +6,7 @@
     {% if items %}
     	{% include "wagtailsnippets/chooser/list.html" with choosing=1 %}
     {% else %}
-    	{% url 'wagtailsnippets:create' content_type.app_label content_type.model as wagtailsnippets_create_snippet_url %}
+    	{% url 'wagtailsnippets:add' content_type.app_label content_type.model as wagtailsnippets_create_snippet_url %}
     	<p>{% blocktrans %}You haven't created any {{ snippet_type_name }} snippets. Why not <a href="{{ wagtailsnippets_create_snippet_url }}" target="_blank">create one now{% endblocktrans %}</p>
     {% endif %}
 

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/create.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/create.html
@@ -6,7 +6,7 @@
     {% trans "New" as new_str %}
     {% include "wagtailadmin/shared/header.html" with title=new_str subtitle=snippet_type_name icon="snippet" %}
 
-    <form action="{% url 'wagtailsnippets:create' content_type.app_label content_type.model %}" method="POST">
+    <form action="{% url 'wagtailsnippets:add' content_type.app_label content_type.model %}" method="POST">
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
         

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/type_index.html
@@ -10,7 +10,7 @@
                 <h1 class="icon icon-snippet">{% blocktrans with snippet_type_name_plural=snippet_type_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}</h1>
             </div>
             <div class="right col3">
-                <a href="{% url 'wagtailsnippets:create' content_type.app_label content_type.model %}" class="button bicolor icon icon-plus">{% blocktrans %}Add {{ snippet_type_name }}{% endblocktrans %}</a>
+                <a href="{% url 'wagtailsnippets:add' content_type.app_label content_type.model %}" class="button bicolor icon icon-plus">{% blocktrans %}Add {{ snippet_type_name }}{% endblocktrans %}</a>
                 {# TODO: figure out a way of saying "Add a/an [foo]" #}
             </div>
         </div>
@@ -19,7 +19,7 @@
         {% if items %}
             {% include "wagtailsnippets/snippets/list.html" %}
         {% else %}
-            {% url 'wagtailsnippets:create' content_type.app_label content_type.model as wagtailsnippets_create_url %}
+            {% url 'wagtailsnippets:add' content_type.app_label content_type.model as wagtailsnippets_create_url %}
             <p class="no-results-message">{% blocktrans %}No {{ snippet_type_name_plural }} have been created. Why not <a href="{{ wagtailsnippets_create_url }}">add one</a>?{% endblocktrans %}</p>
         {% endif %}
     </div>

--- a/wagtail/wagtailsnippets/tests.py
+++ b/wagtail/wagtailsnippets/tests.py
@@ -60,12 +60,12 @@ class TestSnippetCreateView(TestCase, WagtailTestUtils):
         self.login()
 
     def get(self, params={}):
-        return self.client.get(reverse('wagtailsnippets:create',
+        return self.client.get(reverse('wagtailsnippets:add',
                                        args=('tests', 'advert')),
                                params)
 
     def post(self, post_data={}):
-        return self.client.post(reverse('wagtailsnippets:create',
+        return self.client.post(reverse('wagtailsnippets:add',
                                args=('tests', 'advert')),
                                post_data)
 

--- a/wagtail/wagtailsnippets/urls.py
+++ b/wagtail/wagtailsnippets/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     url(r'^choose/(\w+)/(\w+)/(\d+)/$', chooser.chosen, name='chosen'),
 
     url(r'^(\w+)/(\w+)/$', snippets.list, name='list'),
-    url(r'^(\w+)/(\w+)/new/$', snippets.create, name='create'),
+    url(r'^(\w+)/(\w+)/add/$', snippets.create, name='add'),
     url(r'^(\w+)/(\w+)/(\d+)/$', snippets.edit, name='edit'),
     url(r'^(\w+)/(\w+)/(\d+)/delete/$', snippets.delete, name='delete'),
     url(r'^(\w+)/(\w+)/(\d+)/usage/$', snippets.usage, name='usage'),

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/create.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/create.html
@@ -16,7 +16,7 @@
     {% include "wagtailadmin/shared/header.html" with title=add_group_str icon="group" %}
     
     <div class="nice-padding">
-        <form action="{% url 'wagtailusers_groups:create' %}" method="POST">
+        <form action="{% url 'wagtailusers_groups:add' %}" method="POST">
             {% csrf_token %}
             
             <ul class="fields">

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/index.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/index.html
@@ -16,7 +16,7 @@
 {% block content %}
     {% trans "groups" as groups_str %}
     {% trans "Add a group" as add_a_group_str %}
-    {% include "wagtailadmin/shared/header.html" with title=groups_str add_link="wagtailusers_groups:create" add_text=add_a_group_str icon="group" search_url="wagtailusers_groups:index" %}
+    {% include "wagtailadmin/shared/header.html" with title=groups_str add_link="wagtailusers_groups:add" add_text=add_a_group_str icon="group" search_url="wagtailusers_groups:index" %}
 
     <div class="nice-padding">
         <div id="group-results" class="groups">

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/results.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/results.html
@@ -5,6 +5,6 @@
 
     {% include "wagtailadmin/shared/pagination_nav.html" with items=groups is_searching=is_searching linkurl="wagtailusers_groups:index" %}
 {% else %}
-    {% url 'wagtailusers_groups:create' as wagtailusers_create_group_url %}
+    {% url 'wagtailusers_groups:add' as wagtailusers_create_group_url %}
     <p>{% blocktrans %}There are no groups configured. Why not <a href="{{ wagtailusers_create_group_url }}">add some</a>?{% endblocktrans %}</p>
 {% endif %}

--- a/wagtail/wagtailusers/templates/wagtailusers/users/create.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/create.html
@@ -13,7 +13,7 @@
         <li><a href="#roles">{% trans "Roles" %}</a></li>
     </ul>   
 
-    <form action="{% url 'wagtailusers_users:create' %}" method="POST">
+    <form action="{% url 'wagtailusers_users:add' %}" method="POST">
         <div class="tab-content">
             {% csrf_token %}
             <section id="account" class="active nice-padding">

--- a/wagtail/wagtailusers/templates/wagtailusers/users/index.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/index.html
@@ -16,7 +16,7 @@
 {% block content %}
     {% trans "Users" as users_str %}
     {% trans "Add a user" as add_a_user_str %}
-    {% include "wagtailadmin/shared/header.html" with title=users_str add_link="wagtailusers_users:create" add_text=add_a_user_str icon="user" search_url="wagtailusers_users:index" %}
+    {% include "wagtailadmin/shared/header.html" with title=users_str add_link="wagtailusers_users:add" add_text=add_a_user_str icon="user" search_url="wagtailusers_users:index" %}
 
     <div class="nice-padding">
         <div id="user-results" class="users">

--- a/wagtail/wagtailusers/tests.py
+++ b/wagtail/wagtailusers/tests.py
@@ -54,10 +54,10 @@ class TestUserCreateView(TestCase, WagtailTestUtils):
         self.login()
 
     def get(self, params={}):
-        return self.client.get(reverse('wagtailusers_users:create'), params)
+        return self.client.get(reverse('wagtailusers_users:add'), params)
 
     def post(self, post_data={}):
-        return self.client.post(reverse('wagtailusers_users:create'), post_data)
+        return self.client.post(reverse('wagtailusers_users:add'), post_data)
 
     def test_simple(self):
         response = self.get()
@@ -182,7 +182,7 @@ class TestGroupCreateView(TestCase, WagtailTestUtils):
         self.login()
 
     def get(self, params={}):
-        return self.client.get(reverse('wagtailusers_groups:create'), params)
+        return self.client.get(reverse('wagtailusers_groups:add'), params)
 
     def post(self, post_data={}):
         post_defaults = {
@@ -192,7 +192,7 @@ class TestGroupCreateView(TestCase, WagtailTestUtils):
         }
         for k, v in six.iteritems(post_defaults):
             post_data[k] = post_data.get(k, v)
-        return self.client.post(reverse('wagtailusers_groups:create'), post_data)
+        return self.client.post(reverse('wagtailusers_groups:add'), post_data)
 
     def test_simple(self):
         response = self.get()

--- a/wagtail/wagtailusers/urls/groups.py
+++ b/wagtail/wagtailusers/urls/groups.py
@@ -3,7 +3,7 @@ from wagtail.wagtailusers.views import groups
 
 urlpatterns = [
     url(r'^$', groups.index, name='index'),
-    url(r'^new/$', groups.create, name='create'),
+    url(r'^add/$', groups.create, name='add'),
     url(r'^(\d+)/$', groups.edit, name='edit'),
     url(r'^(\d+)/delete/$', groups.delete, name='delete'),
 ]

--- a/wagtail/wagtailusers/urls/users.py
+++ b/wagtail/wagtailusers/urls/users.py
@@ -3,6 +3,6 @@ from wagtail.wagtailusers.views import users
 
 urlpatterns = [
     url(r'^$', users.index, name='index'),
-    url(r'^new/$', users.create, name='create'),
+    url(r'^add/$', users.create, name='add'),
     url(r'^([^\/]+)/$', users.edit, name='edit'),
 ]


### PR DESCRIPTION
Naming of URLs is inconsistent in Wagtail. This PR aims to standardise the common ones.

This is required if we're going to refactor wagtails admin interface into "modules" (#858, #891)

See commit log for details