### PR TITLE
updated settings so that there is no decrepation warning

### DIFF
--- a/wagtail/project_template/project_name/settings/dev.py
+++ b/wagtail/project_template/project_name/settings/dev.py
@@ -3,7 +3,10 @@ from .base import *
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
-TEMPLATE_DEBUG = True
+DEBUG_TEMPLATE = True
+
+for i in range(0, len(TEMPLATES) - 1):
+    TEMPLATES[i]['OPTIONS']['debug'] = DEBUG_TEMPLATE
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '{{ secret_key }}'

--- a/wagtail/project_template/project_name/settings/dev.py
+++ b/wagtail/project_template/project_name/settings/dev.py
@@ -3,10 +3,9 @@ from .base import *
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
-DEBUG_TEMPLATE = True
 
-for i in range(0, len(TEMPLATES) - 1):
-    TEMPLATES[i]['OPTIONS']['debug'] = DEBUG_TEMPLATE
+for template_engine in TEMPLATES:
+    template_engine['OPTIONS']['debug'] = True
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '{{ secret_key }}'

--- a/wagtail/project_template/project_name/settings/production.py
+++ b/wagtail/project_template/project_name/settings/production.py
@@ -2,7 +2,10 @@ from .base import *
 
 
 DEBUG = False
-TEMPLATE_DEBUG = False
+DEBUG_TEMPLATE = False
+
+for i in range(0, len(TEMPLATES) - 1):
+    TEMPLATES[i]['OPTIONS']['debug'] = DEBUG_TEMPLATE
 
 
 try:

--- a/wagtail/project_template/project_name/settings/production.py
+++ b/wagtail/project_template/project_name/settings/production.py
@@ -2,11 +2,6 @@ from .base import *
 
 
 DEBUG = False
-DEBUG_TEMPLATE = False
-
-for i in range(0, len(TEMPLATES) - 1):
-    TEMPLATES[i]['OPTIONS']['debug'] = DEBUG_TEMPLATE
-
 
 try:
     from .local import *


### PR DESCRIPTION
I got warnings about `TEMPLATE_DEBUG = True` and that it's [decrepated](https://docs.djangoproject.com/en/1.8/ref/settings/#template-debug). So I changed it the way It's supposed to be ... I think