### PR TITLE
Chooser widgets should appear in the visible_fields list, not hidden_fields

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/generic/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/generic/create.html
@@ -16,7 +16,7 @@
 
         <div class="nice-padding">
             <ul class="fields">
-                {% block form %}
+                {% block visible_fields %}
                     {% for field in form.visible_fields %}
                         {% include "wagtailadmin/shared/field_as_li.html" %}
                     {% endfor %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/generic/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/generic/create.html
@@ -9,9 +9,17 @@
 
     <form action="{{ view.get_add_url }}" method="POST">
         {% csrf_token %}
+
+        {% block hidden_fields %}
+            {% for field in form.hidden_fields %}{{ field }}{% endfor %}
+        {% endblock %}
+
         <div class="nice-padding">
             <ul class="fields">
                 {% block form %}
+                    {% for field in form.visible_fields %}
+                        {% include "wagtailadmin/shared/field_as_li.html" %}
+                    {% endfor %}
                 {% endblock %}
                 <li><input type="submit" value="{% trans 'Save' %}" /></li>
             </ul>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/generic/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/generic/edit.html
@@ -10,9 +10,16 @@
     <div class="nice-padding">
         <form action="{{ view.get_edit_url }}" method="POST">
             {% csrf_token %}
-        
+
+            {% block hidden_fields %}
+                {% for field in form.hidden_fields %}{{ field }}{% endfor %}
+            {% endblock %}
+
             <ul class="fields">
                 {% block form %}
+                    {% for field in form.visible_fields %}
+                        {% include "wagtailadmin/shared/field_as_li.html" %}
+                    {% endfor %}
                 {% endblock %}
                 
                 <li>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/generic/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/generic/edit.html
@@ -16,12 +16,12 @@
             {% endblock %}
 
             <ul class="fields">
-                {% block form %}
+                {% block visible_fields %}
                     {% for field in form.visible_fields %}
                         {% include "wagtailadmin/shared/field_as_li.html" %}
                     {% endfor %}
                 {% endblock %}
-                
+
                 <li>
                     <input type="submit" value="{% trans 'Save' %}" />
                     {% if can_delete %}

--- a/wagtail/wagtailadmin/tests/test_widgets.py
+++ b/wagtail/wagtailadmin/tests/test_widgets.py
@@ -18,6 +18,10 @@ class TestAdminPageChooserWidget(TestCase):
         )
         self.root_page.add_child(instance=self.child_page)
 
+    def test_not_hidden(self):
+        widget = widgets.AdminPageChooser()
+        self.assertFalse(widget.is_hidden)
+
     def test_render_html(self):
         widget = widgets.AdminPageChooser()
 

--- a/wagtail/wagtailadmin/widgets.py
+++ b/wagtail/wagtailadmin/widgets.py
@@ -68,6 +68,10 @@ class AdminChooser(WidgetWithScript, widgets.Input):
     link_to_chosen_text = _("Edit this item")
     show_edit_link = True
 
+    # when looping over form fields, this one should appear in visible_fields, not hidden_fields
+    # despite the underlying input being type="hidden"
+    is_hidden = False
+
     def get_instance(self, model_class, value):
         # helper method for cleanly turning 'value' into an instance object
         if value is None:

--- a/wagtail/wagtailsites/templates/wagtailsites/_form.html
+++ b/wagtail/wagtailsites/templates/wagtailsites/_form.html
@@ -1,4 +1,0 @@
-{% include "wagtailadmin/shared/field_as_li.html" with field=form.hostname %}
-{% include "wagtailadmin/shared/field_as_li.html" with field=form.port %}
-{% include "wagtailadmin/shared/field_as_li.html" with field=form.root_page %}
-{% include "wagtailadmin/shared/field_as_li.html" with field=form.is_default_site %}

--- a/wagtail/wagtailsites/templates/wagtailsites/create.html
+++ b/wagtail/wagtailsites/templates/wagtailsites/create.html
@@ -1,9 +1,5 @@
 {% extends "wagtailadmin/generic/create.html" %}
 
-{% block form %}
-    {% include "wagtailsites/_form.html" %}
-{% endblock %}
-
 {% block extra_js %}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 {% endblock %}

--- a/wagtail/wagtailsites/templates/wagtailsites/edit.html
+++ b/wagtail/wagtailsites/templates/wagtailsites/edit.html
@@ -1,9 +1,5 @@
 {% extends "wagtailadmin/generic/edit.html" %}
 
-{% block form %}
-    {% include "wagtailsites/_form.html" %}
-{% endblock %}
-
 {% block extra_js %}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 {% endblock %}


### PR DESCRIPTION
The underlying input element of chooser widgets is `type="hidden"`, which means that they wrongly appear in the `hidden_fields` list of a form, rather than `visible_fields`.

With this bug fixed, the wagtailadmin generic templates can now provide a sensible default form rendering that loops over `hidden_fields` and `visible_fields`. This means wagtailsites no longer has to provide its own _form.html template.