### PR TITLE
Fixes #1549: StreamField blocks are now added automatically if there's only one block type

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/blocks/stream.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/blocks/stream.js
@@ -32,11 +32,11 @@
 
         self.toggle = function() {
             if (self.container.hasClass('stream-menu-closed')) {
-              if (opts.childBlocks.length == 1) {
-                if (opts.onChooseBlock) opts.onChooseBlock(opts.childBlocks[0]);
-              } else {
-                self.show();
-              }
+                if (opts.childBlocks.length == 1) {
+                    if (opts.onChooseBlock) opts.onChooseBlock(opts.childBlocks[0]);
+                } else {
+                    self.show();
+                }
             } else {
                 self.hide();
             }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/blocks/stream.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/blocks/stream.js
@@ -32,7 +32,11 @@
 
         self.toggle = function() {
             if (self.container.hasClass('stream-menu-closed')) {
+              if (opts.childBlocks.length == 1) {
+                if (opts.onChooseBlock) opts.onChooseBlock(opts.childBlocks[0]);
+              } else {
                 self.show();
+              }
             } else {
                 self.hide();
             }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/blocks/stream.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/blocks/stream.js
@@ -30,10 +30,15 @@
             self.container.addClass('stream-menu-closed');
         };
 
+        self.addFirstBlock = function() {
+            if (opts.onChooseBlock) opts.onChooseBlock(opts.childBlocks[0]);
+        };
+
         self.toggle = function() {
             if (self.container.hasClass('stream-menu-closed')) {
                 if (opts.childBlocks.length == 1) {
-                    if (opts.onChooseBlock) opts.onChooseBlock(opts.childBlocks[0]);
+                    /* If there's only one block type, add it automatically */
+                    self.addFirstBlock();
                 } else {
                     self.show();
                 }


### PR DESCRIPTION
In the admin, clicking the + button when a StreamField menu is closed will now automatically add a block if there's only one possible type of block.

Fixes #1549