### PR TITLE
Fix various inconsistencies in our permissions model

### DIFF
--- a/wagtail/contrib/wagtailstyleguide/views.py
+++ b/wagtail/contrib/wagtailstyleguide/views.py
@@ -2,12 +2,12 @@ from django import forms
 from django.shortcuts import render
 from django.utils.translation import ugettext as _
 from wagtail.wagtailadmin import messages
-from django.contrib.auth.decorators import permission_required
 
 from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailadmin.widgets import AdminPageChooser, AdminDateInput, AdminTimeInput, AdminDateTimeInput
 from wagtail.wagtailimages.widgets import AdminImageChooser
 from wagtail.wagtaildocs.widgets import AdminDocumentChooser
+
 
 class ExampleForm(forms.Form):
     def __init__(self, *args, **kwargs):
@@ -37,8 +37,6 @@ class ExampleForm(forms.Form):
     document_chooser = forms.BooleanField(required=True)
 
 
-
-@permission_required('wagtailadmin.access_admin')
 def index(request):
 
     form = SearchForm(placeholder=_("Search something"))

--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -64,13 +64,44 @@ def users_with_page_permission(page, permission_type, include_superusers=True):
     return User.objects.filter(is_active=True).filter(q).distinct()
 
 
+def permission_denied(request):
+    "Return a standard 'permission denied' response"
+    from wagtail.wagtailadmin import messages
+
+    messages.error(request, _('Sorry, you do not have permission to access this area.'))
+    return redirect('wagtailadmin_home')
+
+
+def permission_required(permission_name):
+    """
+    Replacement for django.contrib.auth.decorators.permission_required which returns a
+    more meaningful 'permission denied' response than just redirecting to the login page.
+    (The latter doesn't work anyway because Wagtail doesn't define LOGIN_URL...)
+    """
+    # Construct and return a decorator function specific to the permission name
+    # that has been passed in
+    def decorator(view_func):
+        # decorator takes the view function, and returns the view wrapped in
+        # a permission check
+
+        def wrapped_view_func(request, *args, **kwargs):
+            if request.user.has_perm(permission_name):
+                # permission check succeeds; run the view function as normal
+                return view_func(request, *args, **kwargs)
+            else:
+                # permission check failed
+                return permission_denied(request)
+
+        return wrapped_view_func
+
+    return decorator
+
+
 def any_permission_required(*perms):
     """
     Decorator that accepts a list of permission names, and allows the user
     to pass if they have *any* of the permissions in the list
     """
-    from wagtail.wagtailadmin import messages
-
     # Construct and return a decorator function specific to the permission list
     # that has been passed in
     def decorator(view_func):
@@ -84,8 +115,7 @@ def any_permission_required(*perms):
                     return view_func(request, *args, **kwargs)
 
             # if we get here, none of the permission checks have passed
-            messages.error(request, _('Sorry, you do not have permission to access this area.'))
-            return redirect('wagtailadmin_home')
+            return permission_denied(request)
 
         return wrapped_view_func
 

--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -65,7 +65,7 @@ def users_with_page_permission(page, permission_type, include_superusers=True):
 
 
 def permission_denied(request):
-    "Return a standard 'permission denied' response"
+    """Return a standard 'permission denied' response"""
     from wagtail.wagtailadmin import messages
 
     messages.error(request, _('Sorry, you do not have permission to access this area.'))

--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 from django.template.loader import render_to_string
 from django.core.mail import send_mail as django_send_mail
 from django.conf import settings
@@ -84,6 +86,7 @@ def permission_required(permission_name):
         # decorator takes the view function, and returns the view wrapped in
         # a permission check
 
+        @wraps(view_func)
         def wrapped_view_func(request, *args, **kwargs):
             if request.user.has_perm(permission_name):
                 # permission check succeeds; run the view function as normal
@@ -108,6 +111,7 @@ def any_permission_required(*perms):
         # decorator takes the view function, and returns the view wrapped in
         # a permission check
 
+        @wraps(view_func)
         def wrapped_view_func(request, *args, **kwargs):
             for perm in perms:
                 if request.user.has_perm(perm):

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/index.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/index.html
@@ -13,8 +13,13 @@
 
 {% block content %}
     {% trans "Documents" as doc_str %}
