### PR TITLE
Page copy uses new fresh instance instead of copied one.

### DIFF
--- a/wagtail/tests/testapp/fixtures/test.json
+++ b/wagtail/tests/testapp/fixtures/test.json
@@ -87,6 +87,41 @@
 },
 
 {
+    "pk": 13,
+    "model": "wagtailcore.page",
+    "fields": {
+        "title": "Saint Patrick",
+        "numchild": 0,
+        "show_in_menus": true,
+        "live": true,
+        "depth": 4,
+        "content_type": ["tests", "singleeventpage"],
+        "path": "0001000100010005",
+        "url_path": "/home/events/saint-patrick/",
+        "slug": "saint-patrick",
+        "owner": 2
+    }
+},
+{
+    "pk": 13,
+    "model": "tests.eventpage",
+    "fields": {
+        "date_from": "2014-12-25",
+        "audience": "private",
+        "location": "Wellington",
+        "body": "<p>The day when nothing makes sense.</p>",
+        "cost": "Semi-free"
+    }
+},
+{
+    "pk": 13,
+    "model": "tests.singleeventpage",
+    "fields": {
+        "excerpt": "A little tiny excerpt for Saint Patrick."
+    }
+},
+
+{
     "pk": 1,
     "model": "tests.eventpagespeaker",
     "fields": {

--- a/wagtail/tests/testapp/migrations/0007_singleeventpage.py
+++ b/wagtail/tests/testapp/migrations/0007_singleeventpage.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tests', '0006_image_file_size'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SingleEventPage',
+            fields=[
+                ('eventpage_ptr', models.OneToOneField(auto_created=True, to='tests.EventPage', serialize=False, parent_link=True, primary_key=True)),
+                ('excerpt', models.TextField(help_text='Short text to describe what is this action about', max_length=255, null=True, blank=True)),
+            ],
+            bases=('tests.eventpage',),
+        ),
+    ]

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -216,6 +216,13 @@ EventPage.promote_panels = [
 ]
 
 
+# Just to be able to test multi table inheritance
+class SingleEventPage(EventPage):
+    excerpt = models.TextField(max_length=255, blank=True, null=True, help_text="Short text to describe what is this action about")
+
+SingleEventPage.content_panels = [FieldPanel('excerpt')] + EventPage.content_panels
+
+
 # Event index (has a separate AJAX template, and a custom template context)
 class EventIndex(Page):
     intro = RichTextField(blank=True)

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -767,11 +767,12 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         Copy of a given page instance based on a fresh instance to enforce proper multiple inheritance
         """
         # Fill dict with self.specific values
+        exclude_fields = ['id', 'path', 'depth', 'numchild', 'url_path', 'path']
         specific_self = self.specific
         specific_dict = {}
 
         for field in specific_self._meta.fields:
-            if field.name not in ['id', 'path', 'depth', 'numchild', 'url_path', 'path'] and not field.name.endswith("_ptr"):
+            if field.name not in exclude_fields and not (field.rel is not None and field.rel.parent_link):
                 specific_dict[field.name] = getattr(specific_self, field.name)
 
         # Make a new instance from prepared dict values

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -763,13 +763,19 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         logger.info("Page moved: \"%s\" id=%d path=%s", self.title, self.id, new_url_path)
 
     def copy(self, recursive=False, to=None, update_attrs=None, copy_revisions=True, keep_live=True, user=None):
-        # Make a copy
-        page_copy = Page.objects.get(id=self.id).specific
-        page_copy.pk = None
-        page_copy.id = None
-        page_copy.depth = None
-        page_copy.numchild = 0
-        page_copy.path = None
+        """
+        Copy of a given page instance based on a fresh instance to enforce proper multiple inheritance
+        """
+        # Fill dict with self.specific values
+        specific_self = self.specific
+        specific_dict = {}
+
+        for field in specific_self._meta.fields:
+            if field.name not in ['id', 'path', 'depth', 'numchild', 'url_path', 'path'] and not field.name.endswith("_ptr"):
+                specific_dict[field.name] = getattr(specific_self, field.name)
+
+        # Make a new instance from prepared dict values
+        page_copy = self.specific_class(**specific_dict)
 
         if not keep_live:
             page_copy.live = False

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -763,9 +763,6 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         logger.info("Page moved: \"%s\" id=%d path=%s", self.title, self.id, new_url_path)
 
     def copy(self, recursive=False, to=None, update_attrs=None, copy_revisions=True, keep_live=True, user=None):
-        """
-        Copy of a given page instance based on a fresh instance to enforce proper multiple inheritance
-        """
         # Fill dict with self.specific values
         exclude_fields = ['id', 'path', 'depth', 'numchild', 'url_path', 'path']
         specific_self = self.specific
@@ -775,7 +772,7 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
             if field.name not in exclude_fields and not (field.rel is not None and field.rel.parent_link):
                 specific_dict[field.name] = getattr(specific_self, field.name)
 
-        # Make a new instance from prepared dict values
+        # New instance from prepared dict values, in case the instance class implements multiple levels inheritance
         page_copy = self.specific_class(**specific_dict)
 
         if not keep_live:

--- a/wagtail/wagtailcore/tests/test_management_commands.py
+++ b/wagtail/wagtailcore/tests/test_management_commands.py
@@ -80,7 +80,7 @@ class TestFixTreeCommand(TestCase):
         # Check that the issues were detected
         output_string = output.read()
         self.assertIn("Incorrect numchild value found for pages: [2]", output_string)
-        self.assertIn("Orphaned pages found: [4, 5, 6, 9]", output_string)
+        self.assertIn("Orphaned pages found: [4, 5, 6, 9, 13]", output_string)
 
         # Check that christmas_page is still in the tree
         self.assertTrue(Page.objects.filter(id=christmas_page.id).exists())
@@ -102,7 +102,7 @@ class TestFixTreeCommand(TestCase):
         # Check that the issues were detected
         output_string = output.read()
         self.assertIn("Incorrect numchild value found for pages: [2]", output_string)
-        self.assertIn("4 orphaned pages deleted.", output_string)
+        self.assertIn("5 orphaned pages deleted.", output_string)
 
         # Check that christmas_page has been deleted
         self.assertFalse(Page.objects.filter(id=christmas_page.id).exists())


### PR DESCRIPTION
Possible solution to https://github.com/torchbox/wagtail/issues/1543

Create a new instance from prepared dict instead of copying the original one. This avoids keeping the foreign keys to parent instances when the copied class is involved in a multiple level inheritance like:

```
from wagtail.wagtailcore.models import Page

class CorePage(Page):
    ...

class EventPage(CorePage):
    ...
```

