### PR TITLE
Multiple page types in PageChooserPanel (#199)

### DIFF
--- a/docs/reference/pages/editing_api.rst
+++ b/docs/reference/pages/editing_api.rst
@@ -163,10 +163,15 @@ PageChooserPanel
             )
 
             content_panels = Page.content_panels + [
-                PageChooserPanel('related_page', 'demo.PublisherPage'),
+                PageChooserPanel('related_page', ['demo.PublisherPage', 'demo.EventPage']),
             ]
 
-    ``PageChooserPanel`` takes two arguments: a field name and an optional page type. Specifying a page type (in the form of an ``"appname.modelname"`` string) will filter the chooser to display only pages of that type.
+    ``PageChooserPanel`` takes two arguments: a field name and an optional page type.
+
+    The page type parameter restricts which page types can be selected in this field. It defaults to the model that the ``ForeignKey`` is pointing at (in this case, ``wagtailcore.Page``).
+
+    This paramater will take a model class, a string (in the form of an ``"appname.modelname"`` string) or a list of strings/model classes.
+
 
 ImageChooserPanel
 -----------------

--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -544,44 +544,66 @@ class BaseChooserPanel(BaseFieldPanel):
 class BasePageChooserPanel(BaseChooserPanel):
     object_type_name = "page"
 
-    _target_content_type = None
+    _target_content_types = None
 
     @classmethod
     def widget_overrides(cls):
         return {cls.field_name: widgets.AdminPageChooser(
-            content_type=cls.target_content_type())}
+            content_types=cls.target_content_types())}
 
     @classmethod
-    def target_content_type(cls):
-        if cls._target_content_type is None:
-            if cls.page_type:
-                try:
-                    model = resolve_model_string(cls.page_type)
-                except LookupError:
-                    raise ImproperlyConfigured("{0}.page_type must be of the form 'app_label.model_name', given {1!r}".format(
-                        cls.__name__, cls.page_type))
-                except ValueError:
-                    raise ImproperlyConfigured("{0}.page_type refers to model {1!r} that has not been installed".format(
-                        cls.__name__, cls.page_type))
+    def target_content_types(cls):
+        if cls._target_content_types is None:
+            if cls.page_types:
+                models = []
 
-                cls._target_content_type = ContentType.objects.get_for_model(model)
+                for page_type in cls.page_types:
+                    try:
+                        models.append(resolve_model_string(page_type))
+                    except LookupError:
+                        raise ImproperlyConfigured("{0}.page_type must be of the form 'app_label.model_name', given {1!r}".format(
+                            cls.__name__, page_type))
+                    except ValueError:
+                        raise ImproperlyConfigured("{0}.page_type refers to model {1!r} that has not been installed".format(
+                            cls.__name__, page_type))
+
+                # Get a mapping of ContentType objects for the models
+                content_types = ContentType.objects.get_for_models(*models)
+
+                # Convert content types into a list and set it to _target_content_types
+                # As the content types were in a dict, the order would be randomised but
+                # we need the ordering on _target_content_types to be deterministic to
+                # simplify testing
+                cls._target_content_types = [
+                    content_types[model]
+                    for model in models
+                ]
             else:
-                target_model = cls.model._meta.get_field(cls.field_name).rel.to
-                cls._target_content_type = ContentType.objects.get_for_model(target_model)
+                # Find model by introspecting the ForeignKey
+                model = cls.model._meta.get_field(cls.field_name).rel.to
+                cls._target_content_types = [ContentType.objects.get_for_model(model)]
 
-        return cls._target_content_type
+        return cls._target_content_types
 
 
 class PageChooserPanel(object):
-    def __init__(self, field_name, page_type=None):
+    def __init__(self, field_name, page_types=None):
         self.field_name = field_name
-        self.page_type = page_type
+
+        # Make sure page_types is a list
+        if page_types is None:
+            page_types = []
+
+        if not isinstance(page_types, (list, tuple)):
+            page_types = [page_types]
+
+        self.page_types = page_types
 
     def bind_to_model(self, model):
         return type(str('_PageChooserPanel'), (BasePageChooserPanel,), {
             'model': model,
             'field_name': self.field_name,
-            'page_type': self.page_type,
+            'page_types': self.page_types,
         })
 
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/browse.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/browse.html
@@ -1,19 +1,18 @@
 {% load i18n %}
 {% if page_types_restricted %}
     {% trans "Choose" as choose_str %}