-    {% trans "Add a document" as add_doc_str %}
-    {% include "wagtailadmin/shared/header.html" with title=doc_str add_link="wagtaildocs:add" icon="doc-full-inverse" add_text=add_doc_str search_url="wagtaildocs:index" %}
+
+    {% if perms.wagtaildocs.add_document %}
+        {% trans "Add a document" as add_doc_str %}
+        {% include "wagtailadmin/shared/header.html" with title=doc_str add_link="wagtaildocs:add" icon="doc-full-inverse" add_text=add_doc_str search_url="wagtaildocs:index" %}
+    {% else %}
+        {% include "wagtailadmin/shared/header.html" with title=doc_str icon="doc-full-inverse" search_url="wagtaildocs:index" %}
+    {% endif %}
 
     <div class="nice-padding">
         <div id="document-results" class="documents">

--- a/wagtail/wagtaildocs/views/chooser.py
+++ b/wagtail/wagtaildocs/views/chooser.py
@@ -3,14 +3,15 @@ import json
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404, render
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.contrib.auth.decorators import permission_required
 
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 from wagtail.wagtailadmin.forms import SearchForm
+from wagtail.wagtailadmin.utils import permission_required
 from wagtail.wagtailsearch.backends import get_search_backends
 
 from wagtail.wagtaildocs.models import Document
 from wagtail.wagtaildocs.forms import DocumentForm
