### PR TITLE
Remove reference to non-existant page in docs

### DIFF
--- a/docs/editor_manual/administrator_tasks/index.rst
+++ b/docs/editor_manual/administrator_tasks/index.rst
@@ -8,4 +8,3 @@ This section of the guide documents how to perform common tasks as an administra
 
    managing_users
    promoted_search_results
-   .. redirects


### PR DESCRIPTION
I'm not sure what it was supposed to be referencing, but it was not doing anything except printing a warning when building the documentation. I couldn't find any section named 'redirecting', nor any toctree option, nor a rST directive.