### PR TITLE
Allow limiting PageChooserBlock to specific page type.

### DIFF
--- a/wagtail/wagtailadmin/widgets.py
+++ b/wagtail/wagtailadmin/widgets.py
@@ -123,6 +123,9 @@ class AdminPageChooser(AdminChooser):
         model_class = self.target_content_type.model_class()
         instance, value = self.get_instance_and_id(model_class, value)
 
+        if value and not isinstance(value, int):
+            value = value.pk
+
         original_field_html = super(AdminPageChooser, self).render_html(name, value, attrs)
 
         return render_to_string("wagtailadmin/widgets/page_chooser.html", {

--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -352,15 +352,26 @@ class ChooserBlock(FieldBlock):
 
 
 class PageChooserBlock(ChooserBlock):
+    def __init__(self, model_string=None, **kwargs):
+        super(PageChooserBlock, self).__init__(**kwargs)
+        self.model_string = model_string
+
     @cached_property
     def target_model(self):
-        from wagtail.wagtailcore.models import Page  # TODO: allow limiting to specific page types
+        from wagtail.wagtailcore.models import Page
         return Page
 
     @cached_property
     def widget(self):
         from wagtail.wagtailadmin.widgets import AdminPageChooser
-        return AdminPageChooser
+        if self.model_string:
+            from django.contrib.contenttypes.models import ContentType
+            from wagtail.wagtailcore.utils import resolve_model_string
+            model = resolve_model_string(self.model_string)
+            ct = ContentType.objects.get_for_model(model)
+            return AdminPageChooser(ct)
+        else:
+            return AdminPageChooser
 
     def render_basic(self, value):
         if value:


### PR DESCRIPTION
Tested, pep8 checked, implements nicely. Currently, I override PageChooserBlock in my project the same way and use that 'PageChooserBlockOverride' class in my StreamFields when needed. Using Wagtail (1.0), Django (1.8.3) no issues detected. 

This was a feature I needed for my project. It is amusing to notice that PageChooserPanel has such functionality but block doesn't.