### PR TITLE
Make wagtailsites work for non-superusers

### DIFF
--- a/wagtail/wagtailsites/templates/wagtailsites/edit.html
+++ b/wagtail/wagtailsites/templates/wagtailsites/edit.html
@@ -21,7 +21,7 @@
                 
                 <li>
                     <input type="submit" value="{% trans 'Save' %}" />
-                    {% if perms.site.delete_site %}
+                    {% if perms.wagtailcore.delete_site %}
                         <a href="{% url 'wagtailsites:delete' site.id %}" class="button button-secondary no">{% trans "Delete site" %}</a>
                     {% endif %}
                 </li>

--- a/wagtail/wagtailsites/templates/wagtailsites/index.html
+++ b/wagtail/wagtailsites/templates/wagtailsites/index.html
@@ -3,7 +3,7 @@
 {% block titletag %}{% trans "Sites" %}{% endblock %}
 {% block content %}
     {% trans "Sites" as sites_str %}
-    {% if perms.site.add_site %}
+    {% if perms.wagtailcore.add_site %}
         {% trans "Add a site" as add_a_site_str %}
         {% include "wagtailadmin/shared/header.html" with title=sites_str add_link="wagtailsites:add" add_text=add_a_site_str icon="site" %}
     {% else %}

--- a/wagtail/wagtailsites/tests.py
+++ b/wagtail/wagtailsites/tests.py
@@ -244,9 +244,7 @@ class TestSiteDeleteView(TestCase, WagtailTestUtils):
         self.assertEqual(self.get(site_id=100000).status_code, 404)
 
     def test_posting_deletes_site(self):
-        response = self.post({
-            'trivial_key': 'trivial_value'
-        })
+        response = self.post()
 
         # Should redirect back to index
         self.assertRedirects(response, reverse('wagtailsites:index'))
@@ -325,9 +323,7 @@ class TestLimitedPermissions(TestCase, WagtailTestUtils):
 
     def test_delete(self):
         delete_url = reverse('wagtailsites:delete', args=(self.localhost.id,))
-        response = self.client.post(delete_url, {
-            'trivial_key': 'trivial_value'
-        })
+        response = self.client.post(delete_url)
 
         # Should redirect back to index
         self.assertRedirects(response, reverse('wagtailsites:index'))

--- a/wagtail/wagtailsites/tests.py
+++ b/wagtail/wagtailsites/tests.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 from django.utils import six
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailcore.models import Site, Page
@@ -243,6 +245,87 @@ class TestSiteDeleteView(TestCase, WagtailTestUtils):
 
     def test_posting_deletes_site(self):
         response = self.post({
+            'trivial_key': 'trivial_value'
+        })
+
+        # Should redirect back to index
+        self.assertRedirects(response, reverse('wagtailsites:index'))
+
+        # Check that the site was edited
+        with self.assertRaises(Site.DoesNotExist):
+            Site.objects.get(id=self.localhost.id)
+
+
+class TestLimitedPermissions(TestCase, WagtailTestUtils):
+    def setUp(self):
+        # Create a user
+        user = get_user_model().objects.create_user(username='test', email='test@email.com', password='password')
+        user.user_permissions.add(
+            Permission.objects.get(codename='access_admin'),
+            Permission.objects.get(codename='add_site'),
+            Permission.objects.get(codename='change_site'),
+            Permission.objects.get(codename='delete_site')
+        )
+
+        # Login
+        self.client.login(username='test', password='password')
+
+        self.home_page = Page.objects.get(id=2)
+        self.localhost = Site.objects.all()[0]
+
+    def test_get_index(self):
+        response = self.client.get(reverse('wagtailsites:index'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailsites/index.html')
+
+    def test_get_create_view(self):
+        response = self.client.get(reverse('wagtailsites:add'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailsites/create.html')
+
+    def test_create(self):
+        response = self.client.post(reverse('wagtailsites:add'), {
+            'hostname': "testsite",
+            'port': "80",
+            'root_page': str(self.home_page.id),
+        })
+
+        # Should redirect back to index
+        self.assertRedirects(response, reverse('wagtailsites:index'))
+
+        # Check that the site was created
+        self.assertEqual(Site.objects.filter(hostname='testsite').count(), 1)
+
+    def test_get_edit_view(self):
+        edit_url = reverse('wagtailsites:edit', args=(self.localhost.id,))
+        response = self.client.get(edit_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailsites/edit.html')
+
+    def test_edit(self):
+        edit_url = reverse('wagtailsites:edit', args=(self.localhost.id,))
+        edited_hostname = 'edited'
+        response = self.client.post(edit_url, {
+            'hostname': edited_hostname,
+            'port': 80,
+            'root_page': self.home_page.id,
+        })
+
+        # Should redirect back to index
+        self.assertRedirects(response, reverse('wagtailsites:index'))
+
+        # Check that the site was edited
+        self.assertEqual(Site.objects.get(id=self.localhost.id).hostname, edited_hostname)
+
+    def test_get_delete_view(self):
+        delete_url = reverse('wagtailsites:delete', args=(self.localhost.id,))
+        response = self.client.get(delete_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailsites/confirm_delete.html')
+
+    def test_delete(self):
+        delete_url = reverse('wagtailsites:delete', args=(self.localhost.id,))
+        response = self.client.post(delete_url, {
             'trivial_key': 'trivial_value'
         })
 

--- a/wagtail/wagtailsites/views.py
+++ b/wagtail/wagtailsites/views.py
@@ -7,9 +7,10 @@ from wagtail.wagtailcore.models import Site
 from wagtail.wagtailsites.forms import SiteForm
 from wagtail.wagtailadmin import messages
 
+
 def user_has_site_model_perm(user):
     for verb in ['add', 'change', 'delete']:
-        if user.has_perm('site.%s_site' % verb):
+        if user.has_perm('wagtailcore.%s_site' % verb):
             return True
     return False
 
@@ -22,7 +23,7 @@ def index(request):
     })
 
 
-@permission_required('site.add_site')
+@permission_required('wagtailcore.add_site')
 def create(request):
     if request.POST:
         form = SiteForm(request.POST)
@@ -42,7 +43,7 @@ def create(request):
     })
 
 
-@permission_required('site.change_site')
+@permission_required('wagtailcore.change_site')
 def edit(request, site_id):
     site = get_object_or_404(Site, id=site_id)
 
@@ -65,7 +66,7 @@ def edit(request, site_id):
     })
 
 
