### PR TITLE
Remove all menu-{section_name} classnames on the <body> element and menu item <li>s

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -156,7 +156,7 @@ The available hooks are:
 
   Add an item to the Wagtail admin menu. The callable passed to this hook must return an instance of ``wagtail.wagtailadmin.menu.MenuItem``. New items can be constructed from the ``MenuItem`` class by passing in a ``label`` which will be the text in the menu item, and the URL of the admin page you want the menu item to link to (usually by calling ``reverse()`` on the admin view you've set up). Additionally, the following keyword arguments are accepted:
 
-  :name: an internal name used to identify the menu item; defaults to the slugified form of the label. Also applied as a CSS class to the wrapping ``<li>``, as ``"menu-{name}"``.
+  :name: an internal name used to identify the menu item; defaults to the slugified form of the label.
   :classnames: additional classnames applied to the link, used to give it an icon
   :attrs: additional HTML attributes to apply to the link
   :order: an integer which determines the item's position in the menu

--- a/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/index.html
+++ b/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/index.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% trans "Search Terms" %}{% endblock %}
-{% block bodyclass %}menu-editorspicks{% endblock %}
 
 {% block extra_js %}
     <script>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/add_subpage.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/add_subpage.html
@@ -2,7 +2,6 @@
 {% load i18n %}
 {% load wagtailadmin_tags %}
 
