### PR TITLE
Add first publish/updated dates to search index

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -316,6 +316,8 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         index.FilterField('depth'),
         index.FilterField('locked'),
         index.FilterField('show_in_menus'),
+        index.FilterField('first_published_at'),
+        index.FilterField('latest_revision_created_at'),
     )
 
     # Do not allow plain Page instances to be created through the Wagtail admin


### PR DESCRIPTION
Wagtail search can filter on date ranges, and may soon support ordering on date fields as well. So I think these date fields aught to be in the search index.