### PR TITLE
Fixed StreamField hover jitter

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/streamfield.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/streamfield.scss
@@ -5,12 +5,13 @@ ul.sequence{
 li.sequence-member{
     @include clearfix;
     position:relative;
+    border-style: solid;
+    border-color: transparent;
+    border-width: 1px 0;
 
     &:hover{
         background-color:$color-input-focus;
-        box-shadow:
-          inset 0 1px 0 darken($color-input-focus, 10%),
-          inset 0 -1px 0 darken($color-input-focus, 10%);
+        border-color: darken($color-input-focus, 10%);
 
         .sequence-member-inner{
             > .struct-block > label,
@@ -48,8 +49,8 @@ li.sequence-member{
         position:relative;
         padding:1.5em 50px;
 
-        .sequence-member:hover{
-            box-shadow:none;
+        .sequence-member {
+            border: 0;
         }
 
         /* sequences within sequences, such as a ListBlock within StructBlock*/

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/streamfield.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/streamfield.scss
@@ -8,8 +8,9 @@ li.sequence-member{
 
     &:hover{
         background-color:$color-input-focus;
-        border:1px solid darken($color-input-focus, 10%);
-        border-width:1px 0;
+        box-shadow:
+          inset 0 1px 0 darken($color-input-focus, 10%),
+          inset 0 -1px 0 darken($color-input-focus, 10%);
 
         .sequence-member-inner{
             > .struct-block > label,
@@ -24,7 +25,7 @@ li.sequence-member{
         opacity:1;
     }
 
-   
+
     .struct-block .fields{
         @include column(10);
         padding-left:0;
@@ -48,7 +49,7 @@ li.sequence-member{
         padding:1.5em 50px;
 
         .sequence-member:hover{
-            border:0;
+            box-shadow:none;
         }
 
         /* sequences within sequences, such as a ListBlock within StructBlock*/
@@ -120,7 +121,7 @@ should be borderless and full-width
 .block_field > .field-content > .input > .sequence-container > .sequence-container-inner > .sequence > .sequence-member > .sequence-member-inner{
     > .widget-text_input input,
     > .widget-rich_text_area .richtext,
-    > .widget-textarea textarea{ 
+    > .widget-textarea textarea{
         border:0;
         padding:0;
         background-color:transparent;
@@ -180,10 +181,10 @@ should be borderless and full-width
         &:hover label{
             opacity:1;
         }
-   
+
     .disabled{
         display:none;
-    }       
+    }
 }
 
 /* list controls are slightly different as they require closer proximity to their associated fields */
@@ -270,7 +271,7 @@ should be borderless and full-width
             clear:left;
         }
     }
-    
+
 
     button{
         @include transition(all 0.2s ease);
@@ -328,7 +329,7 @@ should be borderless and full-width
             &:focus{
                 color:$color-teal;
             }
-        }        
+        }
 
         &:hover{
             border-top-color:$color-teal;
@@ -336,7 +337,7 @@ should be borderless and full-width
             .toggle{
                 color:$color-teal;
             }
-        }   
+        }
     }
 
     @media screen and (min-width: $breakpoint-mobile){


### PR DESCRIPTION
When you hover over a StreamField block, it creates a 1px blue border which causes it to jitter. This solution uses ~~an inset box-shadow instead~~ an initial transparent border so that hovering produces no jitter.

~~If you don't like this, an alternative solution is to let the block always have a 1px transparent border, then the color of the border changes on hover. I felt the box-shadow solution would be cleaner, but the [browser compatibility](http://caniuse.com/#search=box-shadow) isn't as good. (#1724 what browsers should we support?)~~

Note that my text editor automatically stripped out some whitespace in this commit, hence the other lines being altered.