-    {% trans page_type_name as subtitle %}
 {% else %}
     {% trans "Choose a page" as choose_str %}
 {% endif %}
 
-{% include "wagtailadmin/shared/header.html" with title=choose_str subtitle=subtitle search_url="wagtailadmin_choose_page_search" query_parameters="page_type="|add:page_type_string icon="doc-empty-inverse" %}
+{% include "wagtailadmin/shared/header.html" with title=choose_str subtitle=page_type_names|join:", " search_url="wagtailadmin_choose_page_search" query_parameters="page_types="|add:page_type_string icon="doc-empty-inverse" %}
 
 <div class="nice-padding">
     {% include 'wagtailadmin/chooser/_link_types.html' with current='internal' %}
 
     {% if page_types_restricted %}
         <p class="help-block help-warning">
-            {% blocktrans with type=page_type_name %}
+            {% blocktrans with type=page_type_names|join:", " %}
                 Only pages of type "{{ type }}" may be chosen for this field. Search results will exclude pages of other types.
             {% endblocktrans %}
         </p>

--- a/wagtail/wagtailadmin/tests/test_page_chooser.py
+++ b/wagtail/wagtailadmin/tests/test_page_chooser.py
@@ -41,7 +41,7 @@ class TestChooserBrowse(TestCase, WagtailTestUtils):
         self.assertContains(response, "There are 0 matches")
 
     def test_get_invalid(self):
-        response = self.search({'page_type': 'foo.bar'})
+        response = self.search({'page_types': 'foo.bar'})
         self.assertEqual(response.status_code, 404)
 
 

--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -12,7 +12,7 @@ from wagtail.wagtailcore.models import Page
 
 def get_querystring(request):
     return urlencode({
-        'page_type': request.GET.get('page_type', ''),
+        'page_types': request.GET.get('page_types', ''),
         'allow_external_link': request.GET.get('allow_external_link', ''),
         'allow_email_link': request.GET.get('allow_email_link', ''),
         'prompt_for_link_text': request.GET.get('prompt_for_link_text', ''),
@@ -22,25 +22,29 @@ def get_querystring(request):
 def browse(request, parent_page_id=None):
     ITEMS_PER_PAGE = 25
 
-    page_type = request.GET.get('page_type') or 'wagtailcore.page'
-    content_type_app_name, content_type_model_name = page_type.split('.')
+    page_types = request.GET.get('page_types', 'wagtailcore.page').split(',')
 
-    try:
-        content_type = ContentType.objects.get_by_natural_key(content_type_app_name, content_type_model_name)
-    except ContentType.DoesNotExist:
-        raise Http404
-    desired_class = content_type.model_class()
+    desired_classes = []
+    for page_type in page_types:
+        content_type_app_name, content_type_model_name = page_type.split('.')
+
+        try:
+            content_type = ContentType.objects.get_by_natural_key(content_type_app_name, content_type_model_name)
+        except ContentType.DoesNotExist:
+            raise Http404
+
+        desired_classes.append(content_type.model_class())
 
     if parent_page_id:
         parent_page = get_object_or_404(Page, id=parent_page_id)
     else:
         parent_page = Page.get_first_root_node()
 
-    parent_page.can_choose = issubclass(parent_page.specific_class, desired_class)
+    parent_page.can_choose = issubclass(parent_page.specific_class, tuple(desired_classes))
     search_form = SearchForm()
     pages = parent_page.get_children()
 
-    if desired_class == Page:
+    if desired_classes == [Page]:
         # apply pagination first, since we know that the page listing won't
         # have to be filtered, and that saves us walking the entire list
         p = request.GET.get('p', 1)
@@ -63,7 +67,7 @@ def browse(request, parent_page_id=None):
 
         shown_pages = []
         for page in pages:
-            page.can_choose = issubclass(page.specific_class or Page, desired_class)
+            page.can_choose = issubclass(page.specific_class or Page, tuple(desired_classes))
             page.can_descend = page.get_children_count()
 
             if page.can_choose or page.can_descend:
@@ -86,29 +90,43 @@ def browse(request, parent_page_id=None):
         'parent_page': parent_page,
         'pages': pages,
         'search_form': search_form,
-        'page_type_string': page_type,
-        'page_type_name': desired_class.get_verbose_name(),
+        'page_type_string': ','.join(page_types),
+        'page_type_names': [desired_class.get_verbose_name() for desired_class in desired_classes],
         'page_types_restricted': (page_type != 'wagtailcore.page')
     })
 
 
 def search(request, parent_page_id=None):
