### PR TITLE
Added documentation in favor of #1214

### DIFF
--- a/docs/topics/writing_templates.rst
+++ b/docs/topics/writing_templates.rst
@@ -118,6 +118,16 @@ Only fields using ``RichTextField`` need this applied in the template.
     ...
     {{ self.body|richtext }}
 
+
+By default the ``RichTextField`` wraps the HTML content in a ``div``. To use the direct contents of the field refer to its source property.
+
+.. code-block:: django
+
+    {% load wagtailcore_tags %}
+    ...
+    {{ self.body.source|safe }}
+
+
 Responsive Embeds
 -----------------
 


### PR DESCRIPTION
I have added some documentation regarding to #1214 
Makes it more clear in how you can approach a richt text field directly without the use of a wrapper div