### PR TITLE
Rename is_abstract to is_creatable

### DIFF
--- a/docs/reference/pages/model_reference.rst
+++ b/docs/reference/pages/model_reference.rst
@@ -153,6 +153,10 @@ In addition to the model fields provided, ``Page`` has many properties and metho
 
         Defines which template file should be used to render the login form for Protected pages using this model. This overrides the default, defined using ``PASSWORD_REQUIRED_TEMPLATE`` in your settings. See :ref:`private_pages`
 
+    .. attribute:: is_creatable
+
+        Controls if this page can be created through the Wagtail administration. Defaults to True, and is not inherited by subclasses. This is useful when using `multi-table inheritance <https://docs.djangoproject.com/en/1.8/topics/db/models/#multi-table-inheritance>`_, to stop the base model from being created as an actual page.
+
 ``Site``
 ========
 

--- a/wagtail/contrib/wagtailroutablepage/models.py
+++ b/wagtail/contrib/wagtailroutablepage/models.py
@@ -138,7 +138,5 @@ class RoutablePage(RoutablePageMixin, Page):
     added to it.
     """
 
-    is_abstract = True
-
     class Meta:
         abstract = True

--- a/wagtail/contrib/wagtailroutablepage/tests.py
+++ b/wagtail/contrib/wagtailroutablepage/tests.py
@@ -151,8 +151,6 @@ class TestOldStyleRoutablePage(TestNewStyleRoutablePage, WagtailTestUtils):
             # prevent this class appearing in the global PAGE_MODEL_CLASSES list, as
             # its non-standard location causes failures when translating from content types
             # back to models
-            is_abstract = True
-
             class Meta:
                 abstract = True
 

--- a/wagtail/tests/testapp/migrations/0010_mtibasepage_mtichildpage.py
+++ b/wagtail/tests/testapp/migrations/0010_mtibasepage_mtichildpage.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0019_verbose_names_cleanup'),
+        ('tests', '0009_auto_20150820_0419'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='MTIBasePage',
+            fields=[
+                ('page_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('wagtailcore.page',),
+        ),
+        migrations.CreateModel(
+            name='MTIChildPage',
+            fields=[
+                ('mtibasepage_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.MTIBasePage')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('tests.mtibasepage',),
+        ),
+    ]

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -440,3 +440,17 @@ class StreamPage(Page):
     ])
 
     api_fields = ('body',)
+
+
+class MTIBasePage(Page):
+    is_creatable = False
+
+
+class MTIChildPage(MTIBasePage):
+    # Should be creatable by default, no need to set anything
+    pass
+
+
+class AbstractPage(Page):
+    class Meta:
+        abstract = True

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -2,10 +2,10 @@ from __future__ import unicode_literals
 
 import logging
 import json
+import warnings
+
 from collections import defaultdict
-
 from modelcluster.models import ClusterableModel, get_all_child_relations
-
 import django
 from django.db import models, connection, transaction
 from django.db.models import Q
@@ -41,6 +41,8 @@ from wagtail.wagtailcore.signals import page_published, page_unpublished
 
 from wagtail.wagtailsearch import index
 from wagtail.wagtailsearch.backends import get_search_backend
+
+from wagtail.utils.deprecation import RemovedInWagtail13Warning
 
 
 logger = logging.getLogger('wagtail.core')
@@ -266,7 +268,13 @@ class PageBase(models.base.ModelBase):
         # All pages should be creatable unless explicitly set otherwise.
         # This attribute is not inheritable.
         if 'is_creatable' not in dct:
-            cls.is_creatable = not cls._meta.abstract
+            if 'is_abstract' in dct:
+                warnings.warn(
+                    "The is_abstract flag is deprecated - use is_creatable instead.",
+                    RemovedInWagtail13Warning)
+                cls.is_creatable = not dct['is_abstract']
+            else:
+                cls.is_creatable = not cls._meta.abstract
 
         if cls.is_creatable:
             # register this type in the list of page content types

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -10,8 +10,11 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 
-from wagtail.wagtailcore.models import Page, Site
-from wagtail.tests.testapp.models import SingleEventPage, EventPage, EventIndex, SimplePage, BusinessIndex, BusinessSubIndex, BusinessChild, StandardIndex
+from wagtail.wagtailcore.models import Page, Site, PAGE_MODEL_CLASSES
+from wagtail.tests.testapp.models import (
+    SingleEventPage, EventPage, EventIndex, SimplePage,
+    BusinessIndex, BusinessSubIndex, BusinessChild, StandardIndex,
+    MTIBasePage, MTIChildPage, AbstractPage)
 
 
 class TestSiteRouting(TestCase):
@@ -731,3 +734,30 @@ class TestIssue1216(TestCase):
         new_christmas_event = EventPage.objects.get(id=christmas_event.id)
         expected_url_path = "/home/%s/%s/" % (new_event_index_slug, new_christmas_slug)
         self.assertEqual(new_christmas_event.url_path, expected_url_path)
+
+
+class TestIsCreatable(TestCase):
+    def test_is_creatable_default(self):
+        """By default, pages should be creatable"""
+        self.assertTrue(SimplePage.is_creatable)
+        self.assertIn(SimplePage, PAGE_MODEL_CLASSES)
+
+    def test_is_creatable_false(self):
+        """Page types should be able to disable their creation"""
+        self.assertFalse(MTIBasePage.is_creatable)
+        self.assertNotIn(MTIBasePage, PAGE_MODEL_CLASSES)
+
+    def test_is_creatable_not_inherited(self):
+        """
+        is_creatable should not be inherited in the normal manner, and should
+        default to True unless set otherwise
+        """
+        self.assertTrue(MTIChildPage.is_creatable)
+        self.assertIn(MTIChildPage, PAGE_MODEL_CLASSES)
+
+    def test_abstract_pages(self):
+        """
+        Abstract models should not be creatable
+        """
+        self.assertFalse(AbstractPage.is_creatable)
+        self.assertNotIn(AbstractPage, PAGE_MODEL_CLASSES)

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import warnings
 
 import pytz
 
@@ -9,6 +10,7 @@ from django.http import HttpRequest, Http404
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
+from django.utils.six import text_type
 
 from wagtail.wagtailcore.models import Page, Site, PAGE_MODEL_CLASSES
 from wagtail.tests.testapp.models import (
@@ -761,3 +763,19 @@ class TestIsCreatable(TestCase):
         """
         self.assertFalse(AbstractPage.is_creatable)
         self.assertNotIn(AbstractPage, PAGE_MODEL_CLASSES)
