### PR TITLE
Allow operator to be specified when searching

### DIFF
--- a/docs/topics/search/searching.rst
+++ b/docs/topics/search/searching.rst
@@ -85,6 +85,49 @@ This can be limited to a certian set of fields using the ``fields`` keyword argu
     [<EventPage: Event 1>, <EventPage: Event 2>]
 
 
+Changing search behaviour
+-------------------------
+
+Search operator
+^^^^^^^^^^^^^^^
+
+.. versionadded:: 1.2
+
+The search operator specifies how search should behave when the user has typed in multiple search terms. There are two possible values:
+
+ - "or" - The results must match at least one term (default for Elasticsearch)
+ - "and" - The results must match all terms (default for database search)
+
+Both operators have benefits and drawbacks. The "or" operator will return many more results but will likely contain a lot of results that aren't relevent. The "and" operator only returns results that contain all search terms, but require the user to be more precise with their query.
+
+We recommend using the "or" operator when ordering by relevance and the "and" operator when ordering by anything else (note: the database backend doesn't currently support ordering by relevance).
+
+Here's an example of using the "operator" keyword argument:
+
+.. code-block:: python
+
+    # The database contains a "Thing" model with the following items:
+    # - Hello world
+    # - Hello
+    # - World
+
+
+    # Search with the "or" operator
+    >>> s = get_search_backend()
+    >>> s.search("Hello world", Things, operator="or")
+
+    # All records returned as they all contain either "hello" or "world"
+    [<Thing: Hello World>, <Thing: Hello>, <Thing: World>]
+
+
+    # Search with the "and" operator
+    >>> s = get_search_backend()
+    >>> s.search("Hello world", Things, operator="and")
+
+    # Only "hello world" returned as that's the only item that contains both terms
+    [<Thing: Hello world>]
+
+
 .. _wagtailsearch_frontend_views:
 
 

--- a/docs/topics/search/searching.rst
+++ b/docs/topics/search/searching.rst
@@ -41,34 +41,45 @@ All other methods of ``PageQuerySet`` can be used with ``search()``. For example
     The ``search()`` method will convert your ``QuerySet`` into an instance of one of Wagtail's ``SearchResults`` classes (depending on backend). This means that you must perform filtering before calling ``search()``.
 
 
-Searching other models
-----------------------
+.. _wagtailsearch_images_documents_custom_models:
 
-All other models, which aren't automatically given the ``search()`` method on their ``QuerySet``, can instead search by calling the backend directly:
+Searching Images, Documents and custom models
+---------------------------------------------
+
+Wagtail's document and image models provide a ``search`` method on their QuerySets, just as pages do:
 
 .. code-block:: python
 
     >>> from wagtail.wagtailimages.models import Image
-    >>> from wagtail.wagtailsearch.backends import get_search_backend
 
-    # Search images
-    >>> s = get_search_backend()
-    >>> s.search("Hello", Image)
+    >>> Image.objects.filter(uploaded_by_user=user).search("Hello")
     [<Image: Hello>, <Image: Hello world!>]
 
-Here, we're calling ``.search()`` on the backend which takes two positional arguments: the query string and a model/queryset.
 
-Here's an example of searching a standard ``QuerySet``:
+:ref:`Custom models <wagtailsearch_indexing_models>` can be searched by using the ``search`` method on the search backend directly:
 
 .. code-block:: python
 
-    >>> from wagtail.wagtailimages.models import Image
+    >>> from myapp.models import Book
     >>> from wagtail.wagtailsearch.backends import get_search_backend
 
-    # Search images
+    # Search books
     >>> s = get_search_backend()
-    >>> s.search("Hello", Image.objects.filter(uploaded_by_user=user))
-    [<Image: Hello>]
+    >>> s.search("Great", Book)
+    [<Book: Great Expectations>, <Book: The Great Gatsby>]
+
+
+You can also pass a QuerySet into the ``search`` method which allows you to add filters to your search results:
+
+.. code-block:: python
+
+    >>> from myapp.models import Book
+    >>> from wagtail.wagtailsearch.backends import get_search_backend
+
+    # Search books
+    >>> s = get_search_backend()
+    >>> s.search("Great", Book.objects.filter(published_date__year__lt=1900))
+    [<Book: Great Expectations>]
 
 
 Specifying the fields to search
@@ -204,44 +215,3 @@ Promoted search results
 "Promoted search results" allow editors to explicitly link relevant content to search terms, so results pages can contain curated content in addition to results from the search engine.
 
 This functionality is provided by the :mod:`~wagtail.contrib.wagtailsearchpromotions` contrib module.
-
-
-.. _wagtailsearch_images_documents_custom_models:
-
-Searching Images, Documents and custom models
-=============================================
-
-Wagtail's document and image models provide a ``search`` method on their QuerySets, just as pages do:
-
-.. code-block:: python
-
-    >>> from wagtail.wagtailimages.models import Image
-
-    >>> Image.objects.filter(uploaded_by_user=user).search("Hello")
-    [<Image: Hello>, <Image: Hello world!>]
-
-
-:ref:`Custom models <wagtailsearch_indexing_models>` can be searched by using the ``search`` method on the search backend directly:
-
-.. code-block:: python
-
-    >>> from myapp.models import Book
-    >>> from wagtail.wagtailsearch.backends import get_search_backend
-
-    # Search books
-    >>> s = get_search_backend()
-    >>> s.search("Great", Book)
-    [<Book: Great Expectations>, <Book: The Great Gatsby>]
-
-
-You can also pass a QuerySet into the ``search`` method which allows you to add filters to your search results:
-
-.. code-block:: python
-
-    >>> from myapp.models import Book
-    >>> from wagtail.wagtailsearch.backends import get_search_backend
-
-    # Search books
-    >>> s = get_search_backend()
-    >>> s.search("Great", Book.objects.filter(published_date__year__lt=1900))
-    [<Book: Great Expectations>]

--- a/wagtail/wagtailcore/query.py
+++ b/wagtail/wagtailcore/query.py
@@ -197,12 +197,12 @@ class PageQuerySet(MP_NodeQuerySet):
         """
         return self.exclude(self.public_q())
 
-    def search(self, query_string, fields=None, backend='default'):
+    def search(self, query_string, fields=None, operator=None, backend='default'):
         """
         This runs a search query on all the pages in the QuerySet
         """
         search_backend = get_search_backend(backend)
-        return search_backend.search(query_string, self, fields=fields)
+        return search_backend.search(query_string, self, fields=fields, operator=operator)
 
     def unpublish(self):
         """

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -20,12 +20,12 @@ from wagtail.wagtailsearch.backends import get_search_backend
 
 
 class DocumentQuerySet(models.QuerySet):
-    def search(self, query_string, fields=None, backend='default'):
+    def search(self, query_string, fields=None, operator=None, backend='default'):
         """
         This runs a search query on all the documents in the QuerySet
         """
         search_backend = get_search_backend(backend)
-        return search_backend.search(query_string, self, fields=fields)
+        return search_backend.search(query_string, self, fields=fields, operator=operator)
 
 
 @python_2_unicode_compatible

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -43,12 +43,12 @@ class SourceImageIOError(IOError):
 
 
 class ImageQuerySet(models.QuerySet):
-    def search(self, query_string, fields=None, backend='default'):
+    def search(self, query_string, fields=None, operator=None, backend='default'):
         """
         This runs a search query on all the images in the QuerySet
         """
         search_backend = get_search_backend(backend)
-        return search_backend.search(query_string, self, fields=fields)
+        return search_backend.search(query_string, self, fields=fields, operator=operator)
 
 
 def get_upload_to(instance, filename):

--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -173,6 +173,9 @@ class BaseSearchResults(object):
 
 
 class BaseSearch(object):
+    search_query_class = None
+    search_results_class = None
+
     def __init__(self, params):
         pass
 
@@ -195,9 +198,6 @@ class BaseSearch(object):
         raise NotImplementedError
 
     def delete(self, obj):
-        raise NotImplementedError
-
-    def _search(self, queryset, query_string, fields=None):
         raise NotImplementedError
 
     def search(self, query_string, model_or_queryset, fields=None, filters=None, prefetch_related=None):
@@ -227,4 +227,5 @@ class BaseSearch(object):
                 queryset = queryset.prefetch_related(prefetch)
 
         # Search
-        return self._search(queryset, query_string, fields=fields)
+        search_query = self.search_query_class(queryset, query_string, fields=fields)
+        return self.search_results_class(self, search_query)

--- a/wagtail/wagtailsearch/backends/db.py
+++ b/wagtail/wagtailsearch/backends/db.py
@@ -4,6 +4,8 @@ from wagtail.wagtailsearch.backends.base import BaseSearch, BaseSearchQuery, Bas
 
 
 class DBSearchQuery(BaseSearchQuery):
+    DEFAULT_OPERATOR = 'and'
+
     def _process_lookup(self, field, lookup, value):
         return models.Q(**{field.get_attname(self.queryset.model) + '__' + lookup: value})
 
@@ -52,7 +54,10 @@ class DBSearchQuery(BaseSearchQuery):
                     # Filter on this field
                     term_query |= models.Q(**{'%s__icontains' % field_name: term})
 
-                q &= term_query
+                if self.operator == 'or':
+                    q |= term_query
+                elif self.operator == 'and':
+                    q &= term_query
 
         return q
 

--- a/wagtail/wagtailsearch/backends/db.py
+++ b/wagtail/wagtailsearch/backends/db.py
@@ -72,6 +72,9 @@ class DBSearchResults(BaseSearchResults):
 
 
 class DBSearch(BaseSearch):
+    search_query_class = DBSearchQuery
+    search_results_class = DBSearchResults
+
     def __init__(self, params):
         super(DBSearch, self).__init__(params)
 
@@ -92,9 +95,6 @@ class DBSearch(BaseSearch):
 
     def delete(self, obj):
         pass # Not needed
-
-    def _search(self, queryset, query_string, fields=None):
-        return DBSearchResults(self, DBSearchQuery(queryset, query_string, fields=fields))
 
 
 SearchBackend = DBSearch

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -467,6 +467,9 @@ class ElasticSearchAtomicIndexRebuilder(ElasticSearchIndexRebuilder):
 
 
 class ElasticSearch(BaseSearch):
+    search_query_class = ElasticSearchQuery
+    search_results_class = ElasticSearchResults
+
     def __init__(self, params):
         super(ElasticSearch, self).__init__(params)
 
@@ -578,9 +581,6 @@ class ElasticSearch(BaseSearch):
             )
         except NotFoundError:
             pass  # Document doesn't exist, ignore this exception
