### PR TITLE
Added DeprecationWarnings for people still referencing EditorsPick

### DIFF
--- a/wagtail/contrib/wagtailsearchpromotions/models.py
+++ b/wagtail/contrib/wagtailsearchpromotions/models.py
@@ -1,11 +1,9 @@
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from wagtail.wagtailsearch.models import Query
-
 
 class SearchPromotion(models.Model):
-    query = models.ForeignKey(Query, db_index=True, related_name='editors_picks')
+    query = models.ForeignKey('wagtailsearch.Query', db_index=True, related_name='editors_picks')
     page = models.ForeignKey('wagtailcore.Page', verbose_name=_('Page'))
     sort_order = models.IntegerField(null=True, blank=True, editable=False)
     description = models.TextField(verbose_name=_('Description'), blank=True)

--- a/wagtail/wagtailsearch/models.py
+++ b/wagtail/wagtailsearch/models.py
@@ -91,7 +91,7 @@ def _make_fake_editors_pick_class():
             warnings.warn(
                 "The wagtailsearch.EditorsPick module has been moved to "
                 "contrib.wagtailsearchpromotions.SearchPromotion",
-                RemovedInWagtail13Warning, stacklevel=2)
+                RemovedInWagtail13Warning, stacklevel=5)
 
             super(EditorsPickQuerySet, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
I think lots of projects will have this reference so I think it's good to go the extra step to show the deprecation warning (which turned out to be quite tricky).

This fixes #1588 