### PR TITLE
Add help text to steer editors away from creating non-routable pages

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/index.html
@@ -14,7 +14,7 @@
         {% csrf_token %}
 
         {% page_permissions parent_page as parent_page_perms %}
-        {% include "wagtailadmin/pages/listing/_list_explore.html" with sortable=1 allow_navigation=1 full_width=1 parent_page=parent_page orderable=parent_page_perms.can_reorder_children %}
+        {% include "wagtailadmin/pages/listing/_list_explore.html" with sortable=1 allow_navigation=1 full_width=1 show_ordering_column=1 parent_page=parent_page orderable=parent_page_perms.can_reorder_children %}
 
         {% url 'wagtailadmin_explore' parent_page.id as pagination_base_url %}
         {% include "wagtailadmin/pages/listing/_pagination.html" with page=pages base_url=pagination_base_url query_params=pagination_query_params only %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load wagtailadmin_tags %}
 <table class="listing {% if full_width %}full-width{% endif %} {% block table_classname %}{% endblock %}">
-    {% if orderable %}
+    {% if show_ordering_column %}
         <col width="50px" />
     {% endif %}
     <col />
@@ -19,7 +19,7 @@
         {% if parent_page %}
             {% page_permissions parent_page as parent_page_perms %}
             <tr class="index {% if not parent_page.live %} unpublished{% endif %} {% block parent_page_row_classname %}{% endblock %}">
-                <td class="title" {% if orderable %}colspan="2"{% endif %}>
+                <td class="title" {% if show_ordering_column %}colspan="2"{% endif %}>
                     {% block parent_page_title %}
                     {% endblock %}
                 </td>
@@ -46,8 +46,8 @@
             {% for page in pages %}
                 {% page_permissions page as page_perms %}
                 <tr {% if ordering == "ord" %}id="page_{{ page.id }}" data-page-title="{{ page.title }}"{% endif %} class="{% if not page.live %}unpublished{% endif %} {% block page_row_classname %}{% endblock %}">
