### PR TITLE
Use alternate context var for Jinja support

### DIFF
--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -421,6 +421,8 @@ class MultiFieldPanel(object):
 
 class BaseFieldPanel(EditHandler):
 
+    TEMPLATE_VAR = 'field_panel'
+
     @classmethod
     def widget_overrides(cls):
         """check if a specific widget has been defined for this field"""
@@ -459,6 +461,7 @@ class BaseFieldPanel(EditHandler):
     def render_as_object(self):
         return mark_safe(render_to_string(self.object_template, {
             'self': self,
+            self.TEMPLATE_VAR: self,
             'field': self.bound_field,
         }))
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/userbar/frame.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/userbar/frame.html
@@ -4,7 +4,7 @@
     var wagtail = wagtail || {};
     wagtail.static_root = '{% static "wagtailadmin/" %}';
     wagtail.userbar = {
-        src: '{% if revision_id %}{% url "wagtailadmin_userbar_moderation" revision_id %}{% else %}{% url "wagtailadmin_userbar_frontend" page.self.id %}{% endif %}',
+        src: '{% if revision_id %}{% url "wagtailadmin_userbar_moderation" revision_id %}{% else %}{% url "wagtailadmin_userbar_frontend" page.id %}{% endif %}',
         origin:'{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.get_host }}'
     };
     (function(d) {

--- a/wagtail/wagtailadmin/templatetags/wagtailuserbar.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailuserbar.py
@@ -1,7 +1,7 @@
 from django import template
 from django.template.loader import render_to_string
 
-from wagtail.wagtailcore.models import Page
+from wagtail.wagtailcore.models import Page, PAGE_TEMPLATE_VAR
 
 
 register = template.Library()
@@ -16,10 +16,13 @@ def wagtailuserbar(context):
     if not request.user.has_perm('wagtailadmin.access_admin'):
         return ''
 
-    # Only render if the context contains a 'self' variable referencing a saved page
-    if 'self' in context and isinstance(context['self'], Page) and context['self'].id is not None:
-        pass
-    else:
+    # Only render if the context contains a 'PAGE_TEMPLATE_VAR' variable
+    # referencing a saved page
+    if PAGE_TEMPLATE_VAR not in context:
+        return ''
+
+    page = context[PAGE_TEMPLATE_VAR]
+    if not isinstance(page, Page) or page.id is None:
         return ''
 
     try:
@@ -30,6 +33,6 @@ def wagtailuserbar(context):
     # Render the frame to contain the userbar items
     return render_to_string('wagtailadmin/userbar/frame.html', {
         'request': request,
-        'page': context,
+        'page': page,
         'revision_id': revision_id
     })

--- a/wagtail/wagtailadmin/tests/test_userbar.py
+++ b/wagtail/wagtailadmin/tests/test_userbar.py
@@ -6,7 +6,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 
 from wagtail.tests.utils import WagtailTestUtils
-from wagtail.wagtailcore.models import Page
+from wagtail.wagtailcore.models import Page, PAGE_TEMPLATE_VAR
 from wagtail.tests.testapp.models import BusinessIndex, BusinessChild
 
 
@@ -23,7 +23,7 @@ class TestUserbarTag(TestCase):
     def test_userbar_tag(self):
         template = Template("{% load wagtailuserbar %}{% wagtailuserbar %}")
         content = template.render(Context({
-            'self': self.homepage,
+            PAGE_TEMPLATE_VAR: self.homepage,
             'request': self.dummy_request(self.user),
         }))
 
@@ -32,7 +32,7 @@ class TestUserbarTag(TestCase):
     def test_userbar_tag_anonymous_user(self):
         template = Template("{% load wagtailuserbar %}{% wagtailuserbar %}")
         content = template.render(Context({
-            'self': self.homepage,
+            PAGE_TEMPLATE_VAR: self.homepage,
             'request': self.dummy_request(),
         }))
 

--- a/wagtail/wagtailcore/blocks/base.py
+++ b/wagtail/wagtailcore/blocks/base.py
@@ -41,6 +41,8 @@ class Block(six.with_metaclass(BaseBlock, object)):
     name = ''
     creation_counter = 0
 
+    TEMPLATE_VAR = 'value'
+
     class Meta:
         label = None
         icon = "placeholder"
@@ -206,7 +208,10 @@ class Block(six.with_metaclass(BaseBlock, object)):
         """
         template = getattr(self.meta, 'template', None)
         if template:
-            return render_to_string(template, {'self': value})
+            return render_to_string(template, {
+                'self': value,
+                self.TEMPLATE_VAR: value,
+            })
         else:
             return self.render_basic(value)
 

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -44,6 +44,8 @@ from wagtail.wagtailsearch.backends import get_search_backend
 
 logger = logging.getLogger('wagtail.core')
 
+PAGE_TEMPLATE_VAR = 'page'
+
 
 class SiteManager(models.Manager):
     def get_by_natural_key(self, hostname, port):
@@ -549,6 +551,7 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
 
     def get_context(self, request, *args, **kwargs):
         return {
+            PAGE_TEMPLATE_VAR: self,
             'self': self,
             'request': request,
         }


### PR DESCRIPTION
Jinja does not support using `self` as a template variable, as `self` is reserved for its own internal use. To add support for Jinja templates, an alternative name has been added where 'self' has been used.  Templat authors are free to use which ever template variable works in their template language.

I have not changed all the internal Wagtail templates, as these are not using Jinja. I have changed the wagtailuserbar templatetag to use the new `page` variable so  that it can theoretically be used in Jinja as well, although the template tag would need to be added to Jinja first.

This needs to be documented somehow, although I am unsure how exactly to do this. The docs could be converted completely to use the `page` template variable, as this would work on all templating engines, but this is a big change. Alternately, a note could be added regarding the `self`/`page` duplication and which to use when, but this note may need to be added to multiple places in the docs so people do not miss it. Which approach would you prefer?