+
+    def test_is_abstract(self):
+        """
+        is_abstract has been deprecated. Check that it still works, but issues
+        a deprecation warning
+        """
+        with warnings.catch_warnings(record=True) as ws:
+            class IsAbstractPage(Page):
+                is_abstract = True
+
+                class Meta:
+                    abstract = True
+
+            self.assertEqual(len(ws), 1)
+            warning = ws[0]
+            self.assertIn("is_creatable", text_type(warning.message))

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -131,7 +131,6 @@ class AbstractForm(Page):
     """
 
     form_builder = FormBuilder
-    is_abstract = True  # Don't display me in "Add"
 
     def __init__(self, *args, **kwargs):
         super(AbstractForm, self).__init__(*args, **kwargs)
@@ -207,7 +206,6 @@ class AbstractEmailForm(AbstractForm):
     """
     A Form Page that sends email. Pages implementing a form to be send to an email should inherit from it
     """
-    is_abstract = True  # Don't display me in "Add"
 
     to_address = models.CharField(verbose_name=_('To address'), max_length=255, blank=True, help_text=_("Optional - form submissions will be emailed to this address"))
     from_address = models.CharField(verbose_name=_('From address'), max_length=255, blank=True)


### PR DESCRIPTION
(Old title: Remove is_abstract) It was only really used because Page is a special case. It needs to be a real, non-abstract model, but should not be creatable through the admin. Instead of inventing a new (undocumented) setting, Page is specially handled in a single place. Now, `Model._meta.abstract` should work as expected.

See #1603, #515