+
 
 def get_document_json(document):
     """

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -6,7 +6,7 @@ from django.views.decorators.vary import vary_on_headers
 from django.core.urlresolvers import reverse
 
 from wagtail.wagtailadmin.forms import SearchForm
-from wagtail.wagtailadmin.utils import any_permission_required
+from wagtail.wagtailadmin.utils import permission_required, any_permission_required
 from wagtail.wagtailsearch.backends import get_search_backends
 from wagtail.wagtailadmin import messages
 
@@ -77,7 +77,7 @@ def index(request):
         })
 
 
-@any_permission_required('wagtaildocs.add_document')
+@permission_required('wagtaildocs.add_document')
 def add(request):
     if request.POST:
         doc = Document(uploaded_by_user=request.user)

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -1,12 +1,12 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.contrib.auth.decorators import permission_required
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 from django.core.urlresolvers import reverse
 
 from wagtail.wagtailadmin.forms import SearchForm
+from wagtail.wagtailadmin.utils import any_permission_required
 from wagtail.wagtailsearch.backends import get_search_backends
 from wagtail.wagtailadmin import messages
 
@@ -14,7 +14,7 @@ from wagtail.wagtaildocs.models import Document
 from wagtail.wagtaildocs.forms import DocumentForm
 
 
-@permission_required('wagtaildocs.add_document')
+@any_permission_required('wagtaildocs.add_document', 'wagtaildocs.change_document')
 @vary_on_headers('X-Requested-With')
 def index(request):
     # Get documents
@@ -77,7 +77,7 @@ def index(request):
         })
 
 
-@permission_required('wagtaildocs.add_document')
+@any_permission_required('wagtaildocs.add_document')
 def add(request):
     if request.POST:
         doc = Document(uploaded_by_user=request.user)

--- a/wagtail/wagtaildocs/wagtail_hooks.py
+++ b/wagtail/wagtaildocs/wagtail_hooks.py
@@ -3,7 +3,6 @@ from django.conf.urls import include, url
 from django.core import urlresolvers
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import ugettext_lazy as _
-from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.models import Permission
 
 from wagtail.wagtailcore import hooks
@@ -25,6 +24,7 @@ def register_admin_urls():
 class DocumentsMenuItem(MenuItem):
     def is_shown(self, request):
         return request.user.has_perm('wagtaildocs.add_document')
+
 
 @hooks.register('register_admin_menu_item')
 def register_documents_menu_item():
@@ -53,9 +53,8 @@ def editor_js():
 
 @hooks.register('register_permissions')
 def register_permissions():
-    document_content_type = ContentType.objects.get(app_label='wagtaildocs', model='document')
-    document_permissions = Permission.objects.filter(content_type=document_content_type)
-    return document_permissions
+    return Permission.objects.filter(content_type__app_label='wagtaildocs',
+        codename__in=['add_document', 'change_document'])
 
 
 @hooks.register('register_rich_text_link_handler')
@@ -71,6 +70,7 @@ class DocumentsSummaryItem(SummaryItem):
         return {
             'total_docs': Document.objects.count(),
         }
+
 
 @hooks.register('construct_homepage_summary_items')
 def add_documents_summary_item(request, items):

--- a/wagtail/wagtaildocs/wagtail_hooks.py
+++ b/wagtail/wagtaildocs/wagtail_hooks.py
@@ -23,7 +23,7 @@ def register_admin_urls():
 
 class DocumentsMenuItem(MenuItem):
     def is_shown(self, request):
-        return request.user.has_perm('wagtaildocs.add_document')
+        return request.user.has_perm('wagtaildocs.add_document') or request.user.has_perm('wagtaildocs.change_document')
 
 
 @hooks.register('register_admin_menu_item')

--- a/wagtail/wagtailimages/templates/wagtailimages/images/index.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/index.html
@@ -15,8 +15,13 @@
 
 {% block content %}
     {% trans "Images" as im_str %}
-    {% trans "Add an image" as add_img_str %}
-    {% include "wagtailadmin/shared/header.html" with title=im_str add_link="wagtailimages:add_multiple" icon="image" add_text=add_img_str search_url="wagtailimages:index" %}
+
+    {% if perms.wagtailimages.add_image %}
+        {% trans "Add an image" as add_img_str %}
+        {% include "wagtailadmin/shared/header.html" with title=im_str add_link="wagtailimages:add_multiple" icon="image" add_text=add_img_str search_url="wagtailimages:index" %}
+    {% else %}
+        {% include "wagtailadmin/shared/header.html" with title=im_str icon="image" search_url="wagtailimages:index" %}
+    {% endif %}
 
     <div class="nice-padding">
         <div id="image-results">

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -3,10 +3,10 @@ import json
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404, render
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.contrib.auth.decorators import permission_required
 
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 from wagtail.wagtailadmin.forms import SearchForm
+from wagtail.wagtailadmin.utils import permission_required
 from wagtail.wagtailsearch.backends import get_search_backends
 
 from wagtail.wagtailimages.models import get_image_model

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -3,7 +3,6 @@ import json
 
 from django.shortcuts import render, redirect, get_object_or_404
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.contrib.auth.decorators import permission_required
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
@@ -13,6 +12,7 @@ from django.http import HttpResponse
 from wagtail.wagtailcore.models import Site
 from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailadmin import messages
+from wagtail.wagtailadmin.utils import any_permission_required
 from wagtail.wagtailsearch.backends import get_search_backends
 
 from wagtail.wagtailimages.models import get_image_model, Filter
@@ -21,7 +21,7 @@ from wagtail.wagtailimages.utils import generate_signature
 from wagtail.wagtailimages.exceptions import InvalidFilterSpecError
 
 
-@permission_required('wagtailimages.add_image')
+@any_permission_required('wagtailimages.add_image', 'wagtailimages.change_image')
 @vary_on_headers('X-Requested-With')
 def index(request):
     Image = get_image_model()
@@ -233,7 +233,7 @@ def delete(request, image_id):
     })
 
 
-@permission_required('wagtailimages.add_image')
+@any_permission_required('wagtailimages.add_image')
 def add(request):
     ImageModel = get_image_model()
     ImageForm = get_image_form(ImageModel)

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -12,7 +12,7 @@ from django.http import HttpResponse
 from wagtail.wagtailcore.models import Site
 from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailadmin import messages
-from wagtail.wagtailadmin.utils import any_permission_required
+from wagtail.wagtailadmin.utils import permission_required, any_permission_required
 from wagtail.wagtailsearch.backends import get_search_backends
 
 from wagtail.wagtailimages.models import get_image_model, Filter
@@ -233,7 +233,7 @@ def delete(request, image_id):
     })
 
 
-@any_permission_required('wagtailimages.add_image')
+@permission_required('wagtailimages.add_image')
 def add(request):
     ImageModel = get_image_model()
     ImageForm = get_image_form(ImageModel)

--- a/wagtail/wagtailimages/views/multiple.py
+++ b/wagtail/wagtailimages/views/multiple.py
@@ -1,12 +1,13 @@
 import json
 
 from django.shortcuts import render, get_object_or_404
-from django.contrib.auth.decorators import permission_required
 from django.views.decorators.http import require_POST
 from django.core.exceptions import PermissionDenied
 from django.views.decorators.vary import vary_on_headers
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.utils.encoding import force_text
+
+from wagtail.wagtailadmin.utils import any_permission_required
 
 from wagtail.wagtailsearch.backends import get_search_backends
 
@@ -38,7 +39,7 @@ def get_image_edit_form(ImageModel):
     return ImageEditForm
 
 
-@permission_required('wagtailimages.add_image')
+@any_permission_required('wagtailimages.add_image')
 @vary_on_headers('X-Requested-With')
 def add(request):
     Image = get_image_model()

--- a/wagtail/wagtailimages/views/multiple.py
+++ b/wagtail/wagtailimages/views/multiple.py
@@ -7,7 +7,7 @@ from django.views.decorators.vary import vary_on_headers
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.utils.encoding import force_text
 
-from wagtail.wagtailadmin.utils import any_permission_required
+from wagtail.wagtailadmin.utils import permission_required
 
 from wagtail.wagtailsearch.backends import get_search_backends
 
@@ -39,7 +39,7 @@ def get_image_edit_form(ImageModel):
     return ImageEditForm
 
 
-@any_permission_required('wagtailimages.add_image')
+@permission_required('wagtailimages.add_image')
 @vary_on_headers('X-Requested-With')
 def add(request):
     Image = get_image_model()

--- a/wagtail/wagtailimages/wagtail_hooks.py
+++ b/wagtail/wagtailimages/wagtail_hooks.py
@@ -23,7 +23,7 @@ def register_admin_urls():
 
 class ImagesMenuItem(MenuItem):
     def is_shown(self, request):
-        return request.user.has_perm('wagtailimages.add_image')
+        return request.user.has_perm('wagtailimages.add_image') or request.user.has_perm('wagtailimages.change_image')
 
 
 @hooks.register('register_admin_menu_item')

--- a/wagtail/wagtailimages/wagtail_hooks.py
+++ b/wagtail/wagtailimages/wagtail_hooks.py
@@ -4,7 +4,6 @@ from django.core import urlresolvers
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth.models import Permission
-from django.contrib.contenttypes.models import ContentType
 
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailadmin.menu import MenuItem
@@ -25,6 +24,7 @@ def register_admin_urls():
 class ImagesMenuItem(MenuItem):
     def is_shown(self, request):
         return request.user.has_perm('wagtailimages.add_image')
+
 
 @hooks.register('register_admin_menu_item')
 def register_images_menu_item():
@@ -53,9 +53,8 @@ def editor_js():
 
 @hooks.register('register_permissions')
 def register_permissions():
-    image_content_type = ContentType.objects.get(app_label='wagtailimages', model='image')
-    image_permissions = Permission.objects.filter(content_type=image_content_type)
-    return image_permissions
+    return Permission.objects.filter(content_type__app_label='wagtailimages',
+        codename__in=['add_image', 'change_image'])
 
 
 @hooks.register('register_image_operations')
@@ -83,6 +82,7 @@ class ImagesSummaryItem(SummaryItem):
         return {
             'total_images': get_image_model().objects.count(),
         }
+
 
 @hooks.register('construct_homepage_summary_items')
 def add_images_summary_item(request, items):

--- a/wagtail/wagtailredirects/views.py
+++ b/wagtail/wagtailredirects/views.py
@@ -1,5 +1,4 @@
 from django.shortcuts import render, redirect, get_object_or_404
-from django.contrib.auth.decorators import permission_required
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
@@ -7,6 +6,7 @@ from django.core.urlresolvers import reverse
 
 from wagtail.wagtailadmin.edit_handlers import ObjectList
 from wagtail.wagtailadmin.forms import SearchForm
+from wagtail.wagtailadmin.utils import permission_required
 from wagtail.wagtailadmin import messages
 
 from wagtail.wagtailredirects import models

--- a/wagtail/wagtailsites/views.py
+++ b/wagtail/wagtailsites/views.py
@@ -1,21 +1,14 @@
 from django.shortcuts import render, redirect, get_object_or_404
-from django.contrib.auth.decorators import permission_required, user_passes_test
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 
 from wagtail.wagtailcore.models import Site
 from wagtail.wagtailsites.forms import SiteForm
 from wagtail.wagtailadmin import messages
+from wagtail.wagtailadmin.utils import permission_required, any_permission_required
 
 
-def user_has_site_model_perm(user):
-    for verb in ['add', 'change', 'delete']:
-        if user.has_perm('wagtailcore.%s_site' % verb):
-            return True
-    return False
-
-
-@user_passes_test(user_has_site_model_perm)
+@any_permission_required('wagtailcore.add_site', 'wagtailcore.change_site', 'wagtailcore.delete_site')
 def index(request):
     sites = Site.objects.all()
     return render(request, 'wagtailsites/index.html', {

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/includes/formatted_permissions.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/includes/formatted_permissions.html
@@ -20,17 +20,23 @@
             <td class="title"><h3>{{ content_perms_dict.object|capfirst }}</h3></td>
             <td>
                 {% with content_perms_dict.add as perm_tuple %}
-                <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1 }} value="{{ perm_tuple.0.id }}">
+                    {% if perm_tuple %}
+                        <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1 }} value="{{ perm_tuple.0.id }}">
+                    {% endif %}
                 {% endwith %}
             </td>
             <td>
                 {% with content_perms_dict.change as perm_tuple %}
-                <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1 }} value="{{ perm_tuple.0.id }}">
+                    {% if perm_tuple %}
+                        <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1 }} value="{{ perm_tuple.0.id }}">
+                    {% endif %}
                 {% endwith %}
             </td>
             <td>
                 {% with content_perms_dict.delete as perm_tuple %}
-                <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1 }} value="{{ perm_tuple.0.id }}">
+                    {% if perm_tuple %}
+                        <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1 }} value="{{ perm_tuple.0.id }}">
+                    {% endif %}
                 {% endwith %}
             </td>
         </tr>

--- a/wagtail/wagtailusers/views/groups.py
+++ b/wagtail/wagtailusers/views/groups.py
@@ -1,6 +1,5 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.models import Group
-from django.contrib.auth.decorators import permission_required, user_passes_test
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
@@ -8,17 +7,11 @@ from django.views.decorators.vary import vary_on_headers
 
 from wagtail.wagtailadmin import messages
 from wagtail.wagtailadmin.forms import SearchForm
+from wagtail.wagtailadmin.utils import permission_required, any_permission_required
 from wagtail.wagtailusers.forms import GroupForm, GroupPagePermissionFormSet
 
 
-def user_has_group_model_perm(user):
-    for verb in ['add', 'change', 'delete']:
-        if user.has_perm('auth.%s_group' % verb):
-            return True
-    return False
-
-
-@user_passes_test(user_has_group_model_perm)
+@any_permission_required('auth.add_group', 'auth.change_group', 'auth.delete_group')
 @vary_on_headers('X-Requested-With')
 def index(request):
     q = None

--- a/wagtail/wagtailusers/views/users.py
+++ b/wagtail/wagtailusers/views/users.py
@@ -8,19 +8,21 @@ from django.views.decorators.vary import vary_on_headers
 
 from wagtail.wagtailadmin import messages
 from wagtail.wagtailadmin.forms import SearchForm
-from wagtail.wagtailadmin.utils import permission_required
+from wagtail.wagtailadmin.utils import permission_required, any_permission_required
 from wagtail.wagtailusers.forms import UserCreationForm, UserEditForm
 from wagtail.wagtailcore.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
 
 User = get_user_model()
 
-# Typically we would check the permission 'auth.change_user' for user
-# management actions, but this may vary according to the AUTH_USER_MODEL
-# setting
+# Typically we would check the permission 'auth.change_user' (and 'auth.add_user' /
+# 'auth.delete_user') for user management actions, but this may vary according to
+# the AUTH_USER_MODEL setting
+add_user_perm = "{0}.add_{1}".format(AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME.lower())
 change_user_perm = "{0}.change_{1}".format(AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME.lower())
+delete_user_perm = "{0}.delete_{1}".format(AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME.lower())
 
 
-@permission_required(change_user_perm)
+@any_permission_required(add_user_perm, change_user_perm, delete_user_perm)
 @vary_on_headers('X-Requested-With')
 def index(request):
     q = None
@@ -81,7 +83,7 @@ def index(request):
         })
 
 
-@permission_required(change_user_perm)
+@permission_required(add_user_perm)
 def create(request):
     if request.POST:
         form = UserCreationForm(request.POST)

--- a/wagtail/wagtailusers/views/users.py
+++ b/wagtail/wagtailusers/views/users.py
@@ -1,6 +1,5 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth import get_user_model
-from django.contrib.auth.decorators import permission_required
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.urlresolvers import reverse
 from django.db.models import Q
@@ -9,6 +8,7 @@ from django.views.decorators.vary import vary_on_headers
 
 from wagtail.wagtailadmin import messages
 from wagtail.wagtailadmin.forms import SearchForm
+from wagtail.wagtailadmin.utils import permission_required
 from wagtail.wagtailusers.forms import UserCreationForm, UserEditForm
 from wagtail.wagtailcore.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
 

--- a/wagtail/wagtailusers/wagtail_hooks.py
+++ b/wagtail/wagtailusers/wagtail_hooks.py
@@ -5,6 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.wagtailcore import hooks
+from wagtail.wagtailcore.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
 from wagtail.wagtailadmin.menu import MenuItem
 
 from wagtail.wagtailusers.urls import users, groups
@@ -18,9 +19,21 @@ def register_admin_urls():
     ]
 
 
+# Typically we would check the permission 'auth.change_user' (and 'auth.add_user' /
+# 'auth.delete_user') for user management actions, but this may vary according to
+# the AUTH_USER_MODEL setting
+add_user_perm = "{0}.add_{1}".format(AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME.lower())
+change_user_perm = "{0}.change_{1}".format(AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME.lower())
+delete_user_perm = "{0}.delete_{1}".format(AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME.lower())
+
+
 class UsersMenuItem(MenuItem):
     def is_shown(self, request):
-        return request.user.has_module_perms('auth')
+        return (
+            request.user.has_perm(add_user_perm)
+            or request.user.has_perm(change_user_perm)
+            or request.user.has_perm(delete_user_perm)
+        )
 
 
 @hooks.register('register_settings_menu_item')

--- a/wagtail/wagtailusers/wagtail_hooks.py
+++ b/wagtail/wagtailusers/wagtail_hooks.py
@@ -2,7 +2,6 @@ from django.db.models import Q
 from django.conf.urls import include, url
 from django.core import urlresolvers
 from django.contrib.auth.models import Permission
-from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.wagtailcore import hooks

--- a/wagtail/wagtailusers/wagtail_hooks.py
+++ b/wagtail/wagtailusers/wagtail_hooks.py
@@ -22,9 +22,11 @@ class AuthMenuItem(MenuItem):
     def is_shown(self, request):
         return request.user.has_module_perms('auth')
 
+
 @hooks.register('register_settings_menu_item')
 def register_users_menu_item():
     return AuthMenuItem(_('Users'), urlresolvers.reverse('wagtailusers_users:index'), classnames='icon icon-user', order=600)
+
 
 @hooks.register('register_settings_menu_item')
 def register_groups_menu_item():
@@ -33,7 +35,6 @@ def register_groups_menu_item():
 
 @hooks.register('register_permissions')
 def register_permissions():
-    user_profile_content_types = ContentType.objects.filter(app_label='wagtailusers', model='userprofile')
     auth_content_types = ContentType.objects.filter(app_label='auth', model__in=['group', 'user'])
-    relevant_content_types = user_profile_content_types | auth_content_types
+    relevant_content_types = auth_content_types
     return Permission.objects.filter(content_type__in=relevant_content_types)

--- a/wagtail/wagtailusers/wagtail_hooks.py
+++ b/wagtail/wagtailusers/wagtail_hooks.py
@@ -18,19 +18,28 @@ def register_admin_urls():
     ]
 
 
-class AuthMenuItem(MenuItem):
+class UsersMenuItem(MenuItem):
     def is_shown(self, request):
         return request.user.has_module_perms('auth')
 
 
 @hooks.register('register_settings_menu_item')
 def register_users_menu_item():
-    return AuthMenuItem(_('Users'), urlresolvers.reverse('wagtailusers_users:index'), classnames='icon icon-user', order=600)
+    return UsersMenuItem(_('Users'), urlresolvers.reverse('wagtailusers_users:index'), classnames='icon icon-user', order=600)
+
+
+class GroupsMenuItem(MenuItem):
+    def is_shown(self, request):
+        return (
+            request.user.has_perm('auth.add_group')
+            or request.user.has_perm('auth.change_group')
+            or request.user.has_perm('auth.delete_group')
+        )
 
 
 @hooks.register('register_settings_menu_item')
 def register_groups_menu_item():
-    return AuthMenuItem(_('Groups'), urlresolvers.reverse('wagtailusers_groups:index'), classnames='icon icon-group', order=601)
+    return GroupsMenuItem(_('Groups'), urlresolvers.reverse('wagtailusers_groups:index'), classnames='icon icon-group', order=601)
 
 
 @hooks.register('register_permissions')

--- a/wagtail/wagtailusers/wagtail_hooks.py
+++ b/wagtail/wagtailusers/wagtail_hooks.py
@@ -1,3 +1,4 @@
+from django.db.models import Q
 from django.conf.urls import include, url
 from django.core import urlresolvers
 from django.contrib.auth.models import Permission
@@ -57,6 +58,11 @@ def register_groups_menu_item():
 
 @hooks.register('register_permissions')
 def register_permissions():
-    auth_content_types = ContentType.objects.filter(app_label='auth', model__in=['group', 'user'])
-    relevant_content_types = auth_content_types
-    return Permission.objects.filter(content_type__in=relevant_content_types)
+    user_permissions = Q(content_type__app_label=AUTH_USER_APP_LABEL, codename__in=[
+        'add_%s' % AUTH_USER_MODEL_NAME.lower(),
+        'change_%s' % AUTH_USER_MODEL_NAME.lower(),
+        'delete_%s' % AUTH_USER_MODEL_NAME.lower(),
+    ])
+    group_permissions = Q(content_type__app_label='auth', codename__in=['add_group', 'change_group', 'delete_group'])
+
+    return Permission.objects.filter(user_permissions | group_permissions)


### PR DESCRIPTION
There are currently quite a few discrepancies between the permissions that are exposed in the group admin interface, the permissions that determine whether or not a particular menu item is shown, and the permissions that are actually enforced in the views. This is a first pass at fixing some of these inconsistencies so that:

* for models with a concept of ownership (documents, images and (TODO) pages), 'add' allows you to add items and edit/delete ones owned by you, and 'change' allows you to edit/delete other people's. (We ought to have some sort of help text in the group permissions UI to explain this - need to discuss with @davecranwell, as there doesn't seem to be anything suitable in the style guide right now)
* for models without a concept of ownership, 'add', 'change' and 'delete' permissions work as expected
* partial permissions (e.g. 'change' but not 'add') should work, even if they're of questionable usefulness
* menu items should appear if (and only if) there is at least one action you can perform within that area
* the group permissions interface should expose all permissions that are actually used as per the above rules, and leave out the ones that aren't

As a bonus (because I needed it for the unit tests), I've implemented a replacement for `permission_required` that fixes #1539.

Still to do (in a separate PR): snippets, page permissions, and models that are not currently represented in the group permissions interface (redirects, sites and search promotions).