### PR TITLE
Add tests for and update documentation for tagged snippets

### DIFF
--- a/docs/reference/pages/model_recipes.rst
+++ b/docs/reference/pages/model_recipes.rst
@@ -155,11 +155,11 @@ Using an example from the Wagtail demo site, here's what the tag model and the r
 
     from modelcluster.fields import ParentalKey
     from modelcluster.contrib.taggit import ClusterTaggableManager
-    from taggit.models import Tag, TaggedItemBase
-    ...
+    from taggit.models import TaggedItemBase
+
     class BlogPageTag(TaggedItemBase):
         content_object = ParentalKey('demo.BlogPage', related_name='tagged_items')
-    ...
+
     class BlogPage(Page):
         ...
         tags = ClusterTaggableManager(through=BlogPageTag, blank=True)

--- a/docs/topics/snippets.rst
+++ b/docs/topics/snippets.rst
@@ -169,3 +169,28 @@ These child objects are now accessible through the page's ``advert_placements`` 
   {% endfor %}
 
 
+Tagging snippets
+----------------
+
+Adding tags to snippets is very similar to adding tags to pages. The only difference is that :class:`taggit.manager.TaggableManager` should be used in the place of :class:`~modelcluster.contrib.taggit.ClusterTaggableManager`.
+
+.. code-block:: python
+
+    from modelcluster.fields import ParentalKey
+    from taggit.models import TaggedItemBase
+    from taggit.managers import TaggableManager
+
+    class AdvertTag(TaggedItemBase):
+        content_object = ParentalKey('demo.Advert', related_name='tagged_items')
+
+    @register_snippet
+    class Advert(models.Model):
+        ...
+        tags = TaggableManager(through=BlogPageTag, blank=True)
+
+        panels = [
+            ...
+            FieldPanel('tags'),
+        ]
+
+The :ref:`documentation on tagging pages <tagging>` has more information on how to use tags in views.

--- a/wagtail/tests/testapp/migrations/0007_auto_20150820_0419.py
+++ b/wagtail/tests/testapp/migrations/0007_auto_20150820_0419.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import taggit.managers
+import modelcluster.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taggit', '0001_initial'),
+        ('tests', '0006_image_file_size'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='AdvertTag',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('content_object', modelcluster.fields.ParentalKey(related_name='tagged_items', to='tests.Advert')),
+                ('tag', models.ForeignKey(related_name='tests_adverttag_items', to='taggit.Tag')),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+        migrations.AddField(
+            model_name='advert',
+            name='tags',
+            field=taggit.managers.TaggableManager(to='taggit.Tag', through='tests.AdvertTag', blank=True, help_text='A comma-separated list of tags.', verbose_name='Tags'),
+        ),
+    ]

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -5,6 +5,7 @@ from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.utils.encoding import python_2_unicode_compatible
 
 from taggit.models import TaggedItemBase
+from taggit.managers import TaggableManager
 
 from modelcluster.fields import ParentalKey
 from modelcluster.contrib.taggit import ClusterTaggableManager
@@ -302,14 +303,22 @@ class AdvertPlacement(models.Model):
     advert = models.ForeignKey('tests.Advert', related_name='+')
     colour = models.CharField(max_length=255)
 
+
+class AdvertTag(TaggedItemBase):
+    content_object = ParentalKey('Advert', related_name='tagged_items')
+
+
 @python_2_unicode_compatible
 class Advert(models.Model):
     url = models.URLField(null=True, blank=True)
     text = models.CharField(max_length=255)
 
+    tags = TaggableManager(through=AdvertTag, blank=True)
+
     panels = [
         FieldPanel('url'),
         FieldPanel('text'),
+        FieldPanel('tags'),
     ]
 
     def __str__(self):


### PR DESCRIPTION
Following the [Tagging recipe](http://docs.wagtail.io/en/v1.0/reference/pages/model_recipes.html#tagging) does not work for snippets. Instead, you should use TaggableManager. A test case checking that tags work on Snippets has been added, and the documentation will be updated shortly. 