### PR TITLE
Remove uses of Model._meta.description

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/add_subpage.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/add_subpage.html
@@ -21,7 +21,6 @@
                             </div>
 
                             <small class="col6" style="text-align:right">
-                                {{ content_type|meta_description }}
                                 <a href="{% url 'wagtailadmin_pages:type_use' content_type.app_label content_type.model %}" class="nolink">{% blocktrans with page_type=content_type.model_class.get_verbose_name %}Pages using {{ page_type }}{% endblocktrans %}</a>
                             </small>
                             

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -76,15 +76,6 @@ def widgettype(bound_field):
             return ""
 
 
-
-@register.filter
-def meta_description(model):
-    try:
-        return model.model_class()._meta.description
-    except:
-        return ""
-
-
 @register.assignment_tag(takes_context=True)
 def page_permissions(context, page):
     """

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/index.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/index.html
@@ -7,7 +7,7 @@
 
     <div class="nice-padding">
         <ul class="listing">
-            {% for name, description, content_type in snippet_types %}
+            {% for name, content_type in snippet_types %}
                 <li>
                     <div class="row row-flush title">
                         <h2>
@@ -15,7 +15,6 @@
                                 {{ name|capfirst }}
                             </a>
                         </h2>
-                        <small class="col6">{{ description }}</small>
                     </div>
                 </li>
             {% endfor %}

--- a/wagtail/wagtailsnippets/views/snippets.py
+++ b/wagtail/wagtailsnippets/views/snippets.py
@@ -31,15 +31,6 @@ def get_snippet_type_name(content_type):
     )
 
 
-def get_snippet_type_description(content_type):
-    """ return the meta description of the class associated with the given content type """
-    opts = content_type.model_class()._meta
-    try:
-        return force_text(opts.description)
-    except:
-        return ''
-
-
 def get_content_type_from_url_params(app_name, model_name):
     """
     retrieve a content type from an app_name / model_name combo.
@@ -76,7 +67,6 @@ def index(request):
     snippet_types = [
         (
             get_snippet_type_name(content_type)[1],
-            get_snippet_type_description(content_type),
             content_type
         )
         for content_type in get_snippet_content_types()


### PR DESCRIPTION
Due to harsher restrictions on model Meta attributes in Django 1.6, it is no longer possible to add a description attribute. This commit removes any code in Wagtail that still tried to rely on a description attribute.

I found this while searching the code base for bare `except:` clauses, so this is semi-related to #1684