### PR TITLE
Fix rich text link modal window tabs

### DIFF
--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -19,6 +19,16 @@ def get_querystring(request):
     })
 
 
+def shared_context(request, extra_context={}):
+    context = {
+        'allow_external_link': request.GET.get('allow_external_link'),
+        'allow_email_link': request.GET.get('allow_email_link'),
+        'querystring': get_querystring(request),
+    }
+    context.update(extra_context)
+    return context
+
+
 def browse(request, parent_page_id=None):
     ITEMS_PER_PAGE = 25
 
@@ -79,17 +89,18 @@ def browse(request, parent_page_id=None):
         except EmptyPage:
             pages = paginator.page(paginator.num_pages)
 
-    return render_modal_workflow(request, 'wagtailadmin/chooser/browse.html', 'wagtailadmin/chooser/browse.js', {
-        'allow_external_link': request.GET.get('allow_external_link'),
-        'allow_email_link': request.GET.get('allow_email_link'),
-        'querystring': get_querystring(request),
-        'parent_page': parent_page,
-        'pages': pages,
-        'search_form': search_form,
-        'page_type_string': page_type,
-        'page_type_name': desired_class.get_verbose_name(),
-        'page_types_restricted': (page_type != 'wagtailcore.page')
-    })
+    return render_modal_workflow(
+        request,
+        'wagtailadmin/chooser/browse.html', 'wagtailadmin/chooser/browse.js',
+        shared_context(request, {
+            'parent_page': parent_page,
+            'pages': pages,
+            'search_form': search_form,
+            'page_type_string': page_type,
+            'page_type_name': desired_class.get_verbose_name(),
+            'page_types_restricted': (page_type != 'wagtailcore.page')
+        })
+    )
 
 
 def search(request, parent_page_id=None):
@@ -115,11 +126,13 @@ def search(request, parent_page_id=None):
         page.can_choose = True
         shown_pages.append(page)
 
-    return render(request, 'wagtailadmin/chooser/_search_results.html', {
-        'querystring': get_querystring(request),
-        'searchform': search_form,
-        'pages': shown_pages,
-    })
+    return render(
+        request, 'wagtailadmin/chooser/_search_results.html',
+        shared_context(request, {
+            'searchform': search_form,
+            'pages': shown_pages,
+        })
+    )
 
 
 def external_link(request):
@@ -147,11 +160,9 @@ def external_link(request):
     return render_modal_workflow(
         request,
         'wagtailadmin/chooser/external_link.html', 'wagtailadmin/chooser/external_link.js',
-        {
-            'querystring': get_querystring(request),
-            'allow_email_link': request.GET.get('allow_email_link'),
+        shared_context(request, {
             'form': form,
-        }
+        })
     )
 
 
@@ -180,9 +191,7 @@ def email_link(request):
     return render_modal_workflow(
         request,
         'wagtailadmin/chooser/email_link.html', 'wagtailadmin/chooser/email_link.js',
-        {
-            'querystring': get_querystring(request),
-            'allow_external_link': request.GET.get('allow_external_link'),
+        shared_context(request, {
             'form': form,
-        }
+        })
     )


### PR DESCRIPTION
Some or all of the 'Internal link | External link | Email link' tabs at the top of the modal disappeared when changing tabs. This was caused by the `allow_external_link`/`allow_email_link` context variables not consistently being set across all instances where the tabs were printed.

A new `shared_context(request)` function has been added that generate these context variables, which can easily be used to add these variables to any context that needs them.