### PR TITLE
Show 12 images in image chooser

### DIFF
--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -51,14 +51,14 @@ def chooser(request):
             # page number
             p = request.GET.get("p", 1)
 
-            images = Image.search(q, results_per_page=10, page=p)
+            images = Image.search(q, results_per_page=12, page=p)
 
             is_searching = True
 
         else:
             images = Image.objects.order_by('-created_at')
             p = request.GET.get("p", 1)
-            paginator = Paginator(images, 10)
+            paginator = Paginator(images, 12)
 
             try:
                 images = paginator.page(p)
@@ -80,7 +80,7 @@ def chooser(request):
 
         images = Image.objects.order_by('-created_at')
         p = request.GET.get("p", 1)
-        paginator = Paginator(images, 10)
+        paginator = Paginator(images, 12)
 
         try:
             images = paginator.page(p)


### PR DESCRIPTION
Currently, the image chooser shows 10 images which creates annoying gaps in the results.

The results are displayed in a grid with up to 4 results per row. 12 is divisible by 1, 2, 3 and 4 eliminating any gaps in the last row.