### PR TITLE
Add Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,14 @@ matrix:
    - env: TOXENV=py34-dj18-postgres
    - env: TOXENV=py34-dj18-sqlite
    - env: TOXENV=py34-dj18-mysql
+   - env: TOXENV=py35-dj18-postgres
+     python: 3.5
+   - env: TOXENV=py35-dj18-sqlite
+     python: 3.5
+   - env: TOXENV=py35-dj18-mysql
+     python: 3.5
+  allow_failures:
+    - python: 3.5
 
 # Services
 services:

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = py{27,33,34}-dj{17,18}-{sqlite,postgres,mysql}, flake8
+envlist = py{27,33,34,35}-dj{17,18}-{sqlite,postgres,mysql}, flake8
 
 [flake8]
 ignore = E501,E128,E261,E302,E303,E124,E126
@@ -15,6 +15,7 @@ basepython =
     py27: python2.7
     py33: python3.3
     py34: python3.4
+    py35: python3.5
 
 deps =
     django-compressor>=1.4


### PR DESCRIPTION
Python 3.5 has been released. I added 3.5 to tox/travis, ran the tests, and it worked!

Django 1.8 does not officially support Python 3.5, so I do not know if Python 3.5 support should be officially added at this point. I've set it as `allow_failure` in Travis. I do not know when Django 1.9 with Python 3.5 support will be coming out.