### PR TITLE
Fix crash in get_search_promotions templatetag

### DIFF
--- a/wagtail/contrib/wagtailsearchpromotions/templatetags/wagtailsearchpromotions_tags.py
+++ b/wagtail/contrib/wagtailsearchpromotions/templatetags/wagtailsearchpromotions_tags.py
@@ -1,6 +1,7 @@
 from django import template
 
 from wagtail.wagtailsearch.models import Query
+from wagtail.contrib.wagtailsearchpromotions.models import SearchPromotion
 
 
 register = template.Library()
@@ -8,4 +9,7 @@ register = template.Library()
 
 @register.assignment_tag()
 def get_search_promotions(search_query):
-    return Query.get(search_query).editors_picks.all()
+    if search_query:
+        return Query.get(search_query).editors_picks.all()
+    else:
+        return SearchPromotion.objects.none()

--- a/wagtail/contrib/wagtailsearchpromotions/tests.py
+++ b/wagtail/contrib/wagtailsearchpromotions/tests.py
@@ -1,3 +1,5 @@
+import unittest
+
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 
@@ -70,6 +72,11 @@ class TestGetSearchPromotionsTemplateTag(TestCase):
         # Check
         search_picks = list(get_search_promotions("root page"))
         self.assertEqual(search_picks, [pick])
+
+    @unittest.expectedFailure
+    def test_get_search_promotions_with_none_query_string(self):
+        search_picks = list(get_search_promotions(None))
+        self.assertEqual(search_picks, [])
 
 
 class TestSearchPromotionsIndexView(TestCase, WagtailTestUtils):

--- a/wagtail/contrib/wagtailsearchpromotions/tests.py
+++ b/wagtail/contrib/wagtailsearchpromotions/tests.py
@@ -1,5 +1,3 @@
-import unittest
-
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 
@@ -73,7 +71,6 @@ class TestGetSearchPromotionsTemplateTag(TestCase):
         search_picks = list(get_search_promotions("root page"))
         self.assertEqual(search_picks, [pick])
 
-    @unittest.expectedFailure
     def test_get_search_promotions_with_none_query_string(self):
         search_picks = list(get_search_promotions(None))
         self.assertEqual(search_picks, [])


### PR DESCRIPTION
When the ``search_query`` parameter was set to ``None``, the template crashed with an error as it was attempting to run ``len()`` on the ``None`` value.