### PR TITLE
Added section on hostnames to Sitemaps docs

### DIFF
--- a/docs/reference/contrib/sitemaps.rst
+++ b/docs/reference/contrib/sitemaps.rst
@@ -36,6 +36,33 @@ Then, in ``urls.py``, you need to add a link to the ``wagtail.contrib.wagtailsit
 You should now be able to browse to ``/sitemap.xml`` and see the sitemap working. By default, all published pages in your website will be added to the site map.
 
 
+Setting the hostname
+~~~~~~~~~~~~~~~~~~~~
+
+By default, the sitemap uses the hostname defined in the Wagtail Admin's ``Sites`` area. If your
+default site is called ``localhost``, then URLs in the sitemap will look like:
+
+ .. code-block:: xml
+    <url>
+        <loc>http://localhost/about/</loc>
+        <lastmod>2015-09-26</lastmod>
+    </url>
+
+
+For tools like Google Search Tools to properly index your site, you need to set a valid, crawlable hostname. If you change the site's hostname from ``localhost`` to ``mysite.com``, ``sitemap.xml``
+will contain the correct URLs:
+
+ .. code-block:: xml
+    <url>
+        <loc>http://mysite.com/about/</loc>
+        <lastmod>2015-09-26</lastmod>
+    </url>
+
+
+Find out more about `working with Sites
+</reference/pages/model_reference.html?highlight=site#site>`.
+
+
 Customising
 ~~~~~~~~~~~
 


### PR DESCRIPTION
This is a quick clarification: at first read of the Sitemap docs, it's not immediately obvious that the hostname in the sitemap is derived from the Sites configuration. 