### PR TITLE
Snippets docs: __str__ instead of __unicode__

### DIFF
--- a/docs/topics/snippets.rst
+++ b/docs/topics/snippets.rst
@@ -32,12 +32,12 @@ Here's an example snippet from the Wagtail demo website:
           FieldPanel('text'),
       ]
       
-      def __unicode__(self):
+      def __str__(self):
           return self.text
 
 The ``Advert`` model uses the basic Django model class and defines two properties: text and URL. The editing interface is very close to that provided for ``Page``-derived models, with fields assigned in the panels property. Snippets do not use multiple tabs of fields, nor do they provide the "save as draft" or "submit for moderation" features.
 
-``@register_snippet`` tells Wagtail to treat the model as a snippet. The ``panels`` list defines the fields to show on the snippet editing page. It's also important to provide a string representation of the class through ``def __unicode__(self):`` so that the snippet objects make sense when listed in the Wagtail admin.
+``@register_snippet`` tells Wagtail to treat the model as a snippet. The ``panels`` list defines the fields to show on the snippet editing page. It's also important to provide a string representation of the class through ``def __str__(self):`` so that the snippet objects make sense when listed in the Wagtail admin.
 
 Including Snippets in Template Tags
 -----------------------------------
@@ -145,7 +145,7 @@ To attach multiple adverts to a page, the ``SnippetChooserPanel`` can be placed 
           SnippetChooserPanel('advert', Advert),
       ]
   
-      def __unicode__(self):
+      def __str__(self):
           return self.page.title + " -> " + self.advert.text
   
   

--- a/docs/topics/snippets.rst
+++ b/docs/topics/snippets.rst
@@ -32,7 +32,7 @@ Here's an example snippet from the Wagtail demo website:
           FieldPanel('text'),
       ]
       
-      def __str__(self):
+      def __str__(self):              # __unicode__ on Python 2
           return self.text
 
 The ``Advert`` model uses the basic Django model class and defines two properties: text and URL. The editing interface is very close to that provided for ``Page``-derived models, with fields assigned in the panels property. Snippets do not use multiple tabs of fields, nor do they provide the "save as draft" or "submit for moderation" features.
@@ -145,7 +145,7 @@ To attach multiple adverts to a page, the ``SnippetChooserPanel`` can be placed 
           SnippetChooserPanel('advert', Advert),
       ]
   
-      def __str__(self):
+      def __str__(self):              # __unicode__ on Python 2
           return self.page.title + " -> " + self.advert.text
   
   


### PR DESCRIPTION
I was trying to follow the docs and was confused why the example code wasn't working. Looked into it and discovered that __str__ does work, while __unicode__ does not.

I'm guessing this has something to do with Unicode support being added in Python 3 (which is what I'm using).