### PR TITLE
Remap primary keys of child objects in revisions when copying page

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import logging
 import json
+from collections import defaultdict
 
 from modelcluster.models import ClusterableModel, get_all_child_relations
 
@@ -810,17 +811,26 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         else:
             page_copy = self.add_sibling(instance=page_copy)
 
+        # A dict that maps child objects to their new ids
+        # Used to remap child object ids in revisions
+        child_object_id_map = defaultdict(dict)
+
         # Copy child objects
         specific_self = self.specific
         for child_relation in get_all_child_relations(specific_self):
+            accessor_name = child_relation.get_accessor_name()
             parental_key_name = child_relation.field.attname
-            child_objects = getattr(specific_self, child_relation.get_accessor_name(), None)
+            child_objects = getattr(specific_self, accessor_name, None)
 
             if child_objects:
                 for child_object in child_objects.all():
+                    old_pk = child_object.pk
                     child_object.pk = None
                     setattr(child_object, parental_key_name, page_copy.id)
                     child_object.save()
+
+                    # Add mapping to new primary key (so we can apply this change to revisions)
+                    child_object_id_map[accessor_name][old_pk] = child_object.pk
 
         # Copy revisions
         if copy_revisions:
@@ -835,8 +845,9 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
                 revision_content['pk'] = page_copy.pk
 
                 for child_relation in get_all_child_relations(specific_self):
+                    accessor_name = child_relation.get_accessor_name()
                     try:
-                        child_objects = revision_content[child_relation.get_accessor_name()]
+                        child_objects = revision_content[accessor_name]
                     except KeyError:
                         # KeyErrors are possible if the revision was created
                         # before this child relation was added to the database
@@ -844,6 +855,11 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
 
                     for child_object in child_objects:
                         child_object[child_relation.field.name] = page_copy.pk
+
+                        # Remap primary key to copied versions
+                        # If the primary key is not recognised (eg, the child object has been deleted from the database)
+                        # set the primary key to None
+                        child_object['pk'] = child_object_id_map[accessor_name].get(child_object['pk'], None)
 
                 revision.content_json = json.dumps(revision_content)
 

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -1,4 +1,3 @@
-import unittest
 import datetime
 import json
 
@@ -424,7 +423,6 @@ class TestCopyPage(TestCase):
         self.assertEqual(new_christmas_event.advert_placements.count(), 1, "Child objects defined on the superclass weren't copied")
         self.assertEqual(christmas_event.advert_placements.count(), 1, "Child objects defined on the superclass were removed from the original page")
 
-    @unittest.expectedFailure
     def test_copy_page_copies_revisions(self):
         christmas_event = EventPage.objects.get(url_path='/home/events/christmas/')
         christmas_event.save_revision()

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -1,3 +1,4 @@
+import unittest
 import datetime
 import json
 
@@ -423,6 +424,7 @@ class TestCopyPage(TestCase):
         self.assertEqual(new_christmas_event.advert_placements.count(), 1, "Child objects defined on the superclass weren't copied")
         self.assertEqual(christmas_event.advert_placements.count(), 1, "Child objects defined on the superclass were removed from the original page")
 
+    @unittest.expectedFailure
     def test_copy_page_copies_revisions(self):
         christmas_event = EventPage.objects.get(url_path='/home/events/christmas/')
         christmas_event.save_revision()
@@ -447,6 +449,11 @@ class TestCopyPage(TestCase):
         new_revision_content = json.loads(new_revision.content_json)
         self.assertEqual(new_revision_content['pk'], new_christmas_event.id)
         self.assertEqual(new_revision_content['speakers'][0]['page'], new_christmas_event.id)
+
+        # Also, check that the child objects in the new revision are given new IDs
+        old_speakers_ids = set(christmas_event.speakers.values_list('id', flat=True))
+        new_speakers_ids = set(speaker['pk'] for speaker in new_revision_content['speakers'])
+        self.assertFalse(old_speakers_ids.intersection(new_speakers_ids), "Child objects in revisions were not given a new primary key")
 
     def test_copy_page_copies_revisions_and_doesnt_submit_for_moderation(self):
         christmas_event = EventPage.objects.get(url_path='/home/events/christmas/')


### PR DESCRIPTION
Fixes #1418 

Wagtail copies child objects and revisions when copying pages. However, it didn't remap the primary keys of the child objects in the new revisions (so the COs in the revisions still had the ids they had when they were part of the previous page).

This PR fixes this by creating a mapping of old pks to new pks when copying the child objects. This mapping is then applied to each child object in every revision so the revisions match up with the new database records.

If a child object is found in a revision that no longer exists in the database, they are assigned ``None`` to their pk as they've effectively never existed.