### PR TITLE
Add a couple of indexes for performance

### DIFF
--- a/wagtail/tests/testapp/migrations/0007_auto_20150819_0614.py
+++ b/wagtail/tests/testapp/migrations/0007_auto_20150819_0614.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tests', '0006_image_file_size'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='customimagewithadminformfields',
+            name='created_at',
+            field=models.DateTimeField(db_index=True, verbose_name='Created at', auto_now_add=True),
+        ),
+        migrations.AlterField(
+            model_name='customimagewithoutadminformfields',
+            name='created_at',
+            field=models.DateTimeField(db_index=True, verbose_name='Created at', auto_now_add=True),
+        ),
+    ]

--- a/wagtail/wagtailcore/migrations/0018_pagerevision_submitted_for_moderation_index.py
+++ b/wagtail/wagtailcore/migrations/0018_pagerevision_submitted_for_moderation_index.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0017_change_edit_page_permission_description'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='pagerevision',
+            name='submitted_for_moderation',
+            field=models.BooleanField(default=False, db_index=True, verbose_name='Submitted for moderation'),
+        ),
+    ]

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1074,7 +1074,7 @@ class SubmittedRevisionsManager(models.Manager):
 @python_2_unicode_compatible
 class PageRevision(models.Model):
     page = models.ForeignKey('Page', verbose_name=_('Page'), related_name='revisions')
-    submitted_for_moderation = models.BooleanField(verbose_name=_('Submitted for moderation'), default=False)
+    submitted_for_moderation = models.BooleanField(verbose_name=_('Submitted for moderation'), default=False, db_index=True)
     created_at = models.DateTimeField(verbose_name=_('Created at'))
     user = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_('User'), null=True, blank=True)
     content_json = models.TextField(verbose_name=_('Content JSON'))

--- a/wagtail/wagtailimages/migrations/0008_image_created_at_index.py
+++ b/wagtail/wagtailimages/migrations/0008_image_created_at_index.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailimages', '0007_image_file_size'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='image',
+            name='created_at',
+            field=models.DateTimeField(db_index=True, verbose_name='Created at', auto_now_add=True),
+        ),
+    ]

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -63,7 +63,7 @@ class AbstractImage(models.Model, TagSearchable):
     file = models.ImageField(verbose_name=_('File'), upload_to=get_upload_to, width_field='width', height_field='height')
     width = models.IntegerField(verbose_name=_('Width'), editable=False)
     height = models.IntegerField(verbose_name=_('Height'), editable=False)
-    created_at = models.DateTimeField(verbose_name=_('Created at'), auto_now_add=True)
+    created_at = models.DateTimeField(verbose_name=_('Created at'), auto_now_add=True, db_index=True)
     uploaded_by_user = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_('Uploaded by user'), null=True, blank=True, editable=False)
 
     tags = TaggableManager(help_text=None, blank=True, verbose_name=_('Tags'))


### PR DESCRIPTION
Fixes #1622 
Fixes #1598 

Both of these indexes I've found greatly improve performance on the dashboard and image index/choosers.

We could extend this to include compound indexes between key fields (``page``, ``user`` and ``submitted_for_moderation``) and ``created_at`` (as these are very often used together). I didn't find much speed improvement by doing that though (as those key fields generally have quite a high cardinality anyway).