### PR TITLE
Use rest frameworks serializers in API

### DIFF
--- a/wagtail/contrib/wagtailapi/endpoints.py
+++ b/wagtail/contrib/wagtailapi/endpoints.py
@@ -20,7 +20,7 @@ from .filters import (
 )
 from .renderers import WagtailJSONRenderer
 from .pagination import WagtailPagination
-from .serializers import BaseSerializer, PageSerializer, DocumentSerializer, get_serializer_class
+from .serializers import BaseSerializer, PageSerializer, DocumentSerializer, ImageSerializer, get_serializer_class
 from .utils import BadRequestError
 
 
@@ -220,6 +220,7 @@ class PagesAPIEndpoint(BaseAPIEndpoint):
 
 class ImagesAPIEndpoint(BaseAPIEndpoint):
     queryset = get_image_model().objects.all().order_by('id')
+    base_serializer_class = ImageSerializer
     filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
     extra_api_fields = ['title', 'tags', 'width', 'height']
     name = 'images'

--- a/wagtail/contrib/wagtailapi/endpoints.py
+++ b/wagtail/contrib/wagtailapi/endpoints.py
@@ -20,14 +20,14 @@ from .filters import (
 )
 from .renderers import WagtailJSONRenderer
 from .pagination import WagtailPagination
-from .serializers import WagtailSerializer, PageSerializer, DocumentSerializer
+from .serializers import BaseSerializer, PageSerializer, DocumentSerializer, get_serializer_class
 from .utils import BadRequestError
 
 
 class BaseAPIEndpoint(GenericViewSet):
     renderer_classes = [WagtailJSONRenderer]
     pagination_class = WagtailPagination
-    serializer_class = WagtailSerializer
+    base_serializer_class = BaseSerializer
     filter_classes = []
     queryset = None  # Set on subclasses or implement `get_queryset()`.
 
@@ -87,18 +87,21 @@ class BaseAPIEndpoint(GenericViewSet):
         if unknown_parameters:
             raise BadRequestError("query parameter is not an operation or a recognised field: %s" % ', '.join(sorted(unknown_parameters)))
 
-    def get_serializer_context(self):
-        """
-        The serialization context differs between listing and detail views.
-        """
+    def get_serializer_class(self):
         request = self.request
 
+        # Get model
         if self.action == 'listing_view':
             model = self.get_queryset().model
+        else:
+            model = type(self.get_object())
 
-            all_fields = self.get_api_fields(model)
-            all_fields = list(OrderedDict.fromkeys(all_fields)) # Removes any duplicates in case the developer put "title" in api_fields
+        # Get all available fields
+        all_fields = self.get_api_fields(model)
+        all_fields = list(OrderedDict.fromkeys(all_fields)) # Removes any duplicates in case the developer put "title" in api_fields
 
+        if self.action == 'listing_view':
+            # Listing views just show the title field and any other allowed field the user specified
             if 'fields' in request.GET:
                 fields = set(request.GET['fields'].split(','))
             else:
@@ -111,22 +114,27 @@ class BaseAPIEndpoint(GenericViewSet):
 
             # Reorder fields so it matches the order of all_fields
             fields = [field for field in all_fields if field in fields]
+        else:
+            # Detail views show all fields all the time
+            fields = all_fields
 
+        return get_serializer_class(model, fields, base=self.base_serializer_class)
+
+    def get_serializer_context(self):
+        """
+        The serialization context differs between listing and detail views.
+        """
+        request = self.request
+
+        if self.action == 'listing_view':
             return {
                 'request': request,
                 'view': self,
-                'fields': fields
             }
-
-        model = type(self.get_object())
-
-        all_fields = self.get_api_fields(model)
-        all_fields = list(OrderedDict.fromkeys(all_fields)) # Removes any duplicates in case the developer put "title" in api_fields
 
         return {
             'request': request,
             'view': self,
-            'fields': all_fields,
             'show_details': True
         }
 
@@ -155,7 +163,7 @@ class BaseAPIEndpoint(GenericViewSet):
 
 
 class PagesAPIEndpoint(BaseAPIEndpoint):
