### PR TITLE
Add CSS class to wagtail richtext editor buttons.

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
@@ -17,7 +17,7 @@
                     return $(node).parents('a').get(0);
                 };
 
-                button = $('<span></span>');
+                button = jQuery('<span class="' + this.widgetName + '"></span>');
                 button.hallobutton({
                     uuid: this.options.uuid,
                     editable: this.options.editable,

--- a/wagtail/wagtaildocs/static_src/wagtaildocs/js/hallo-plugins/hallo-wagtaildoclink.js
+++ b/wagtail/wagtaildocs/static_src/wagtaildocs/js/hallo-plugins/hallo-wagtaildoclink.js
@@ -10,7 +10,7 @@
                 var button, widget;
 
                 widget = this;
-                button = $('<span></span>');
+                button = jQuery('<span class="' + this.widgetName + '"></span>');
                 button.hallobutton({
                     uuid: this.options.uuid,
                     editable: this.options.editable,

--- a/wagtail/wagtailembeds/static_src/wagtailembeds/js/hallo-plugins/hallo-wagtailembeds.js
+++ b/wagtail/wagtailembeds/static_src/wagtailembeds/js/hallo-plugins/hallo-wagtailembeds.js
@@ -10,7 +10,7 @@
                 var button, widget;
 
                 widget = this;
-                button = $('<span></span>');
+                button = jQuery('<span class="' + this.widgetName + '"></span>');
                 button.hallobutton({
                     uuid: this.options.uuid,
                     editable: this.options.editable,

--- a/wagtail/wagtailimages/static_src/wagtailimages/js/hallo-plugins/hallo-wagtailimage.js
+++ b/wagtail/wagtailimages/static_src/wagtailimages/js/hallo-plugins/hallo-wagtailimage.js
@@ -10,7 +10,7 @@
                 var button, widget;
 
                 widget = this;
-                button = $('<span></span>');
+                button = jQuery('<span class="' + this.widgetName + '"></span>');
                 button.hallobutton({
                     uuid: this.options.uuid,
                     editable: this.options.editable,


### PR DESCRIPTION
Copying the hallo-hr.js CSS class definition approach to wagtail richtext editor buttons.  This allows them to be hidden via css if required, e.g.

.hallotoolbar .hallowagtailimage { display: none; }
