### PR TITLE
Check both `page` and `self` in templatetag contexts

### DIFF
--- a/wagtail/wagtailadmin/tests/test_userbar.py
+++ b/wagtail/wagtailadmin/tests/test_userbar.py
@@ -29,6 +29,18 @@ class TestUserbarTag(TestCase):
 
         self.assertIn("<!-- Wagtail user bar embed code -->", content)
 
+    def test_userbar_tag_self(self):
+        """
+        Ensure the userbar renders with `self` instead of `PAGE_TEMPLATE_VAR`
+        """
+        template = Template("{% load wagtailuserbar %}{% wagtailuserbar %}")
+        content = template.render(Context({
+            'self': self.homepage,
+            'request': self.dummy_request(self.user),
+        }))
+
+        self.assertIn("<!-- Wagtail user bar embed code -->", content)
+
     def test_userbar_tag_anonymous_user(self):
         template = Template("{% load wagtailuserbar %}{% wagtailuserbar %}")
         content = template.render(Context({


### PR DESCRIPTION
Old code that does not properly extend `Page.get_context()` for context generation will not get the new `PAGE_TEMPLATE_VAR` in their contexts, which did not play nicely with the `wagtailuserbar`. Now, the template context is checked for both `PAGE_TEMPLATE_VAR` and `self`, in that order, for a Page.

See #1742