-    serializer_class = PageSerializer
+    base_serializer_class = PageSerializer
     filter_backends = [
         FieldsFilter,
         ChildOfFilter,
@@ -216,7 +224,7 @@ class ImagesAPIEndpoint(BaseAPIEndpoint):
 
 class DocumentsAPIEndpoint(BaseAPIEndpoint):
     queryset = Document.objects.all().order_by('id')
-    serializer_class = DocumentSerializer
+    base_serializer_class = DocumentSerializer
     filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
     extra_api_fields = ['title', 'tags']
     name = 'documents'

--- a/wagtail/contrib/wagtailapi/endpoints.py
+++ b/wagtail/contrib/wagtailapi/endpoints.py
@@ -121,6 +121,10 @@ class BaseAPIEndpoint(GenericViewSet):
         # Always show id and meta first
         fields = ['id', 'meta'] + fields
 
+        # If showing details, add the parent field
+        if isinstance(self, PagesAPIEndpoint) and self.get_serializer_context().get('show_details', False):
+            fields.insert(2, 'parent')
+
         return get_serializer_class(model, fields, base=self.base_serializer_class)
 
     def get_serializer_context(self):

--- a/wagtail/contrib/wagtailapi/endpoints.py
+++ b/wagtail/contrib/wagtailapi/endpoints.py
@@ -118,8 +118,8 @@ class BaseAPIEndpoint(GenericViewSet):
             # Detail views show all fields all the time
             fields = all_fields
 
-        # Always show id first
-        fields = ['id'] + fields
+        # Always show id and meta first
+        fields = ['id', 'meta'] + fields
 
         return get_serializer_class(model, fields, base=self.base_serializer_class)
 

--- a/wagtail/contrib/wagtailapi/endpoints.py
+++ b/wagtail/contrib/wagtailapi/endpoints.py
@@ -118,6 +118,9 @@ class BaseAPIEndpoint(GenericViewSet):
             # Detail views show all fields all the time
             fields = all_fields
 
+        # Always show id first
+        fields = ['id'] + fields
+
         return get_serializer_class(model, fields, base=self.base_serializer_class)
 
     def get_serializer_context(self):

--- a/wagtail/contrib/wagtailapi/renderers.py
+++ b/wagtail/contrib/wagtailapi/renderers.py
@@ -6,11 +6,6 @@ from django.utils.six import text_type
 
 from rest_framework import renderers
 
-from taggit.managers import _TaggableManager
-from taggit.models import Tag
-
-from wagtail.wagtailcore.blocks import StreamValue
-
 from .utils import URLPath, ObjectDetailURL, get_base_url
 
 
@@ -35,11 +30,7 @@ class WagtailJSONRenderer(renderers.BaseRenderer):
 
         class WagtailAPIJSONEncoder(DjangoJSONEncoder):
             def default(self, o):
-                if isinstance(o, _TaggableManager):
-                    return list(o.all())
-                elif isinstance(o, Tag):
-                    return o.name
-                elif isinstance(o, URLPath):
+                if isinstance(o, URLPath):
                     return get_full_url(request, o.path)
                 elif isinstance(o, ObjectDetailURL):
                     detail_view = find_model_detail_view(o.model, endpoints)
@@ -48,8 +39,6 @@ class WagtailJSONRenderer(renderers.BaseRenderer):
                         return get_full_url(request, reverse(detail_view, args=(o.pk, )))
                     else:
                         return None
-                elif isinstance(o, StreamValue):
-                    return o.stream_block.get_prep_value(o)
                 else:
                     return super(WagtailAPIJSONEncoder, self).default(o)
 

--- a/wagtail/contrib/wagtailapi/serializers.py
+++ b/wagtail/contrib/wagtailapi/serializers.py
@@ -56,7 +56,7 @@ class StreamField(Field):
 
 class TagsField(Field):
     def to_representation(self, value):
-        return list(value.all().values_list('name', flat=True))
+        return list(value.all().order_by('name').values_list('name', flat=True))
 
 
 class BaseSerializer(serializers.ModelSerializer):

--- a/wagtail/contrib/wagtailapi/serializers.py
+++ b/wagtail/contrib/wagtailapi/serializers.py
@@ -104,11 +104,6 @@ def get_serializer_class(model, fields):
     })
 
 
