### PR TITLE
Some cleanup to verbose names of core models

### DIFF
--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -424,7 +424,7 @@ class TestPageChooserPanel(TestCase):
             'barbecue',
             'wagtailcore.site'
         ).bind_to_model(PageChooserModel).target_content_type()[0]
-        self.assertEqual(result.name, 'Site')
+        self.assertEqual(result.name, 'site')
 
     def test_target_content_type_malformed_type(self):
         result = PageChooserPanel(

--- a/wagtail/wagtailcore/migrations/0019_verbose_names_cleanup.py
+++ b/wagtail/wagtailcore/migrations/0019_verbose_names_cleanup.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0018_pagerevision_submitted_for_moderation_index'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='grouppagepermission',
+            options={'verbose_name': 'group page permission', 'verbose_name_plural': 'group page permissions'},
+        ),
+        migrations.AlterModelOptions(
+            name='page',
+            options={'verbose_name': 'page', 'verbose_name_plural': 'pages'},
+        ),
+        migrations.AlterModelOptions(
+            name='pagerevision',
+            options={'verbose_name': 'page revision', 'verbose_name_plural': 'page revisions'},
+        ),
+        migrations.AlterModelOptions(
+            name='pageviewrestriction',
+            options={'verbose_name': 'page view restriction', 'verbose_name_plural': 'page view restrictions'},
+        ),
+        migrations.AlterModelOptions(
+            name='site',
+            options={'verbose_name': 'site', 'verbose_name_plural': 'sites'},
+        ),
+    ]

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -59,7 +59,8 @@ class Site(models.Model):
 
     class Meta:
         unique_together = ('hostname', 'port')
-        verbose_name = _('Site')
+        verbose_name = _('site')
+        verbose_name_plural = _('sites')
 
     def natural_key(self):
         return (self.hostname, self.port)
@@ -1025,6 +1026,10 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         context['action_url'] = action_url
         return TemplateResponse(request, self.password_required_template, context)
 
+    class Meta:
+        verbose_name = _('page')
+        verbose_name_plural = _('pages')
+
 
 def get_navigation_menu_items():
     # Get all pages that appear in the navigation menu: ones which have children,
@@ -1200,7 +1205,8 @@ class PageRevision(models.Model):
         return '"' + six.text_type(self.page) + '" at ' + six.text_type(self.created_at)
 
     class Meta:
-        verbose_name = _('Page Revision')
+        verbose_name = _('page revision')
+        verbose_name_plural = _('page revisions')
 
 
 PAGE_PERMISSION_TYPE_CHOICES = [
@@ -1218,7 +1224,8 @@ class GroupPagePermission(models.Model):
 
     class Meta:
         unique_together = ('group', 'page', 'permission_type')
-        verbose_name = _('Group Page Permission')
+        verbose_name = _('group page permission')
+        verbose_name_plural = _('group page permissions')
 
 
 class UserPagePermissionsProxy(object):
@@ -1444,4 +1451,5 @@ class PageViewRestriction(models.Model):
     password = models.CharField(verbose_name=_('Password'), max_length=255)
 
     class Meta:
-        verbose_name = _('Page View Restriction')
+        verbose_name = _('page view restriction')
+        verbose_name_plural = _('page view restrictions')


### PR DESCRIPTION
This PR makes the wagtailcore model names easier to translate

- Added verbose name to Page
- All models now have verbose_name_plural
- Made all verbose names lowercase

I originally started this to address https://github.com/torchbox/wagtail/pull/1613 but since that required a migration, I thought it would be worth throwing in a couple of other cleanups as well.