-{% block bodyclass %}menu-explorer{% endblock %}
 {% block titletag %}{% blocktrans with title=parent_page.title %}Create a page in {{ title }}{% endblocktrans %}{% endblock %}
 
 {% block content %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_delete.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_delete.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% blocktrans with title=page.title %}Delete {{ title }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-explorer{% endblock %}
 
 {% block content %}
     {% trans "Delete" as del_str %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_move.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_move.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% blocktrans with title=page.title %}Move {{ title }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-explorer{% endblock %}
 {% block content %}
     {% trans "Move" as move_str %}
     {% include "wagtailadmin/shared/header.html" with title=move_str subtitle=page_to_move.title icon="doc-empty-inverse" %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_unpublish.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_unpublish.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% blocktrans with title=page.title%}Unpublish {{ title }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-explorer{% endblock %}
 {% block content %}
     {% trans "Unpublish" as unpublish_str %}
     {% include "wagtailadmin/shared/header.html" with title=unpublish_str subtitle=page.title icon="doc-empty-inverse" %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/content_type_use.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/content_type_use.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% endblock %}
-{% block bodyclass %}menu-explorer{% endblock %}
 
 {% block content %}
     {% trans "Pages using" as pages_str %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/copy.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/copy.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% blocktrans with title=page.title %}Copy {{ title }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-explorer{% endblock %}
 {% block content %}
     {% trans "Copy" as copy_str %}
     {% include "wagtailadmin/shared/header.html" with title=copy_str subtitle=page.title icon="doc-empty-inverse" %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block titletag %}{% blocktrans with page_type=content_type.model_class.get_verbose_name %}New {{ page_type }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-explorer page-editor create model-{{ content_type.model }}{% endblock %}
+{% block bodyclass %}page-editor create model-{{ content_type.model }}{% endblock %}
 
 {% block content %}
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -3,7 +3,7 @@
 {% load gravatar %}
 {% load i18n %}
 {% block titletag %}{% blocktrans with title=page.title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }}: {{ title }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-explorer page-editor model-{{ content_type.model }}{% endblock %}
+{% block bodyclass %}page-editor model-{{ content_type.model }}{% endblock %}
 
 {% block content %}
     {% page_permissions page as page_perms %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/index.html
@@ -1,7 +1,7 @@
 {% extends "wagtailadmin/base.html" %}
 {% load wagtailadmin_tags static compress i18n %}
 {% block titletag %}{% blocktrans with title=parent_page.title %}Exploring {{ title }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-explorer page-explorer {% if ordering == 'ord' %}reordering{% endif %}{% endblock %}
+{% block bodyclass %}page-explorer {% if ordering == 'ord' %}reordering{% endif %}{% endblock %}
 
 {% block content %}
     <header class="merged no-border nice-padding no-v-padding">

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/move_choose_destination.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/move_choose_destination.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% blocktrans with title=page_to_move.title %}Select a new parent page for {{ title }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-explorer{% endblock %}
 {% block content %}
     <header class="nice-padding">
         <h1 class="icon icon-doc-empty-inverse">{% blocktrans with title=page_to_move.title %}Select a new parent page for <span>{{ title }}</span>{% endblocktrans %}</h1>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/search.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/search.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% trans 'Search' %}{% endblock %}
-{% block bodyclass %}menu-search{% endblock %}
 {% block extra_js %}
     <script>
         window.headerSearch = {

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/menu_item.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/menu_item.html
@@ -1,3 +1,3 @@
-<li class="menu-item menu-{{ name }}{% if active %} menu-active{% endif %}">
+<li class="menu-item{% if active %} menu-active{% endif %}">
     <a href="{{ url }}" class="{{ classnames }}"{{ attr_string }}>{{ label }}</a>
 </li>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/menu_submenu_item.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/menu_submenu_item.html
@@ -1,4 +1,4 @@
-<li class="menu-item menu-{{ name }}{% if active %} menu-active{% endif %}">
+<li class="menu-item{% if active %} menu-active{% endif %}">
     <a href="#" class="submenu-trigger {{ classnames }}"{{ attr_string }}>{{ label }}</a>
     <div class="nav-submenu">
         <h2 class="{{ classnames }}">{{ label }}</h2>

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/add.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/add.html
@@ -2,7 +2,6 @@
 {% load i18n %}
 {% load wagtailimages_tags %}
 {% block titletag %}{% trans "Add a document" %}{% endblock %}
-{% block bodyclass %}menu-documents{% endblock %}
 {% block extra_css %}
     {% include "wagtailadmin/shared/tag_field_css.html" %}
 {% endblock %}

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/confirm_delete.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/confirm_delete.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% blocktrans with title=document.title %}Delete {{ title }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-documents{% endblock %}
 {% block content %}
     {% trans "Delete document" as del_str %}
     {% include "wagtailadmin/shared/header.html" with title=del_str subtitle=document.title icon="doc-full-inverse" %}

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
@@ -2,7 +2,6 @@
 {% load i18n %}
 {% load wagtailimages_tags %}
 {% block titletag %}{% blocktrans with title=document.title %}Editing {{ title }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-documents{% endblock %}
 {% block extra_css %}
     {% include "wagtailadmin/shared/tag_field_css.html" %}
 {% endblock %}

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/index.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/index.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}Documents{% endblock %}
-{% block bodyclass %}menu-documents{% endblock %}
 {% block extra_js %}
     <script>
         window.headerSearch = {

--- a/wagtail/wagtailforms/templates/wagtailforms/index.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/index.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% trans "Forms" %}{% endblock %}
-{% block bodyclass %}menu-forms{% endblock %}
 {% block content %}
     {% trans "Forms" as forms_str %}
     {% trans "Pages" as select_form_str %}

--- a/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% blocktrans with form_title=form_page.title|capfirst %}Submissions of {{ form_title }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-forms{% endblock %}
 {% block extra_js %}
     {% include "wagtailadmin/shared/datetimepicker_translations.html" %}
 

--- a/wagtail/wagtailimages/templates/wagtailimages/images/add.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/add.html
@@ -2,7 +2,6 @@
 {% load wagtailimages_tags %}
 {% load i18n %}
 {% block titletag %}{% trans "Add an image" %}{% endblock %}
-{% block bodyclass %}menu-images{% endblock %}
 {% block extra_css %}
     {% include "wagtailadmin/shared/tag_field_css.html" %}
 {% endblock %}

--- a/wagtail/wagtailimages/templates/wagtailimages/images/confirm_delete.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/confirm_delete.html
@@ -2,7 +2,6 @@
 {% load wagtailimages_tags %}
 {% load i18n %}
 {% block titletag %}{% trans "Delete image" %}{% endblock %}
-{% block bodyclass %}menu-images{% endblock %}
 
 {% block content %}
     {% trans "Delete image" as del_str %}

--- a/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load wagtailimages_tags compress static i18n %}
 {% block titletag %}{% blocktrans with title=image.title %}Editing image {{ title }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-images{% endblock %}
 {% block extra_css %}
     {% include "wagtailadmin/shared/tag_field_css.html" %}
 

--- a/wagtail/wagtailimages/templates/wagtailimages/images/index.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/index.html
@@ -3,7 +3,6 @@
 {% load i18n %}
 
 {% block titletag %}{% trans "Images" %}{% endblock %}
-{% block bodyclass %}menu-images{% endblock %}
 {% block extra_js %}
     <script>
         window.headerSearch = {

--- a/wagtail/wagtailimages/templates/wagtailimages/images/url_generator.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/url_generator.html
@@ -3,8 +3,6 @@
 
 {% block titletag %}{% blocktrans with title=image.title %}Editing image {{ title }}{% endblocktrans %}{% endblock %}
 
-{% block bodyclass %}menu-images{% endblock %}
-
 {% block content %}
     {% trans "Generating URL" as title_str %}
     {% include "wagtailadmin/shared/header.html" with title=title_str subtitle=image.title icon="image" %}

--- a/wagtail/wagtailimages/templates/wagtailimages/multiple/add.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/multiple/add.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load wagtailimages_tags i18n compress static %}
 {% block titletag %}{% trans "Add multiple images" %}{% endblock %}
-{% block bodyclass %}menu-images{% endblock %}
 {% block extra_css %}
     {% compress css %}
         <link rel="stylesheet" href="{% static 'wagtailimages/css/add-multiple.css' %}" type="text/css" />

--- a/wagtail/wagtailredirects/templates/wagtailredirects/add.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/add.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% trans "Add redirect" %}{% endblock %}
-{% block bodyclass %}menu-redirects{% endblock %}
 {% block content %}
     {% trans "Add redirect" as add_red_str %}
     {% include "wagtailadmin/shared/header.html" with title=add_red_str icon="redirect" %}

--- a/wagtail/wagtailredirects/templates/wagtailredirects/confirm_delete.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/confirm_delete.html
@@ -1,6 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block bodyclass %}menu-redirects{% endblock %}
 {% block titletag %}{% blocktrans with title=redirect.title %}Delete redirect {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Delete" as delete_str %}

--- a/wagtail/wagtailredirects/templates/wagtailredirects/edit.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/edit.html
@@ -1,6 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block bodyclass %}menu-redirects{% endblock %}
 {% block titletag %}{% blocktrans with title=redirect.title %}Editing {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Editing" as editing_str %}

--- a/wagtail/wagtailredirects/templates/wagtailredirects/index.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/index.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% trans "Redirects" %}{% endblock %}
-{% block bodyclass %}menu-redirects{% endblock %}
 
 {% block extra_js %}
     <script>

--- a/wagtail/wagtailsites/templates/wagtailsites/confirm_delete.html
+++ b/wagtail/wagtailsites/templates/wagtailsites/confirm_delete.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% trans "Delete site" %}{% endblock %}
-{% block bodyclass %}menu-site{% endblock %}
 
 {% block content %}
     {% trans "Delete site" as del_str %}

--- a/wagtail/wagtailsites/templates/wagtailsites/create.html
+++ b/wagtail/wagtailsites/templates/wagtailsites/create.html
@@ -2,7 +2,6 @@
 {% load i18n %}
 
 {% block titletag %}{% trans "Add site" %} {{ site.hostname }}{% endblock %}
-{% block bodyclass %}menu-sites{% endblock %}
 
 {% block content %}
 

--- a/wagtail/wagtailsites/templates/wagtailsites/edit.html
+++ b/wagtail/wagtailsites/templates/wagtailsites/edit.html
@@ -2,7 +2,6 @@
 {% load i18n %}
 
 {% block titletag %}{% trans "Editing" %} {{ site.hostname }}{% endblock %}
-{% block bodyclass %}menu-sites{% endblock %}
 
 {% block content %}
 

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/confirm_delete.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/confirm_delete.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% blocktrans %}Delete {{ snippet_type_name}} - {{ instance }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-snippets{% endblock %}
 {% block content %}
     {% trans "Delete" as delete_str %}
     {% include "wagtailadmin/shared/header.html" with title=delete_str subtitle=instance icon="snippet" %}

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/create.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/create.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% blocktrans %}New  {{ snippet_type_name}}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-snippets{% endblock %}
 {% block content %}
     {% trans "New" as new_str %}
     {% include "wagtailadmin/shared/header.html" with title=new_str subtitle=snippet_type_name icon="snippet" %}

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% blocktrans %}Editing {{ snippet_type_name}} - {{ instance }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-snippets{% endblock %}
 {% block content %}
     {% trans "Editing" as editing_str %}
     {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=instance icon="snippet" usage_object=instance %}

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/index.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/index.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% trans "Snippets" %}{% endblock %}
-{% block bodyclass %}menu-snippets{% endblock %}
 {% block content %}
 
     {% include "wagtailadmin/shared/header.html" with title="Snippets" icon="snippet" %}

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/type_index.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% blocktrans with snippet_type_name_plural=snippet_type_name_plural|capfirst %}Snippets {{ snippet_type_name_plural }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}menu-snippets{% endblock %}
 {% block content %}
 
     <header class="nice-padding">

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/confirm_delete.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/confirm_delete.html
@@ -1,7 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% block titletag %}{% trans "Delete group" %}{% endblock %}
-{% block bodyclass %}menu-groups{% endblock %}
 
 {% block content %}
     {% trans "Delete group" as del_str %}

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/create.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/create.html
@@ -2,7 +2,6 @@
 {% load wagtailusers_tags wagtailimages_tags static compress i18n %}
 
 {% block titletag %}{% trans "Add group" %}{% endblock %}
