### PR TITLE
Refactor out a bare except: statement

### DIFF
--- a/wagtail/wagtailredirects/middleware.py
+++ b/wagtail/wagtailredirects/middleware.py
@@ -16,12 +16,11 @@ class RedirectMiddleware(object):
         # Find redirect
         try:
             redirect = models.Redirect.get_for_site(request.site).get(old_path=path)
+        except models.Redirect.DoesNotExist:
+            # No redirect found, return the 400 page
+            return response
 
-            if redirect.is_permanent:
-                return http.HttpResponsePermanentRedirect(redirect.link)
-            else:
-                return http.HttpResponseRedirect(redirect.link)
-        except:
-            pass
-
-        return response
+        if redirect.is_permanent:
+            return http.HttpResponsePermanentRedirect(redirect.link)
+        else:
+            return http.HttpResponseRedirect(redirect.link)


### PR DESCRIPTION
It now catches `Redirect.DoesNotExist`, returning the normal 404 page if no redirect is found. Any other exception should not be caught here.

I found this while searching the code base for bare `except:` clauses, so this is semi-related to #1683

#1677 will have a merge-conflict with this one. I noticed bare `except:` clauses in the codebase when looking at that PR.