### PR TITLE
Added show_in_menus into Page filter fields

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -301,6 +301,7 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         index.FilterField('path'),
         index.FilterField('depth'),
         index.FilterField('locked'),
+        index.FilterField('show_in_menus'),
     )
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Need this for a test. This will add ``show_in_menus`` into the Elasticsearch index so it can be filtered on. Most other fields on ``Page`` are indexed as ``FilterField`` so I think this is worth having anyway.