-
-    def _search(self, queryset, query_string, fields=None):
-        return ElasticSearchResults(self, ElasticSearchQuery(queryset, query_string, fields=fields))
 
 
 SearchBackend = ElasticSearch

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -156,6 +156,8 @@ class ElasticSearchMapping(object):
 
 
 class ElasticSearchQuery(BaseSearchQuery):
+    DEFAULT_OPERATOR = 'or'
+
     def _process_lookup(self, field, lookup, value):
         # Get the name of the field in the index
         field_index_name = field.get_index_name(self.queryset.model)
@@ -254,6 +256,9 @@ class ElasticSearchQuery(BaseSearchQuery):
                         fields[0]: self.query_string,
                     }
                 }
+
+                if self.operator != 'or':
+                    query['match']['operator'] = self.operator
             else:
                 query = {
                     'multi_match': {
@@ -261,6 +266,9 @@ class ElasticSearchQuery(BaseSearchQuery):
                         'fields': fields,
                     }
                 }
+
+                if self.operator != 'or':
+                    query['multi_match']['operator'] = self.operator
         else:
             query = {
                 'match_all': {}

--- a/wagtail/wagtailsearch/tests/test_backends.py
+++ b/wagtail/wagtailsearch/tests/test_backends.py
@@ -76,6 +76,18 @@ class BackendTests(WagtailTestUtils):
         results = self.backend.search("World", models.SearchTest)
         self.assertEqual(set(results), {self.testa, self.testd.searchtest_ptr})
 
+    def test_operator_or(self):
+        # All records that match any term should be returned
+        results = self.backend.search("Hello world", models.SearchTest, operator='or')
+
+        self.assertEqual(set(results), {self.testa, self.testb, self.testc.searchtest_ptr, self.testd.searchtest_ptr})
+
+    def test_operator_and(self):
+        # Records must match all search terms to be returned
+        results = self.backend.search("Hello world", models.SearchTest, operator='and')
+
+        self.assertEqual(set(results), {self.testa})
+
     def test_callable_indexed_field(self):
         results = self.backend.search("Callable", models.SearchTest)
         self.assertEqual(set(results), {self.testa, self.testb, self.testc.searchtest_ptr, self.testd.searchtest_ptr})

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -201,6 +201,14 @@ class TestElasticSearchQuery(TestCase):
         expected_result = {'filtered': {'filter': {'prefix': {'content_type': 'searchtests_searchtest'}}, 'query': {'match_all': {}}}}
         self.assertDictEqual(query.to_es(), expected_result)
 
+    def test_and_operator(self):
+        # Create a query
+        query = self.ElasticSearchQuery(models.SearchTest.objects.all(), "Hello", operator='and')
+
+        # Check it
+        expected_result = {'filtered': {'filter': {'prefix': {'content_type': 'searchtests_searchtest'}}, 'query': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials'], 'operator': 'and'}}}}
+        self.assertDictEqual(query.to_es(), expected_result)
+
     def test_filter(self):
         # Create a query
         query = self.ElasticSearchQuery(models.SearchTest.objects.filter(title="Test"), "Hello")
@@ -250,6 +258,14 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'prefix': {'content_type': 'searchtests_searchtest'}}, 'query': {'match': {'title': 'Hello'}}}}
+        self.assertDictEqual(query.to_es(), expected_result)
+
+    def test_fields_with_and_operator(self):
+        # Create a query
+        query = self.ElasticSearchQuery(models.SearchTest.objects.all(), "Hello", fields=['title'], operator='and')
+
+        # Check it
+        expected_result = {'filtered': {'filter': {'prefix': {'content_type': 'searchtests_searchtest'}}, 'query': {'match': {'title': 'Hello', 'operator': 'and'}}}}
         self.assertDictEqual(query.to_es(), expected_result)
 
     def test_exact_lookup(self):


### PR DESCRIPTION
Fixes #526

This pull request adds a new keyword argument to the search method called ``operator``.

This allows the developer to specify how multiple search terms should be handled:
 - "or" - all results must match one or more search terms
 - "and" - all results must match all search terms

~~The database backend was previously using the "and" operator by default, this has been changed to "or" for parity with elasticsearch.~~ Actually, this is a bad idea as the database backend doesn't order results by relevance, so using the "or" operator would mean users will get lots of trash in their results. Will change back (DONE).

This is especially useful for people who want to order by something other than relevence as the "and" operator can be used to remove records that don't exactly match.