-def get_api_data(obj, fields):
-    serializer_class = get_serializer_class(type(obj), fields)
-    return serializer_class().to_representation(obj).items()
-
-
 class WagtailSerializer(BaseSerializer):
     def to_representation(self, instance):
         request = self.context['request']
@@ -168,7 +163,10 @@ class WagtailSerializer(BaseSerializer):
             # Reorder fields so it matches the order of api_fields
             fields = [field for field in api_fields if field in fields]
 
-        data.extend(get_api_data(obj, fields))
+        # Serialize the fields
+        serializer_class = get_serializer_class(type(obj), fields)
+        serializer = serializer_class()
+        data.extend(serializer.to_representation(obj).items())
 
         return OrderedDict(data)
 

--- a/wagtail/contrib/wagtailapi/serializers.py
+++ b/wagtail/contrib/wagtailapi/serializers.py
@@ -83,9 +83,7 @@ class ChildRelationField(Field):
         serializer = serializer_class()
 
         return [
-            # We don't call to_representation here as we don't want the id or meta
-            # to be added to the child objects
-            serializer.serialize_fields(child_object)
+            serializer.to_representation(child_object)
             for child_object in value.all()
         ]
 
@@ -117,16 +115,6 @@ class BaseSerializer(serializers.ModelSerializer):
             return TagsField, {}
 
         return super(BaseSerializer, self).build_property_field(field_name, model_class)
-
-    def serialize_fields(self, obj):
-        # Call rest frameworks built in to_representation method
-        return super(BaseSerializer, self).to_representation(obj)
-
-    def to_representation(self, obj):
-        # Serialize fields
-        data = list(self.serialize_fields(obj).items())
-
-        return OrderedDict(data)
 
 
 class PageSerializer(BaseSerializer):

--- a/wagtail/contrib/wagtailapi/serializers.py
+++ b/wagtail/contrib/wagtailapi/serializers.py
@@ -93,17 +93,14 @@ class BaseSerializer(serializers.ModelSerializer):
         return super(BaseSerializer, self).to_representation(obj)
 
     def to_representation(self, obj):
-        data = [
-            ('id', obj.id),
-        ]
+        # Serialize fields
+        data = list(self.serialize_fields(obj).items())
 
         # Serialize meta
         metadata = self.serialize_meta(obj)
         if metadata:
-            data.append(('meta', metadata))
-
-        # Serialize fields
-        data.extend(self.serialize_fields(obj).items())
+            # Insert meta just after id
+            data.insert(1, ('meta', metadata))
 
         return OrderedDict(data)
 
@@ -128,7 +125,7 @@ class PageSerializer(BaseSerializer):
             if site_pages.filter(id=parent.id).exists():
                 parent_class = parent.specific_class
 
