### PR TITLE
Discard ResourceWarnings when testing for the presence of deprecation warnings

### DIFF
--- a/wagtail/wagtailimages/tests/tests.py
+++ b/wagtail/wagtailimages/tests/tests.py
@@ -182,6 +182,7 @@ class TestFrontendServeView(TestCase):
 
         # Check response
         self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.streaming)
         self.assertEqual(response['Content-Type'], 'image/png')
 
     def test_get_invalid_signature(self):

--- a/wagtail/wagtailimages/tests/tests.py
+++ b/wagtail/wagtailimages/tests/tests.py
@@ -292,13 +292,20 @@ class TestGetImageForm(TestCase, WagtailTestUtils):
 
     def test_custom_image_model_without_admin_form_fields_raises_warning(self):
         self.reset_warning_registry()
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True) as raw_warnings:
             form = get_image_form(CustomImageWithoutAdminFormFields)
 
             # Check that a RemovedInWagtail12Warning has been triggered
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, RemovedInWagtail12Warning))
-            self.assertTrue("Add admin_form_fields = (tuple of field names) to CustomImageWithoutAdminFormFields" in str(w[-1].message))
+
+            # Ignore any ResourceWarnings. TODO: remove this when we've stopped ResourceWarnings from happening...
+            try:
+                clean_warnings = [w for w in raw_warnings if not issubclass(w.category, ResourceWarning)]
+            except NameError:  # ResourceWarning only exists on Python >= 3.2
+                clean_warnings = raw_warnings
+
+            self.assertEqual(len(clean_warnings), 1)
+            self.assertTrue(issubclass(clean_warnings[-1].category, RemovedInWagtail12Warning))
+            self.assertTrue("Add admin_form_fields = (tuple of field names) to CustomImageWithoutAdminFormFields" in str(clean_warnings[-1].message))
 
         # All fields, including the not editable one should be on the form
         self.assertEqual(list(form.base_fields.keys()), [

--- a/wagtail/wagtailimages/views/frontend.py
+++ b/wagtail/wagtailimages/views/frontend.py
@@ -2,7 +2,7 @@ from wsgiref.util import FileWrapper
 import imghdr
 
 from django.shortcuts import get_object_or_404
-from django.http import HttpResponse
+from django.http import HttpResponse, StreamingHttpResponse
 from django.core.exceptions import PermissionDenied
 
 from wagtail.wagtailimages.models import get_image_model
@@ -20,6 +20,6 @@ def serve(request, signature, image_id, filter_spec):
         rendition = image.get_rendition(filter_spec)
         rendition.file.open('rb')
         image_format = imghdr.what(rendition.file)
-        return HttpResponse(FileWrapper(rendition.file), content_type='image/' + image_format)
+        return StreamingHttpResponse(FileWrapper(rendition.file), content_type='image/' + image_format)
     except InvalidFilterSpecError:
         return HttpResponse("Invalid filter spec: " + filter_spec, content_type='text/plain', status=400)


### PR DESCRIPTION
Workaround for a spurious test failure that appeared while reviewing #1633. Just making a PR for it so that it gets a run through Travis before I merge...