-    page_type = request.GET.get('page_type') or 'wagtailcore.page'
-    content_type_app_name, content_type_model_name = page_type.split('.')
+    page_types = request.GET.get('page_types')
+    content_types = []
 
-    try:
-        content_type = ContentType.objects.get_by_natural_key(content_type_app_name, content_type_model_name)
-    except ContentType.DoesNotExist:
-        raise Http404
-    desired_class = content_type.model_class()
+    # Convert page_types string into list of ContentType objects
+    if page_types:
+        for page_type in page_types.split(','):
+            content_type_app_name, content_type_model_name = page_type.split('.')
+
+            try:
+                content_types.append(ContentType.objects.get_by_natural_key(content_type_app_name, content_type_model_name))
+            except ContentType.DoesNotExist:
+                raise Http404
 
     search_form = SearchForm(request.GET)
     if search_form.is_valid() and search_form.cleaned_data['q']:
-        pages = desired_class.objects.exclude(
+        pages = Page.objects.exclude(
             depth=1  # never include root
-        ).filter(title__icontains=search_form.cleaned_data['q'])[:10]
+        )
+
+        # Restrict content types
+        if content_types:
+            pages = pages.filter(content_type__in=content_types)
+
+        # Do search
+        pages = pages.filter(title__icontains=search_form.cleaned_data['q'])
+
+        # Truncate results
+        pages = pages[:10]
     else:
-        pages = desired_class.objects.none()
+        pages = Page.objects.none()
 
     shown_pages = []
     for page in pages:

--- a/wagtail/wagtailadmin/widgets.py
+++ b/wagtail/wagtailadmin/widgets.py
@@ -110,17 +110,21 @@ class AdminChooser(WidgetWithScript, widgets.Input):
 
 
 class AdminPageChooser(AdminChooser):
-    target_content_type = None
+    target_content_types = None
     choose_one_text = _('Choose a page')
     choose_another_text = _('Choose another page')
     link_to_chosen_text = _('Edit this page')
 
-    def __init__(self, content_type=None, **kwargs):
+    def __init__(self, content_types=None, **kwargs):
         super(AdminPageChooser, self).__init__(**kwargs)
-        self.target_content_type = content_type or ContentType.objects.get_for_model(Page)
+        self.target_content_types = content_types or [ContentType.objects.get_for_model(Page)]
 
     def render_html(self, name, value, attrs):
-        model_class = self.target_content_type.model_class()
+        if len(self.target_content_types) == 1:
+            model_class = self.target_content_types[0].model_class()
+        else:
+            model_class = Page
+
         instance, value = self.get_instance_and_id(model_class, value)
 
         original_field_html = super(AdminPageChooser, self).render_html(name, value, attrs)
@@ -134,17 +138,24 @@ class AdminPageChooser(AdminChooser):
         })
 
     def render_js_init(self, id_, name, value):
-        model_class = self.target_content_type.model_class()
-        if isinstance(value, model_class):
+        if isinstance(value, Page):
             page = value
         else:
+            if len(self.target_content_types) == 1:
+                model_class = self.target_content_types[0].model_class()
+            else:
+                model_class = Page
+
             page = self.get_instance(model_class, value)
+
         parent = page.get_parent() if page else None
-        content_type = self.target_content_type
 
         return "createPageChooser({id}, {content_type}, {parent});".format(
             id=json.dumps(id_),
-            content_type=json.dumps('{app}.{model}'.format(
-                app=content_type.app_label,
-                model=content_type.model)),
+            content_type=json.dumps([
+                '{app}.{model}'.format(
+                    app=content_type.app_label,
+                    model=content_type.model)
+                for content_type in self.target_content_types
+            ]),
             parent=json.dumps(parent.id if parent else None))


### PR DESCRIPTION
This pull request makes it possible to restrict the page types choosable in a particlular ``PageChooserPanel`` to multiple page types (instead of either one or none).

Fixes #199

Example:

```python
content_panels = [
    ...
   PageChooserPanel('page', ['blog.BlogPage', 'events.EventPage']),
]
```