### PR TITLE
Use StreamingHttpResponse in image serve view

### DIFF
--- a/wagtail/wagtailimages/tests/tests.py
+++ b/wagtail/wagtailimages/tests/tests.py
@@ -182,6 +182,7 @@ class TestFrontendServeView(TestCase):
 
         # Check response
         self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.streaming)
         self.assertEqual(response['Content-Type'], 'image/png')
 
     def test_get_invalid_signature(self):

--- a/wagtail/wagtailimages/views/frontend.py
+++ b/wagtail/wagtailimages/views/frontend.py
@@ -2,7 +2,7 @@ from wsgiref.util import FileWrapper
 import imghdr
 
 from django.shortcuts import get_object_or_404
-from django.http import HttpResponse
+from django.http import HttpResponse, StreamingHttpResponse
 from django.core.exceptions import PermissionDenied
 
 from wagtail.wagtailimages.models import get_image_model
@@ -20,6 +20,6 @@ def serve(request, signature, image_id, filter_spec):
         rendition = image.get_rendition(filter_spec)
         rendition.file.open('rb')
         image_format = imghdr.what(rendition.file)
-        return HttpResponse(FileWrapper(rendition.file), content_type='image/' + image_format)
+        return StreamingHttpResponse(FileWrapper(rendition.file), content_type='image/' + image_format)
     except InvalidFilterSpecError:
         return HttpResponse("Invalid filter spec: " + filter_spec, content_type='text/plain', status=400)


### PR DESCRIPTION
Fixes #1584

This will prevent djangos "UpdateCacheMiddleware" from trying to add the image into the cache.

https://github.com/django/django/blob/master/django/middleware/cache.py#L78-L79