### PR TITLE
Correct German translation of 'slug'.

### DIFF
--- a/wagtail/wagtailcore/locale/de/LC_MESSAGES/django.po
+++ b/wagtail/wagtailcore/locale/de/LC_MESSAGES/django.po
@@ -65,7 +65,7 @@ msgid "The page title as you'd like it to be seen by the public"
 msgstr "Der Seitentitel, der öffentlich angezeigt werden soll"
 
 msgid "Slug"
-msgstr "Kugel"
+msgstr "Kurztitel"
 
 msgid ""
 "The name of the page as it will appear in URLs e.g http://domain.com/blog/"


### PR DESCRIPTION
At the moment, 'slug' is translated with the German word for 'sphere' which even confused me.