-@permission_required('site.delete_site')
+@permission_required('wagtailcore.delete_site')
 def delete(request, site_id):
     site = get_object_or_404(Site, id=site_id)
 

--- a/wagtail/wagtailsites/views.py
+++ b/wagtail/wagtailsites/views.py
@@ -25,7 +25,7 @@ def index(request):
 
 @permission_required('wagtailcore.add_site')
 def create(request):
-    if request.POST:
+    if request.method == 'POST':
         form = SiteForm(request.POST)
         if form.is_valid():
             site = form.save()
@@ -47,7 +47,7 @@ def create(request):
 def edit(request, site_id):
     site = get_object_or_404(Site, id=site_id)
 
-    if request.POST:
+    if request.method == 'POST':
         form = SiteForm(request.POST, instance=site)
         if form.is_valid():
             site = form.save()
@@ -70,7 +70,7 @@ def edit(request, site_id):
 def delete(request, site_id):
     site = get_object_or_404(Site, id=site_id)
 
-    if request.POST:
+    if request.method == 'POST':
         site.delete()
         messages.success(request, _("Site '{0}' deleted.").format(site.hostname))
         return redirect('wagtailsites:index')

--- a/wagtail/wagtailsites/wagtail_hooks.py
+++ b/wagtail/wagtailsites/wagtail_hooks.py
@@ -17,7 +17,12 @@ def register_admin_urls():
 
 class SitesMenuItem(MenuItem):
     def is_shown(self, request):
-        return request.user.is_superuser
+        return (
+            request.user.has_perm('wagtailcore.add_site')
+            or request.user.has_perm('wagtailcore.edit_site')
+            or request.user.has_perm('wagtailcore.delete_site')
+        )
+
 
 @hooks.register('register_settings_menu_item')
 def register_sites_menu_item():


### PR DESCRIPTION
Permission checks in wagtailsites are currently using an incorrect app label, 'site' - this should be 'wagtailcore' (because that's where the Site model is). In practice, this doesn't matter, because the Sites menu item is only displayed to superusers, and testing a non-existent permission is equivalent to 'is superuser'. That probably wasn't the intention, though...

This PR:
* updates the Sites menu item to show for users with an explicit add/edit/delete site permission, as well as superusers
* fixes permissions for non-superusers on all wagtailsites views
* fixes an annoyance in the tests where we have to pass a bogus parameter to the 'delete' view
