### PR TITLE
Fixed abstract classes not working. Fixes #1603

### DIFF
--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -112,7 +112,7 @@ def get_form_types():
     if _FORM_CONTENT_TYPES is None:
         _FORM_CONTENT_TYPES = [
             ct for ct in get_page_types()
-            if issubclass(ct.model_class(), AbstractForm)
+            if ct.model_class() and issubclass(ct.model_class(), AbstractForm)
         ]
     return _FORM_CONTENT_TYPES
 


### PR DESCRIPTION
I'm brand new to Python, Django, and Wagtail, so this might not be what you want. But I ran into a problem while trying to learn Wagtail and this fixed it for me.

Although I have a hunch that `wagtail.wagtailcore.models.get_page_types()` shouldn't be returning my abstract type at all. So maybe that's the proper fix.