### PR TITLE
Added min_num and max_num parameters to InlinePanel

### DIFF
--- a/docs/reference/pages/editing_api.rst
+++ b/docs/reference/pages/editing_api.rst
@@ -115,7 +115,7 @@ MultiFieldPanel
 InlinePanel
 -----------
 
-.. class:: InlinePanel(relation_name, panels=None, classname=None, label='', help_text='')
+.. class:: InlinePanel(relation_name, panels=None, classname=None, label='', help_text='', min_num=None, max_num=None)
 
     This panel allows for the creation of a "cluster" of related objects over a join to a separate model, such as a list of related links or slides to an image carousel.
 
@@ -342,9 +342,9 @@ The ``RelatedLink`` class is a vanilla Django abstract model. The ``BookPageRela
 
 .. code-block:: python
 
-    InlinePanel( relation_name, panels=None, label='', help_text='' )
+    InlinePanel( relation_name, panels=None, label='', help_text='', min_num=None, max_num=None )
 
-The ``relation_name`` is the ``related_name`` label given to the cluster's ``ParentalKey`` relation. You can add the ``panels`` manually or make them part of the cluster model. Finally, ``label`` and ``help_text`` provide a heading and caption, respectively, for the Wagtail editor.
+The ``relation_name`` is the ``related_name`` label given to the cluster's ``ParentalKey`` relation. You can add the ``panels`` manually or make them part of the cluster model. ``label`` and ``help_text`` provide a heading and caption, respectively, for the Wagtail editor. Finally, ``min_num`` and ``max_num`` allow you to set the minimum/maximum number of forms that the user must submit.
 
 .. versionchanged:: 1.0
 

--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -612,6 +612,10 @@ class BaseInlinePanel(EditHandler):
             cls.relation_name: {
                 'fields': child_edit_handler_class.required_fields(),
                 'widgets': child_edit_handler_class.widget_overrides(),
+                'min_num': cls.min_num,
+                'validate_min': cls.min_num is not None,
+                'max_num': cls.max_num,
+                'validate_max': cls.max_num is not None
             }
         }
 
@@ -686,6 +690,8 @@ class InlinePanel(object):
         self.panels = kwargs.pop('panels', None)
         self.label = kwargs.pop('label', '')
         self.help_text = kwargs.pop('help_text', '')
+        self.min_num = kwargs.pop('min_num', None)
+        self.max_num = kwargs.pop('max_num', None)
 
         if kwargs:
             raise TypeError("InlinePanel got an unexpected keyword argument '%s'" % kwargs.keys()[0])
@@ -698,6 +704,8 @@ class InlinePanel(object):
             'panels': self.panels,
             'heading': self.label,
             'help_text': self.help_text,  # TODO: can we pick this out of the foreign key definition as an alternative? (with a bit of help from the inlineformset object, as we do for label/heading)
+            'min_num': self.min_num,
+            'max_num': self.max_num
         })
 
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/edit_handlers/inline_panel.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/edit_handlers/inline_panel.html
@@ -1,7 +1,16 @@
 {% load wagtailadmin_tags  %}
 
 {{ self.formset.management_form }}
+
 <ul class="multiple" id="id_{{ self.formset.prefix }}-FORMS">
+    {% if self.formset.non_form_errors %}
+        <li class="error-message">
+            {% for error in self.formset.non_form_errors %}
+                <span>{{ error|escape }}</span>
+            {% endfor %}
+        </li>
+    {% endif %}
+
     {% for child in self.children %}
         {% include "wagtailadmin/edit_handlers/inline_panel_child.html" %}
     {% endfor %}


### PR DESCRIPTION
This pull request implements ``min_num`` and ``max_num`` parameters on ``InlinePanel`` (#669)

It requires a change to ``django-modelcluster`` (https://github.com/torchbox/django-modelcluster/pull/37)