### PR TITLE
Use container-based infrastructure on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+# Use container-based infrastructure
+sudo: false
+
 matrix:
   include:
    - env: TOXENV=py27-dj17-postgres


### PR DESCRIPTION
Travis CI added Docker container support earlier this year (http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/).

Since we've been using Travis CI before 1/1/2015, we must explicitly enable it.

This gives advantages such as:
 - builds start within 10 seconds
 - more resources in each build

Since Docker containers use less resources than VMs, their "fair usage policy" might back off a bit too.