-                data.insert(0,
+                data.insert(1,
                     ('parent', OrderedDict([
                         ('id', parent.id),
                         ('meta', OrderedDict([

--- a/wagtail/contrib/wagtailapi/serializers.py
+++ b/wagtail/contrib/wagtailapi/serializers.py
@@ -251,6 +251,10 @@ class PageSerializer(BaseSerializer):
         return super(BaseSerializer, self).build_relational_field(field_name, relation_info)
 
 
+class ImageSerializer(BaseSerializer):
+    pass
+
+
 class DocumentSerializer(BaseSerializer):
     meta = DocumentMetaField()
 

--- a/wagtail/contrib/wagtailapi/serializers.py
+++ b/wagtail/contrib/wagtailapi/serializers.py
@@ -101,19 +101,17 @@ def get_serializer_class(model_, fields_):
 
 class WagtailSerializer(serializers.BaseSerializer):
     def to_representation(self, instance):
-        request = self.context['request']
         fields = self.context.get('fields', frozenset())
         all_fields = self.context.get('all_fields', False)
         show_details = self.context.get('show_details', False)
         return self.serialize_object(
-            request,
             instance,
             fields=fields,
             all_fields=all_fields,
             show_details=show_details
         )
 
-    def serialize_object_metadata(self, request, obj, show_details=False):
+    def serialize_object_metadata(self, obj, show_details=False):
         """
         This returns a JSON-serialisable dict to use for the "meta"
         section of a particlular object.
@@ -126,7 +124,7 @@ class WagtailSerializer(serializers.BaseSerializer):
 
         return data
 
-    def serialize_object(self, request, obj, fields=frozenset(), extra_data=(), all_fields=False, show_details=False):
+    def serialize_object(self, obj, fields=frozenset(), extra_data=(), all_fields=False, show_details=False):
         """
         This converts an object into JSON-serialisable dict so it can
         be used in the API.
@@ -136,7 +134,7 @@ class WagtailSerializer(serializers.BaseSerializer):
         ]
 
         # Add meta
-        metadata = self.serialize_object_metadata(request, obj, show_details=show_details)
+        metadata = self.serialize_object_metadata(obj, show_details=show_details)
         if metadata:
             data.append(('meta', metadata))
 
@@ -167,20 +165,20 @@ class WagtailSerializer(serializers.BaseSerializer):
 
 
 class PageSerializer(WagtailSerializer):
-    def serialize_object_metadata(self, request, page, show_details=False):
-        data = super(PageSerializer, self).serialize_object_metadata(request, page, show_details=show_details)
+    def serialize_object_metadata(self, page, show_details=False):
+        data = super(PageSerializer, self).serialize_object_metadata(page, show_details=show_details)
 
         # Add type
         data['type'] = page.specific_class._meta.app_label + '.' + page.specific_class.__name__
 
         return data
 
-    def serialize_object(self, request, page, fields=frozenset(), extra_data=(), all_fields=False, show_details=False):
+    def serialize_object(self, page, fields=frozenset(), extra_data=(), all_fields=False, show_details=False):
         # Add parent
         if show_details:
             parent = page.get_parent()
 
-            site_pages = pages_for_site(request.site)
+            site_pages = pages_for_site(self.context['request'].site)
             if site_pages.filter(id=parent.id).exists():
                 parent_class = parent.specific_class
 
@@ -194,12 +192,12 @@ class PageSerializer(WagtailSerializer):
                     ])),
                 )
 
-        return super(PageSerializer, self).serialize_object(request, page, fields=fields, extra_data=extra_data, all_fields=all_fields, show_details=show_details)
+        return super(PageSerializer, self).serialize_object(page, fields=fields, extra_data=extra_data, all_fields=all_fields, show_details=show_details)
 
 
 class DocumentSerializer(WagtailSerializer):
-    def serialize_object_metadata(self, request, document, show_details=False):
-        data = super(DocumentSerializer, self).serialize_object_metadata(request, document, show_details=show_details)
+    def serialize_object_metadata(self, document, show_details=False):
+        data = super(DocumentSerializer, self).serialize_object_metadata(document, show_details=show_details)
 
         # Download URL
         if show_details:

--- a/wagtail/contrib/wagtailapi/serializers.py
+++ b/wagtail/contrib/wagtailapi/serializers.py
@@ -44,14 +44,19 @@ class PageMetaField(MetaField):
     A subclass of MetaField for Page objects.
 
     Changes the "type" field to use the name of the specific model of the page.
+
+    Example:
+
+    "meta": {
+        "type": "blog.BlogPage",
+        "detail_url": "http://api.example.com/v1/pages/1/"
+    }
     """
     def to_representation(self, page):
-        data = super(PageMetaField, self).to_representation(page)
-
-        # Change type to the specific page class instead
-        data['type'] = page.specific_class._meta.app_label + '.' + page.specific_class.__name__
-
-        return data
+        return OrderedDict([
+            ('type', page.specific_class._meta.app_label + '.' + page.specific_class.__name__),
+            ('detail_url', ObjectDetailURL(type(page), page.pk)),
+        ])
 
 
 class DocumentMetaField(MetaField):

--- a/wagtail/contrib/wagtailapi/serializers.py
+++ b/wagtail/contrib/wagtailapi/serializers.py
@@ -89,7 +89,7 @@ class BaseSerializer(serializers.ModelSerializer):
 
         return super(BaseSerializer, self).build_relational_field(field_name, relation_info)
 
-    def serialize_object_metadata(self, obj):
+    def serialize_meta(self, obj):
         """
         This returns a JSON-serialisable dict to use for the "meta"
         section of a particlular object.
@@ -112,7 +112,7 @@ class BaseSerializer(serializers.ModelSerializer):
         ]
 
         # Add meta
-        metadata = self.serialize_object_metadata(obj)
+        metadata = self.serialize_meta(obj)
         if metadata:
             data.append(('meta', metadata))
 
@@ -126,8 +126,8 @@ class BaseSerializer(serializers.ModelSerializer):
 
 
 class PageSerializer(BaseSerializer):
-    def serialize_object_metadata(self, page):
-        data = super(PageSerializer, self).serialize_object_metadata(page)
+    def serialize_meta(self, page):
+        data = super(PageSerializer, self).serialize_meta(page)
 
         # Add type
         data['type'] = page.specific_class._meta.app_label + '.' + page.specific_class.__name__
@@ -157,8 +157,8 @@ class PageSerializer(BaseSerializer):
 
 
 class DocumentSerializer(BaseSerializer):
-    def serialize_object_metadata(self, document):
-        data = super(DocumentSerializer, self).serialize_object_metadata(document)
+    def serialize_meta(self, document):
+        data = super(DocumentSerializer, self).serialize_meta(document)
 
         # Download URL
         if self.context.get('show_details', False):

--- a/wagtail/contrib/wagtailapi/serializers.py
+++ b/wagtail/contrib/wagtailapi/serializers.py
@@ -49,21 +49,20 @@ class DocumentMetaField(MetaField):
 
 
 class RelatedField(relations.RelatedField):
-    def to_representation(self, value):
-        model = type(value)
+    meta_field_serializer_class = MetaField
 
+    def to_representation(self, value):
         return OrderedDict([
             ('id', value.pk),
-            ('meta', OrderedDict([
-                 ('type', model._meta.app_label + '.' + model.__name__),
-                 ('detail_url', ObjectDetailURL(model, value.pk)),
-            ])),
+            ('meta', self.meta_field_serializer_class().to_representation(value)),
         ])
 
 
 class PageParentField(RelatedField):
+    meta_field_serializer_class = PageMetaField
+
     def get_attribute(self, instance):
-        parent = instance.get_parent().specific
+        parent = instance.get_parent()
 
         site_pages = pages_for_site(self.context['request'].site)
         if site_pages.filter(id=parent.id).exists():

--- a/wagtail/contrib/wagtailapi/serializers.py
+++ b/wagtail/contrib/wagtailapi/serializers.py
@@ -64,9 +64,18 @@ class DocumentMetaField(MetaField):
     A subclass of MetaField for Document objects.
 
     Adds a "download_url" field.
+
+    "meta": {
+        "type": "wagtaildocs.Document",
+        "detail_url": "http://api.example.com/v1/documents/1/",
+        "download_url": "http://api.example.com/documents/1/my_document.pdf"
+    }
     """
     def to_representation(self, document):
-        data = super(DocumentMetaField, self).to_representation(document)
+        data = OrderedDict([
+            ('type', "wagtaildocs.Document"),
+            ('detail_url', ObjectDetailURL(type(document), document.pk)),
+        ])
 
         # Add download url
         if self.context.get('show_details', False):

--- a/wagtail/contrib/wagtailapi/serializers.py
+++ b/wagtail/contrib/wagtailapi/serializers.py
@@ -89,9 +89,6 @@ class BaseSerializer(serializers.ModelSerializer):
 
         return super(BaseSerializer, self).build_relational_field(field_name, relation_info)
 
-    def to_representation(self, instance):
-        return self.serialize_object(instance)
-
     def serialize_object_metadata(self, obj):
         """
         This returns a JSON-serialisable dict to use for the "meta"
@@ -105,7 +102,7 @@ class BaseSerializer(serializers.ModelSerializer):
 
         return data
 
-    def serialize_object(self, obj, extra_data=()):
+    def to_representation(self, obj, extra_data=()):
         """
         This converts an object into JSON-serialisable dict so it can
         be used in the API.
@@ -137,7 +134,7 @@ class PageSerializer(BaseSerializer):
 
         return data
 
-    def serialize_object(self, page, extra_data=()):
+    def to_representation(self, page, extra_data=()):
         # Add parent
         if self.context.get('show_details', False):
             parent = page.get_parent()
@@ -156,7 +153,7 @@ class PageSerializer(BaseSerializer):
                     ])),
                 )
 
-        return super(PageSerializer, self).serialize_object(page, extra_data=extra_data)
+        return super(PageSerializer, self).to_representation(page, extra_data=extra_data)
 
 
 class DocumentSerializer(BaseSerializer):

--- a/wagtail/contrib/wagtailapi/serializers.py
+++ b/wagtail/contrib/wagtailapi/serializers.py
@@ -103,15 +103,13 @@ class WagtailSerializer(serializers.BaseSerializer):
     def to_representation(self, instance):
         fields = self.context.get('fields', frozenset())
         all_fields = self.context.get('all_fields', False)
-        show_details = self.context.get('show_details', False)
         return self.serialize_object(
             instance,
             fields=fields,
             all_fields=all_fields,
-            show_details=show_details
         )
 
-    def serialize_object_metadata(self, obj, show_details=False):
+    def serialize_object_metadata(self, obj):
         """
         This returns a JSON-serialisable dict to use for the "meta"
         section of a particlular object.
@@ -124,7 +122,7 @@ class WagtailSerializer(serializers.BaseSerializer):
 
         return data
 
-    def serialize_object(self, obj, fields=frozenset(), extra_data=(), all_fields=False, show_details=False):
+    def serialize_object(self, obj, fields=frozenset(), extra_data=(), all_fields=False):
         """
         This converts an object into JSON-serialisable dict so it can
         be used in the API.
@@ -134,7 +132,7 @@ class WagtailSerializer(serializers.BaseSerializer):
         ]
 
         # Add meta
-        metadata = self.serialize_object_metadata(obj, show_details=show_details)
+        metadata = self.serialize_object_metadata(obj)
         if metadata:
             data.append(('meta', metadata))
 
@@ -165,17 +163,17 @@ class WagtailSerializer(serializers.BaseSerializer):
 
 
 class PageSerializer(WagtailSerializer):
-    def serialize_object_metadata(self, page, show_details=False):
-        data = super(PageSerializer, self).serialize_object_metadata(page, show_details=show_details)
+    def serialize_object_metadata(self, page):
+        data = super(PageSerializer, self).serialize_object_metadata(page)
 
         # Add type
         data['type'] = page.specific_class._meta.app_label + '.' + page.specific_class.__name__
 
         return data
 
-    def serialize_object(self, page, fields=frozenset(), extra_data=(), all_fields=False, show_details=False):
+    def serialize_object(self, page, fields=frozenset(), extra_data=(), all_fields=False):
         # Add parent
-        if show_details:
+        if self.context.get('show_details', False):
             parent = page.get_parent()
 
             site_pages = pages_for_site(self.context['request'].site)
@@ -192,15 +190,15 @@ class PageSerializer(WagtailSerializer):
                     ])),
                 )
 
-        return super(PageSerializer, self).serialize_object(page, fields=fields, extra_data=extra_data, all_fields=all_fields, show_details=show_details)
+        return super(PageSerializer, self).serialize_object(page, fields=fields, extra_data=extra_data, all_fields=all_fields)
 
 
 class DocumentSerializer(WagtailSerializer):
-    def serialize_object_metadata(self, document, show_details=False):
-        data = super(DocumentSerializer, self).serialize_object_metadata(document, show_details=show_details)
+    def serialize_object_metadata(self, document):
+        data = super(DocumentSerializer, self).serialize_object_metadata(document)
 
         # Download URL
-        if show_details:
+        if self.context.get('show_details', False):
             data['download_url'] = URLPath(document.url)
 
         return data

--- a/wagtail/contrib/wagtailapi/tests/test_pages.py
+++ b/wagtail/contrib/wagtailapi/tests/test_pages.py
@@ -586,7 +586,7 @@ class TestPageDetail(TestCase):
         self.assertEqual(content['date'], '2013-12-02')
 
         # Check that the tags were serialised properly
-        self.assertEqual(content['tags'], ['wagtail', 'bird'])
+        self.assertEqual(content['tags'], ['bird', 'wagtail'])
 
         # Check that the feed image was serialised properly
         self.assertIsInstance(content['feed_image'], dict)


### PR DESCRIPTION
This PR replaces the ``get_api_data`` function with REST frameworks serializers/fields APIs