-                    {% if orderable %}
-                        <td class="ord">{% if ordering == "ord" %}<div class="handle icon icon-grip text-replace">{% trans 'Drag' %}</div>{% endif %}</td>
+                    {% if show_ordering_column %}
+                        <td class="ord">{% if orderable and ordering == "ord" %}<div class="handle icon icon-grip text-replace">{% trans 'Drag' %}</div>{% endif %}</td>
                     {% endif %}
                     <td class="title" valign="top">
                         {% block page_title %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list_explore.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list_explore.html
@@ -10,45 +10,47 @@
 
 {% block post_parent_page_headers %}
 
-    {% if parent_page.is_root %}
-        <tr><td colspan="6"><div class="help-block help-info">
-            {% if perms.wagtailcore.add_site %}
-                {% url 'wagtailsites:index' as wagtailsites_index_url %}
-                <p>
+    {% if parent_page %}
+        {% if parent_page.is_root %}
+            <tr><td colspan="6"><div class="help-block help-info">
+                {% if perms.wagtailcore.add_site %}
+                    {% url 'wagtailsites:index' as wagtailsites_index_url %}
+                    <p>
+                        {% blocktrans %}
+                            The root level is where you can add new sites to your Wagtail installation. Pages created here will not be accessible at any URL until they are associated with a site.
+                        {% endblocktrans %}
+                        {% if wagtailsites_index_url %}
+                            <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
+                        {% endif %}
+                    </p>
+                    <p>
+                        {% blocktrans %}
+                            If you just want to add pages to an existing site, create them as children of the homepage instead.
+                        {% endblocktrans %}
+                    </p>
+                {% else %}
                     {% blocktrans %}
-                        The root level is where you can add new sites to your Wagtail installation. Pages created here will not be accessible at any URL until they are associated with a site.
+                        Pages created here will not be accessible at any URL. To add pages to an existing site, create them as children of the homepage.
+                    {% endblocktrans %}
+                {% endif %}
+            </div></td></tr>
+        {% elif not parent_page.url %}
+            <tr><td colspan="6"><div class="help-block help-warning">
+                {% if perms.wagtailcore.add_site %}
+                    {% url 'wagtailsites:index' as wagtailsites_index_url %}
+                    {% blocktrans %}
+                        There is no site set up for this location. Pages created here will not be accessible at any URL until a site is associated with this location.
                     {% endblocktrans %}
                     {% if wagtailsites_index_url %}
                         <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
                     {% endif %}
-                </p>
-                <p>
+                {% else %}
                     {% blocktrans %}
-                        If you just want to add pages to an existing site, create them as children of the homepage instead.
+                        There is no site record for this location. Pages created here will not be accessible at any URL.
                     {% endblocktrans %}
-                </p>
-            {% else %}
-                {% blocktrans %}
-                    Pages created here will not be accessible at any URL. To add pages to an existing site, create them as children of the homepage.
-                {% endblocktrans %}
-            {% endif %}
-        </div></td></tr>
-    {% elif not parent_page.url %}
-        <tr><td colspan="6"><div class="help-block help-warning">
-            {% if perms.wagtailcore.add_site %}
-                {% url 'wagtailsites:index' as wagtailsites_index_url %}
-                {% blocktrans %}
-                    There is no site set up for this location. Pages created here will not be accessible at any URL until a site is associated with this location.
-                {% endblocktrans %}
-                {% if wagtailsites_index_url %}
-                    <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
                 {% endif %}
-            {% else %}
-                {% blocktrans %}
-                    There is no site record for this location. Pages created here will not be accessible at any URL.
-                {% endblocktrans %}
-            {% endif %}
-        </div></td></tr>
+            </div></td></tr>
+        {% endif %}
     {% endif %}
 
     {% include "wagtailadmin/pages/listing/_table_headers_explore.html" %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list_explore.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list_explore.html
@@ -9,6 +9,33 @@
 {% endblock %}
 
 {% block post_parent_page_headers %}
+
+    {% if parent_page.is_root %}
+        <tr><td colspan="6"><div class="help-block help-info">
+            {% if perms.wagtailcore.add_site %}
+                {% blocktrans %}
+                    The root level is where you can add new sites to your Wagtail installation. Pages created here will not be available at any URL until they are associated with a site through the Settings -> Sites area. To add pages to an existing site, create them as children of the homepage.
+                {% endblocktrans %}
+            {% else %}
+                {% blocktrans %}
+                    Pages created here will not be available at any URL. To add pages to an existing site, create them as children of the homepage.
+                {% endblocktrans %}
+            {% endif %}
+        </div></td></tr>
+    {% elif not parent_page.url %}
+        <tr><td colspan="6"><div class="help-block help-warning">
+            {% if perms.wagtailcore.add_site %}
+                {% blocktrans %}
+                    There is no site record for this location. Pages created here will not be available at any URL until a site is configured through the Settings -> Sites area.
+                {% endblocktrans %}
+            {% else %}
+                {% blocktrans %}
+                    There is no site record for this location. Pages created here will not be available at any URL.
+                {% endblocktrans %}
+            {% endif %}
+        </div></td></tr>
+    {% endif %}
+
     {% include "wagtailadmin/pages/listing/_table_headers_explore.html" %}
 {% endblock %}
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list_explore.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list_explore.html
@@ -13,24 +13,39 @@
     {% if parent_page.is_root %}
         <tr><td colspan="6"><div class="help-block help-info">
             {% if perms.wagtailcore.add_site %}
-                {% blocktrans %}
-                    The root level is where you can add new sites to your Wagtail installation. Pages created here will not be available at any URL until they are associated with a site through the Settings -> Sites area. To add pages to an existing site, create them as children of the homepage.
-                {% endblocktrans %}
+                {% url 'wagtailsites:index' as wagtailsites_index_url %}
+                <p>
+                    {% blocktrans %}
+                        The root level is where you can add new sites to your Wagtail installation. Pages created here will not be accessible at any URL until they are associated with a site.
+                    {% endblocktrans %}
+                    {% if wagtailsites_index_url %}
+                        <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
+                    {% endif %}
+                </p>
+                <p>
+                    {% blocktrans %}
+                        If you just want to add pages to an existing site, create them as children of the homepage instead.
+                    {% endblocktrans %}
+                </p>
             {% else %}
                 {% blocktrans %}
-                    Pages created here will not be available at any URL. To add pages to an existing site, create them as children of the homepage.
+                    Pages created here will not be accessible at any URL. To add pages to an existing site, create them as children of the homepage.
                 {% endblocktrans %}
             {% endif %}
         </div></td></tr>
     {% elif not parent_page.url %}
         <tr><td colspan="6"><div class="help-block help-warning">
             {% if perms.wagtailcore.add_site %}
+                {% url 'wagtailsites:index' as wagtailsites_index_url %}
                 {% blocktrans %}
-                    There is no site record for this location. Pages created here will not be available at any URL until a site is configured through the Settings -> Sites area.
+                    There is no site set up for this location. Pages created here will not be accessible at any URL until a site is associated with this location.
                 {% endblocktrans %}
+                {% if wagtailsites_index_url %}
+                    <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
+                {% endif %}
             {% else %}
                 {% blocktrans %}
-                    There is no site record for this location. Pages created here will not be available at any URL.
+                    There is no site record for this location. Pages created here will not be accessible at any URL.
                 {% endblocktrans %}
             {% endif %}
         </div></td></tr>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_table_headers_explore.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_table_headers_explore.html
@@ -5,7 +5,8 @@
 Table headers for the page listing, when in 'explore' mode. Expects the following variables:
 
 sortable: if true, headings are links to wagtailadmin_explore with sort parameters applied.
-orderable: if true, an 'ordering' column is added (again with links to wagtailadmin_explore).
+show_ordering_column: if true, an 'ordering' column is added.
+orderable: if true, the 'ordering' column is populated (again with links to wagtailadmin_explore).
 
 If either sortable or orderable is true, the following variables are also required:
 
@@ -15,12 +16,14 @@ ordering: the current sort parameter
 {% endcomment %}
 
 <tr class="table-headers">
-    {% if orderable %}
+    {% if show_ordering_column %}
         <th class="ord">
-            {% if ordering == "ord" %}
-                <a href="{% url 'wagtailadmin_explore' parent_page.id %}" class="icon icon-order text-replace" title="{% trans 'Disable ordering of child pages' %}">{% trans 'Order' %}</a></th> 
-            {% else %}
-                <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering=ord" class="icon icon-order text-replace" title="{% trans 'Enable ordering of child pages' %}">{% trans 'Order' %}</a></th>
+            {% if orderable %}
+                {% if ordering == "ord" %}
+                    <a href="{% url 'wagtailadmin_explore' parent_page.id %}" class="icon icon-order text-replace" title="{% trans 'Disable ordering of child pages' %}">{% trans 'Order' %}</a></th>
+                {% else %}
+                    <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering=ord" class="icon icon-order text-replace" title="{% trans 'Enable ordering of child pages' %}">{% trans 'Order' %}</a></th>
+                {% endif %}
             {% endif %}
         </th>
     {% endif %}


### PR DESCRIPTION
Adding help text to the explorer at the root level (and any other place where no site is configured), as proposed in https://github.com/torchbox/wagtail/issues/1583#issuecomment-131078851. @davecranwell might want to tweak the styling here (it gets an extra left margin for being the first cell of a table row, which we probably don't want).

Incorporates the display fix from #1611.