-{% block bodyclass %}menu-groups{% endblock %}
 
 {% block extra_css %}
     {% compress css %}

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/edit.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/edit.html
@@ -2,7 +2,6 @@
 {% load wagtailusers_tags wagtailimages_tags static compress i18n %}
 
 {% block titletag %}{% trans "Editing" %} {{ group.name }}{% endblock %}
-{% block bodyclass %}menu-groups{% endblock %}
 
 {% block extra_css %}
     {% compress css %}

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/index.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/index.html
@@ -2,7 +2,6 @@
 {% load i18n %}
 {% load gravatar %}
 {% block titletag %}{% trans "groups" %}{% endblock %}
-{% block bodyclass %}menu-groups{% endblock %}
 {% block extra_js %}
     <script>
         window.headerSearch = {

--- a/wagtail/wagtailusers/templates/wagtailusers/users/create.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/create.html
@@ -2,7 +2,6 @@
 {% load wagtailimages_tags %}
 {% load i18n %}
 {% block titletag %}{% trans "Add user" %}{% endblock %}
-{% block bodyclass %}menu-users{% endblock %}
 {% block content %}
 
     {% trans "Add user" as add_user_str %}

--- a/wagtail/wagtailusers/templates/wagtailusers/users/edit.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/edit.html
@@ -2,7 +2,6 @@
 {% load wagtailimages_tags %}
 {% load i18n %}
 {% block titletag %}{% trans "Editing" %} {{ user.get_username}}{% endblock %}
-{% block bodyclass %}menu-users{% endblock %}
 {% block content %}
     
     {% trans "Editing" as editing_str %}

--- a/wagtail/wagtailusers/templates/wagtailusers/users/index.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/index.html
@@ -2,7 +2,6 @@
 {% load i18n %}
 {% load gravatar %}
 {% block titletag %}{% trans "Users" %}{% endblock %}
-{% block bodyclass %}menu-users{% endblock %}
 {% block extra_js %}
     <script>
         window.headerSearch = {


### PR DESCRIPTION
These were introduced in https://github.com/torchbox/verdant-rca/commit/9d7d016b7c27ca4602eefee2fa920a1e83242319 to support menu item highlighting, but this mechanism was superseded by #1186. There's no sign of any code still using these classnames, and any code that relies on them would be liable to fail on non-English-language sites anyhow (since the menu item name is derived from the label by default, and the label is a translatable string).