### PR TITLE
Remove bare except in unnecessary try block

### DIFF
--- a/wagtail/wagtailimages/rich_text.py
+++ b/wagtail/wagtailimages/rich_text.py
@@ -31,15 +31,12 @@ class ImageEmbedHandler(object):
         Image = get_image_model()
         try:
             image = Image.objects.get(id=attrs['id'])
-            format = get_image_format(attrs['format'])
-
-            if for_editor:
-                try:
-                    return format.image_to_editor_html(image, attrs['alt'])
-                except:
-                    return ''
-            else:
-                return format.image_to_html(image, attrs['alt'])
-
         except Image.DoesNotExist:
             return "<img>"
+
+        format = get_image_format(attrs['format'])
+
+        if for_editor:
+            return format.image_to_editor_html(image, attrs['alt'])
+        else:
+            return format.image_to_html(image, attrs['alt'])

--- a/wagtail/wagtailimages/tests/test_rich_text.py
+++ b/wagtail/wagtailimages/tests/test_rich_text.py
@@ -47,13 +47,3 @@ class TestImageEmbedHandler(TestCase):
             True
         )
         self.assertIn('<img data-embedtype="image" data-id="1" data-format="left" data-alt="test-alt" class="richtext-image left"', result)
-
-    @patch('wagtail.wagtailimages.models.Image')
-    @patch('django.core.files.File')
-    def test_expand_db_attributes_for_editor_throws_exception(self, mock_file, mock_image):
-        result = ImageEmbedHandler.expand_db_attributes(
-            {'id': 1,
-             'format': 'left'},
-            True
-        )
-        self.assertEqual(result, '')


### PR DESCRIPTION
From a comment by @gasman on #1684:

> It appears the try/catch in ImageEmbedHandler was added here: 74b9f43
>
> Since the rest of the commit doesn't deal with images at all, and the
> commit makes it clear that the corresponding change to
> MediaEmbedHandler was intended to preserve the existing 'fail
> silently' behaviour in the light of the new exceptions added for media
> embeds - I think this try/catch is redundant. `Format.image_to_html`
> does its own catching of image IO errors, which seems to be
> sufficiently robust (if it wasn't, we'd be seeing errors on front-end
> page rendering), so I think this try/catch can reasonably be deleted.

https://github.com/torchbox/wagtail/pull/1684#issuecomment-140695060