### PR TITLE
Collections for image/document organisation

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -271,3 +271,10 @@ The available hooks are:
   .. versionadded:: 0.7
 
   Return a queryset of Permission objects to be shown in the Groups administration area.
+
+.. _register_collection_permissions:
+
+``register_collection_permissions``
+  .. versionadded:: 1.2
+
+  Return a queryset of Permission objects to be included in the 'collection permissions' dropdown within the Groups administration area.

--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -6,7 +6,7 @@ from django.contrib.auth.forms import AuthenticationForm, PasswordResetForm
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext, ugettext_lazy
 from wagtail.wagtailadmin.widgets import AdminPageChooser
-from wagtail.wagtailcore.models import Page
+from wagtail.wagtailcore.models import Page, Collection
 
 class URLOrAbsolutePathValidator(validators.URLValidator):
     @staticmethod
@@ -184,3 +184,9 @@ class PageViewRestrictionForm(forms.Form):
             del cleaned_data['password']
 
         return cleaned_data
+
+
+class CollectionForm(forms.ModelForm):
+    class Meta:
+        model = Collection
+        fields = ('name',)

--- a/wagtail/wagtailadmin/templates/wagtailadmin/collections/index.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/collections/index.html
@@ -1,0 +1,30 @@
+{% extends "wagtailadmin/generic/index.html" %}
+{% load i18n %}
+
+{% block listing %}
+    <div class="nice-padding">
+        <div id="sites-list">
+            <table class="listing">
+                <thead>
+                    <tr>
+                        <th>
+                            {% trans "Name" %}
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for collection in collections %}
+                        <tr>
+                            <td class="title">
+                                <h2>
+                                    <a href="{% url 'wagtailadmin_collections:edit' collection.id %}">{{ collection }}</a>
+                                </h2>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+
+        </div>
+    </div>
+{% endblock %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/collections/index.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/collections/index.html
@@ -3,28 +3,33 @@
 
 {% block listing %}
     <div class="nice-padding">
-        <div id="sites-list">
-            <table class="listing">
-                <thead>
-                    <tr>
-                        <th>
-                            {% trans "Name" %}
-                        </th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for collection in collections %}
+        {% if collections %}
+            <div id="sites-list">
+                <table class="listing">
+                    <thead>
                         <tr>
-                            <td class="title">
-                                <h2>
-                                    <a href="{% url 'wagtailadmin_collections:edit' collection.id %}">{{ collection }}</a>
-                                </h2>
-                            </td>
+                            <th>
+                                {% trans "Name" %}
+                            </th>
                         </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                        {% for collection in collections %}
+                            <tr>
+                                <td class="title">
+                                    <h2>
+                                        <a href="{% url 'wagtailadmin_collections:edit' collection.id %}">{{ collection }}</a>
+                                    </h2>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
 
-        </div>
+            </div>
+        {% else %}
+            {% url 'wagtailadmin_collections:add' as add_collection_url %}
+            <p>{% blocktrans %}No collections have been created. Why not <a href="{{ add_collection_url }}">add one</a>?{% endblocktrans %}</p>
+        {% endif %}
     </div>
 {% endblock %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/generic/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/generic/create.html
@@ -16,7 +16,7 @@
 
         <div class="nice-padding">
             <ul class="fields">
-                {% block form %}
+                {% block visible_fields %}
                     {% for field in form.visible_fields %}
                         {% include "wagtailadmin/shared/field_as_li.html" %}
                     {% endfor %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/generic/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/generic/create.html
@@ -9,9 +9,17 @@
 
     <form action="{{ view.get_add_url }}" method="POST">
         {% csrf_token %}
+
+        {% block hidden_fields %}
+            {% for field in form.hidden_fields %}{{ field }}{% endfor %}
+        {% endblock %}
+
         <div class="nice-padding">
             <ul class="fields">
                 {% block form %}
+                    {% for field in form.visible_fields %}
+                        {% include "wagtailadmin/shared/field_as_li.html" %}
+                    {% endfor %}
                 {% endblock %}
                 <li><input type="submit" value="{% trans 'Save' %}" /></li>
             </ul>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/generic/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/generic/edit.html
@@ -10,9 +10,16 @@
     <div class="nice-padding">
         <form action="{{ view.get_edit_url }}" method="POST">
             {% csrf_token %}
-        
+
+            {% block hidden_fields %}
+                {% for field in form.hidden_fields %}{{ field }}{% endfor %}
+            {% endblock %}
+
             <ul class="fields">
                 {% block form %}
+                    {% for field in form.visible_fields %}
+                        {% include "wagtailadmin/shared/field_as_li.html" %}
+                    {% endfor %}
                 {% endblock %}
                 
                 <li>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/generic/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/generic/edit.html
@@ -16,12 +16,12 @@
             {% endblock %}
 
             <ul class="fields">
-                {% block form %}
+                {% block visible_fields %}
                     {% for field in form.visible_fields %}
                         {% include "wagtailadmin/shared/field_as_li.html" %}
                     {% endfor %}
                 {% endblock %}
-                
+
                 <li>
                     <input type="submit" value="{% trans 'Save' %}" />
                     {% if can_delete %}

--- a/wagtail/wagtailadmin/tests/test_widgets.py
+++ b/wagtail/wagtailadmin/tests/test_widgets.py
@@ -18,6 +18,10 @@ class TestAdminPageChooserWidget(TestCase):
         )
         self.root_page.add_child(instance=self.child_page)
 
+    def test_not_hidden(self):
+        widget = widgets.AdminPageChooser()
+        self.assertFalse(widget.is_hidden)
+
     def test_render_html(self):
         widget = widgets.AdminPageChooser()
 

--- a/wagtail/wagtailadmin/urls/__init__.py
+++ b/wagtail/wagtailadmin/urls/__init__.py
@@ -3,6 +3,7 @@ from django.contrib.auth.decorators import permission_required
 from django.views.decorators.cache import cache_control
 
 from wagtail.wagtailadmin.urls import pages as wagtailadmin_pages_urls
+from wagtail.wagtailadmin.urls import collections as wagtailadmin_collections_urls
 from wagtail.wagtailadmin.urls import password_reset as wagtailadmin_password_reset_urls
 from wagtail.wagtailadmin.views import account, chooser, home, pages, tags, userbar
 from wagtail.wagtailcore import hooks
@@ -30,6 +31,8 @@ urlpatterns = [
     url(r'^choose-email-link/$', chooser.email_link, name='wagtailadmin_choose_page_email_link'),
 
     url(r'^tag-autocomplete/$', tags.autocomplete, name='wagtailadmin_tag_autocomplete'),
+
+    url(r'^collections/', include(wagtailadmin_collections_urls, namespace='wagtailadmin_collections')),
 
     url(r'^account/$', account.account, name='wagtailadmin_account'),
     url(r'^account/change_password/$', account.change_password, name='wagtailadmin_account_change_password'),

--- a/wagtail/wagtailadmin/urls/collections.py
+++ b/wagtail/wagtailadmin/urls/collections.py
@@ -1,0 +1,9 @@
+from django.conf.urls import url
+from wagtail.wagtailadmin.views import collections
+
+urlpatterns = [
+    url(r'^$', collections.Index.as_view(), name='index'),
+    url(r'^add/$', collections.Create.as_view(), name='add'),
+    url(r'^(\d+)/$', collections.Edit.as_view(), name='edit'),
+    url(r'^(\d+)/delete/$', collections.Delete.as_view(), name='delete'),
+]

--- a/wagtail/wagtailadmin/views/collections.py
+++ b/wagtail/wagtailadmin/views/collections.py
@@ -14,7 +14,7 @@ class Index(IndexView):
     add_permission_name = 'wagtailcore.add_collection'
     page_title = __("Collections")
     add_item_label = __("Add a collection")
-    header_icon = 'collection'
+    header_icon = 'folder-open-1'
 
     def get_queryset(self):
         # Only return children of the root node, so that the root is not editable
@@ -29,7 +29,7 @@ class Create(CreateView):
     add_url_name = 'wagtailadmin_collections:add'
     edit_url_name = 'wagtailadmin_collections:edit'
     index_url_name = 'wagtailadmin_collections:index'
-    header_icon = 'collection'
+    header_icon = 'folder-open-1'
 
     def save_instance(self, form):
         instance = form.save(commit=False)
@@ -50,7 +50,7 @@ class Edit(EditView):
     delete_url_name = 'wagtailadmin_collections:delete'
     delete_permission_name = 'wagtailcore.delete_collection'
     context_object_name = 'collection'
-    header_icon = 'collection'
+    header_icon = 'folder-open-1'
 
     def get_queryset(self):
         # Only return children of the root node, so that the root is not editable
@@ -65,7 +65,7 @@ class Delete(DeleteView):
     delete_url_name = 'wagtailadmin_collections:delete'
     page_title = __("Delete collection")
     confirmation_message = __("Are you sure you want to delete this collection?")
-    header_icon = 'collection'
+    header_icon = 'folder-open-1'
 
     def get_queryset(self):
         # Only return children of the root node, so that the root is not editable

--- a/wagtail/wagtailadmin/views/collections.py
+++ b/wagtail/wagtailadmin/views/collections.py
@@ -16,6 +16,10 @@ class Index(IndexView):
     add_item_label = __("Add a collection")
     header_icon = 'collection'
 
+    def get_queryset(self):
+        # Only return children of the root node, so that the root is not editable
+        return Collection.get_first_root_node().get_children()
+
 
 class Create(CreateView):
     permission_required = 'wagtailcore.add_collection'

--- a/wagtail/wagtailadmin/views/collections.py
+++ b/wagtail/wagtailadmin/views/collections.py
@@ -27,6 +27,12 @@ class Create(CreateView):
     index_url_name = 'wagtailadmin_collections:index'
     header_icon = 'collection'
 
+    def save_instance(self, form):
+        instance = form.save(commit=False)
+        root_collection = Collection.get_first_root_node()
+        root_collection.add_child(instance=instance)
+        return instance
+
 
 class Edit(EditView):
     permission_required = 'wagtailcore.change_collection'

--- a/wagtail/wagtailadmin/views/collections.py
+++ b/wagtail/wagtailadmin/views/collections.py
@@ -1,0 +1,54 @@
+from django.utils.translation import ugettext_lazy as __
+
+from wagtail.wagtailcore.models import Collection
+from wagtail.wagtailadmin.forms import CollectionForm
+from wagtail.wagtailadmin.views.generic import IndexView, CreateView, EditView, DeleteView
+
+
+class Index(IndexView):
+    any_permission_required = ['wagtailcore.add_collection', 'wagtailcore.change_collection', 'wagtailcore.delete_collection']
+    model = Collection
+    context_object_name = 'collections'
+    template_name = 'wagtailadmin/collections/index.html'
+    add_url_name = 'wagtailadmin_collections:add'
+    add_permission_name = 'wagtailcore.add_collection'
+    page_title = __("Collections")
+    add_item_label = __("Add a collection")
+    header_icon = 'collection'
+
+
+class Create(CreateView):
+    permission_required = 'wagtailcore.add_collection'
+    form_class = CollectionForm
+    page_title = __("Add collection")
+    success_message = __("Collection '{0}' created.")
+    add_url_name = 'wagtailadmin_collections:add'
+    edit_url_name = 'wagtailadmin_collections:edit'
+    index_url_name = 'wagtailadmin_collections:index'
+    header_icon = 'collection'
+
+
+class Edit(EditView):
+    permission_required = 'wagtailcore.change_collection'
+    model = Collection
+    form_class = CollectionForm
+    success_message = __("Collection '{0}' updated.")
+    error_message = __("The collection could not be saved due to errors.")
+    delete_item_label = __("Delete collection")
+    edit_url_name = 'wagtailadmin_collections:edit'
+    index_url_name = 'wagtailadmin_collections:index'
+    delete_url_name = 'wagtailadmin_collections:delete'
+    delete_permission_name = 'wagtailcore.delete_collection'
+    context_object_name = 'collection'
+    header_icon = 'collection'
+
+
+class Delete(DeleteView):
+    permission_required = 'wagtailcore.delete_collection'
+    model = Collection
+    success_message = __("Collection '{0}' deleted.")
+    index_url_name = 'wagtailadmin_collections:index'
+    delete_url_name = 'wagtailadmin_collections:delete'
+    page_title = __("Delete collection")
+    confirmation_message = __("Are you sure you want to delete this collection?")
+    header_icon = 'collection'

--- a/wagtail/wagtailadmin/views/collections.py
+++ b/wagtail/wagtailadmin/views/collections.py
@@ -52,6 +52,10 @@ class Edit(EditView):
     context_object_name = 'collection'
     header_icon = 'collection'
 
+    def get_queryset(self):
+        # Only return children of the root node, so that the root is not editable
+        return Collection.get_first_root_node().get_children()
+
 
 class Delete(DeleteView):
     permission_required = 'wagtailcore.delete_collection'
@@ -62,3 +66,7 @@ class Delete(DeleteView):
     page_title = __("Delete collection")
     confirmation_message = __("Are you sure you want to delete this collection?")
     header_icon = 'collection'
+
+    def get_queryset(self):
+        # Only return children of the root node, so that the root is not editable
+        return Collection.get_first_root_node().get_children()

--- a/wagtail/wagtailadmin/views/generic.py
+++ b/wagtail/wagtailadmin/views/generic.py
@@ -58,6 +58,8 @@ class IndexView(PermissionCheckedMixin, View):
 
 
 class CreateView(PermissionCheckedMixin, View):
+    template_name = 'wagtailadmin/generic/create.html'
+
     def get_add_url(self):
         return reverse(self.add_url_name)
 
@@ -87,6 +89,7 @@ class CreateView(PermissionCheckedMixin, View):
 class EditView(PermissionCheckedMixin, View):
     page_title = __("Editing")
     context_object_name = None
+    template_name = 'wagtailadmin/generic/edit.html'
 
     def get_page_subtitle(self):
         return str(self.instance)

--- a/wagtail/wagtailadmin/views/generic.py
+++ b/wagtail/wagtailadmin/views/generic.py
@@ -67,10 +67,17 @@ class CreateView(PermissionCheckedMixin, View):
         self.form = self.form_class()
         return self.render_to_response()
 
+    def save_instance(self, form):
+        """
+        Called after the form is successfully validated - saves the object to the db
+        and returns the new object. Override this to implement custom save logic.
+        """
+        return form.save()
+
     def post(self, request):
         self.form = self.form_class(request.POST)
         if self.form.is_valid():
-            instance = self.form.save()
+            instance = self.save_instance(self.form)
 
             messages.success(request, self.success_message.format(instance), buttons=[
                 messages.button(reverse(self.edit_url_name, args=(instance.id,)), _('Edit'))
@@ -100,6 +107,13 @@ class EditView(PermissionCheckedMixin, View):
     def get_delete_url(self):
         return reverse(self.delete_url_name, args=(self.instance.id,))
 
+    def save_instance(self, form):
+        """
+        Called after the form is successfully validated - saves the object to the db.
+        Override this to implement custom save logic.
+        """
+        return form.save()
+
     def get(self, request, instance_id):
         self.instance = get_object_or_404(self.model, id=instance_id)
         self.form = self.form_class(instance=self.instance)
@@ -109,7 +123,7 @@ class EditView(PermissionCheckedMixin, View):
         self.instance = get_object_or_404(self.model, id=instance_id)
         self.form = self.form_class(request.POST, instance=self.instance)
         if self.form.is_valid():
-            self.form.save()
+            self.save_instance(self.form)
             messages.success(request, self.success_message.format(self.instance), buttons=[
                 messages.button(reverse(self.edit_url_name, args=(self.instance.id,)), _('Edit'))
             ])

--- a/wagtail/wagtailadmin/views/generic.py
+++ b/wagtail/wagtailadmin/views/generic.py
@@ -98,6 +98,9 @@ class EditView(PermissionCheckedMixin, View):
     context_object_name = None
     template_name = 'wagtailadmin/generic/edit.html'
 
+    def get_queryset(self):
+        return self.model.objects.all()
+
     def get_page_subtitle(self):
         return str(self.instance)
 
@@ -115,12 +118,12 @@ class EditView(PermissionCheckedMixin, View):
         return form.save()
 
     def get(self, request, instance_id):
-        self.instance = get_object_or_404(self.model, id=instance_id)
+        self.instance = get_object_or_404(self.get_queryset(), id=instance_id)
         self.form = self.form_class(instance=self.instance)
         return self.render_to_response()
 
     def post(self, request, instance_id):
-        self.instance = get_object_or_404(self.model, id=instance_id)
+        self.instance = get_object_or_404(self.get_queryset(), id=instance_id)
         self.form = self.form_class(request.POST, instance=self.instance)
         if self.form.is_valid():
             self.save_instance(self.form)
@@ -150,6 +153,9 @@ class DeleteView(PermissionCheckedMixin, View):
     template_name = 'wagtailadmin/generic/confirm_delete.html'
     context_object_name = None
 
+    def get_queryset(self):
+        return self.model.objects.all()
+
     def get_page_subtitle(self):
         return str(self.instance)
 
@@ -157,7 +163,7 @@ class DeleteView(PermissionCheckedMixin, View):
         return reverse(self.delete_url_name, args=(self.instance.id,))
 
     def get(self, request, instance_id):
-        self.instance = get_object_or_404(self.model, id=instance_id)
+        self.instance = get_object_or_404(self.get_queryset(), id=instance_id)
 
         context = {
             'view': self,
@@ -169,7 +175,7 @@ class DeleteView(PermissionCheckedMixin, View):
         return render(request, self.template_name, context)
 
     def post(self, request, instance_id):
-        self.instance = get_object_or_404(self.model, id=instance_id)
+        self.instance = get_object_or_404(self.get_queryset(), id=instance_id)
         self.instance.delete()
         messages.success(request, self.success_message.format(self.instance))
         return redirect(self.index_url_name)

--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -43,4 +43,4 @@ class CollectionsMenuItem(MenuItem):
 
 @hooks.register('register_settings_menu_item')
 def register_collections_menu_item():
-    return CollectionsMenuItem(_('Collections'), urlresolvers.reverse('wagtailadmin_collections:index'), classnames='icon icon-collection', order=700)
+    return CollectionsMenuItem(_('Collections'), urlresolvers.reverse('wagtailadmin_collections:index'), classnames='icon icon-folder-open-1', order=700)

--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -30,3 +30,17 @@ def register_settings_menu():
 @hooks.register('register_permissions')
 def register_permissions():
     return Permission.objects.filter(content_type__app_label='wagtailadmin', codename='access_admin')
+
+
+class CollectionsMenuItem(MenuItem):
+    def is_shown(self, request):
+        return (
+            request.user.has_perm('wagtailcore.add_collection')
+            or request.user.has_perm('wagtailcore.change_collection')
+            or request.user.has_perm('wagtailcore.delete_collection')
+        )
+
+
+@hooks.register('register_settings_menu_item')
+def register_collections_menu_item():
+    return CollectionsMenuItem(_('Collections'), urlresolvers.reverse('wagtailadmin_collections:index'), classnames='icon icon-collection', order=700)

--- a/wagtail/wagtailadmin/widgets.py
+++ b/wagtail/wagtailadmin/widgets.py
@@ -69,6 +69,10 @@ class AdminChooser(WidgetWithScript, widgets.Input):
     link_to_chosen_text = _("Edit this item")
     show_edit_link = True
 
+    # when looping over form fields, this one should appear in visible_fields, not hidden_fields
+    # despite the underlying input being type="hidden"
+    is_hidden = False
+
     def get_instance(self, model_class, value):
         # helper method for cleanly turning 'value' into an instance object
         if value is None:

--- a/wagtail/wagtailcore/migrations/0020_collection.py
+++ b/wagtail/wagtailcore/migrations/0020_collection.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0019_verbose_names_cleanup'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Collection',
+            fields=[
+                ('id', models.AutoField(auto_created=True, verbose_name='ID', primary_key=True, serialize=False)),
+                ('path', models.CharField(max_length=255, unique=True)),
+                ('depth', models.PositiveIntegerField()),
+                ('numchild', models.PositiveIntegerField(default=0)),
+                ('name', models.CharField(max_length=255, verbose_name='Name')),
+            ],
+            options={
+                'verbose_name': 'collection',
+                'verbose_name_plural': 'collections',
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/wagtail/wagtailcore/migrations/0021_collection_initial_data.py
+++ b/wagtail/wagtailcore/migrations/0021_collection_initial_data.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django import VERSION as DJANGO_VERSION
+from django.db import migrations
+
+
+def initial_data(apps, schema_editor):
+    Collection = apps.get_model('wagtailcore.Collection')
+
+    # Create root page
+    Collection.objects.create(
+        name="Root",
+        path='0001',
+        depth=1,
+        numchild=0,
+    )
+
+
+def noop(apps, schema_editor):
+    # no action required to reverse initial_data
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0020_collection'),
+    ]
+
+    operations = [
+        migrations.RunPython(initial_data, noop),
+    ]

--- a/wagtail/wagtailcore/migrations/0021_collection_initial_data.py
+++ b/wagtail/wagtailcore/migrations/0021_collection_initial_data.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django import VERSION as DJANGO_VERSION
 from django.db import migrations
 
 

--- a/wagtail/wagtailcore/migrations/0022_group_collection_permission.py
+++ b/wagtail/wagtailcore/migrations/0022_group_collection_permission.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0001_initial'),
+        ('wagtailcore', '0021_collection_initial_data'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='GroupCollectionPermission',
+            fields=[
+                ('id', models.AutoField(serialize=False, primary_key=True, auto_created=True, verbose_name='ID')),
+                ('collection', models.ForeignKey(related_name='group_permissions', verbose_name='collection', to='wagtailcore.Collection')),
+                ('group', models.ForeignKey(related_name='collection_permissions', verbose_name='group', to='auth.Group')),
+                ('permission', models.ForeignKey(to='auth.Permission', verbose_name='permission')),
+            ],
+            options={
+                'verbose_name': 'group collection permission',
+            },
+            bases=(models.Model,),
+        ),
+        migrations.AlterUniqueTogether(
+            name='groupcollectionpermission',
+            unique_together=set([('group', 'collection', 'permission')]),
+        ),
+    ]

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -171,28 +171,7 @@ def get_page_types():
     return _PAGE_CONTENT_TYPES
 
 
-class PageManager(models.Manager):
-    def get_queryset(self):
-        return PageQuerySet(self.model).order_by('path')
-
-    def live(self):
-        return self.get_queryset().live()
-
-    def not_live(self):
-        return self.get_queryset().not_live()
-
-    def in_menu(self):
-        return self.get_queryset().in_menu()
-
-    def not_in_menu(self):
-        return self.get_queryset().not_in_menu()
-
-    def page(self, other):
-        return self.get_queryset().page(other)
-
-    def not_page(self, other):
-        return self.get_queryset().not_page(other)
-
+class TreeManagerMixin():
     def descendant_of(self, other, inclusive=False):
         return self.get_queryset().descendant_of(other, inclusive)
 
@@ -222,6 +201,29 @@ class PageManager(models.Manager):
 
     def not_sibling_of(self, other, inclusive=False):
         return self.get_queryset().not_sibling_of(other, inclusive)
+
+
+class PageManager(TreeManagerMixin, models.Manager):
+    def get_queryset(self):
+        return PageQuerySet(self.model).order_by('path')
+
+    def live(self):
+        return self.get_queryset().live()
+
+    def not_live(self):
+        return self.get_queryset().not_live()
+
+    def in_menu(self):
+        return self.get_queryset().in_menu()
+
+    def not_in_menu(self):
+        return self.get_queryset().not_in_menu()
+
+    def page(self, other):
+        return self.get_queryset().page(other)
+
+    def not_page(self, other):
+        return self.get_queryset().not_page(other)
 
     def type(self, model):
         return self.get_queryset().type(model)

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -17,7 +17,7 @@ from django.core.handlers.wsgi import WSGIRequest
 from django.core.handlers.base import BaseHandler
 from django.core.urlresolvers import reverse
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission
 from django.conf import settings
 from django.template.response import TemplateResponse
 from django.utils import timezone
@@ -1511,3 +1511,17 @@ class CollectionMember(models.Model):
 
     class Meta:
         abstract = True
+
+
+class GroupCollectionPermission(models.Model):
+    """
+    A rule indicating that a group has permission for some action (e.g. "create document")
+    within a specified collection.
+    """
+    group = models.ForeignKey(Group, verbose_name=_('group'), related_name='collection_permissions')
+    collection = models.ForeignKey(Collection, verbose_name=_('collection'), related_name='group_permissions')
+    permission = models.ForeignKey(Permission, verbose_name=_('permission'))
+
+    class Meta:
+        unique_together = ('group', 'collection', 'permission')
+        verbose_name = _('group collection permission')

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1482,3 +1482,18 @@ class PageViewRestriction(models.Model):
     class Meta:
         verbose_name = _('page view restriction')
         verbose_name_plural = _('page view restrictions')
+
+
+@python_2_unicode_compatible
+class Collection(MP_Node):
+    """
+    A location in which resources such as images and documents can be grouped
+    """
+    name = models.CharField(max_length=255, verbose_name=_('Name'))
+
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        verbose_name = _('collection')
+        verbose_name_plural = _('collections')

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1533,6 +1533,10 @@ class CollectionMember(models.Model):
     """
     collection = models.ForeignKey(Collection, default=get_root_collection_id, verbose_name=_('collection'), related_name='+')
 
+    search_fields = (
+        index.FilterField('collection_id'),
+    )
+
     class Meta:
         abstract = True
 

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1497,3 +1497,17 @@ class Collection(MP_Node):
     class Meta:
         verbose_name = _('collection')
         verbose_name_plural = _('collections')
+
+
+def get_root_collection_id():
+    return Collection.get_first_root_node().id
+
+
+class CollectionMember(models.Model):
+    """
+    Base class for models that are categorised into collections
+    """
+    collection = models.ForeignKey(Collection, default=get_root_collection_id, verbose_name=_('collection'), related_name='+')
+
+    class Meta:
+        abstract = True

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1534,7 +1534,7 @@ class CollectionMember(models.Model):
     collection = models.ForeignKey(Collection, default=get_root_collection_id, verbose_name=_('collection'), related_name='+')
 
     search_fields = (
-        index.FilterField('collection_id'),
+        index.FilterField('collection'),
     )
 
     class Meta:

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -171,7 +171,7 @@ def get_page_types():
     return _PAGE_CONTENT_TYPES
 
 
-class TreeManagerMixin():
+class TreeManagerMixin(object):
     def descendant_of(self, other, inclusive=False):
         return self.get_queryset().descendant_of(other, inclusive)
 

--- a/wagtail/wagtailcore/query.py
+++ b/wagtail/wagtailcore/query.py
@@ -10,48 +10,10 @@ from treebeard.mp_tree import MP_NodeQuerySet
 from wagtail.wagtailsearch.backends import get_search_backend
 
 
-class PageQuerySet(MP_NodeQuerySet):
-    def live_q(self):
-        return Q(live=True)
-
-    def live(self):
-        """
-        This filters the QuerySet to only contain published pages.
-        """
-        return self.filter(self.live_q())
-
-    def not_live(self):
-        """
-        This filters the QuerySet to only contain unpublished pages.
-        """
-        return self.exclude(self.live_q())
-
-    def in_menu_q(self):
-        return Q(show_in_menus=True)
-
-    def in_menu(self):
-        """
-        This filters the QuerySet to only contain pages that are in the menus.
-        """
-        return self.filter(self.in_menu_q())
-
-    def not_in_menu(self):
-        return self.exclude(self.in_menu_q())
-
-    def page_q(self, other):
-        return Q(id=other.id)
-
-    def page(self, other):
-        """
-        This filters the QuerySet so it only contains the specified page.
-        """
-        return self.filter(self.page_q(other))
-
-    def not_page(self, other):
-        """
-        This filters the QuerySet so it doesn't contain the specified page.
-        """
-        return self.exclude(self.page_q(other))
+class TreeQuerySet(MP_NodeQuerySet):
+    """
+    Extends Treebeard's MP_NodeQuerySet with additional useful tree-related operations.
+    """
 
     def descendant_of_q(self, other, inclusive=False):
         q = Q(path__startswith=other.path) & Q(depth__gte=other.depth)
@@ -156,6 +118,50 @@ class PageQuerySet(MP_NodeQuerySet):
         If inclusive is set to False, the page will be included the results.
         """
         return self.exclude(self.sibling_of_q(other, inclusive))
+
+
+class PageQuerySet(TreeQuerySet):
+    def live_q(self):
+        return Q(live=True)
+
+    def live(self):
+        """
+        This filters the QuerySet to only contain published pages.
+        """
+        return self.filter(self.live_q())
+
+    def not_live(self):
+        """
+        This filters the QuerySet to only contain unpublished pages.
+        """
+        return self.exclude(self.live_q())
+
+    def in_menu_q(self):
+        return Q(show_in_menus=True)
+
+    def in_menu(self):
+        """
+        This filters the QuerySet to only contain pages that are in the menus.
+        """
+        return self.filter(self.in_menu_q())
+
+    def not_in_menu(self):
+        return self.exclude(self.in_menu_q())
+
+    def page_q(self, other):
+        return Q(id=other.id)
+
+    def page(self, other):
+        """
+        This filters the QuerySet so it only contains the specified page.
+        """
+        return self.filter(self.page_q(other))
+
+    def not_page(self, other):
+        """
+        This filters the QuerySet so it doesn't contain the specified page.
+        """
+        return self.exclude(self.page_q(other))
 
     def type_q(self, klass):
         content_types = ContentType.objects.get_for_models(*[

--- a/wagtail/wagtaildocs/forms.py
+++ b/wagtail/wagtaildocs/forms.py
@@ -1,14 +1,26 @@
 from django import forms
 
+from wagtail.wagtailcore.models import Collection
 from wagtail.wagtaildocs.models import Document
+from wagtail.wagtaildocs.permissions import is_using_collections, collections_with_add_permission_for_user
 
 
 class DocumentForm(forms.ModelForm):
     required_css_class = "required"
 
+    def __init__(self, *args, **kwargs):
+        user = kwargs.pop('user', None)
+
+        super(DocumentForm, self).__init__(*args, **kwargs)
+        if is_using_collections and user is not None:
+            self.fields['collection'].queryset = collections_with_add_permission_for_user(user)
+
     class Meta:
         model = Document
-        fields = ('title', 'file', 'tags')
+        if is_using_collections:
+            fields = ('title', 'file', 'collection', 'tags')
+        else:
+            fields = ('title', 'file', 'tags')
         widgets = {
             'file': forms.FileInput()
         }

--- a/wagtail/wagtaildocs/forms.py
+++ b/wagtail/wagtaildocs/forms.py
@@ -2,7 +2,8 @@ from django import forms
 
 from wagtail.wagtailcore.models import Collection
 from wagtail.wagtaildocs.models import Document
-from wagtail.wagtaildocs.permissions import is_using_collections, collections_with_add_permission_for_user
+from wagtail.wagtaildocs.permissions import \
+    is_using_collections, collections_with_add_permission_for_user, target_collections_for_move
 
 
 class DocumentForm(forms.ModelForm):
@@ -16,7 +17,11 @@ class DocumentForm(forms.ModelForm):
         if is_using_collections:
             if user is None:
                 self.collections = Collection.objects.all()
+            elif self.instance and self.instance.collection:
+                # editing an existing document
+                self.collections = target_collections_for_move(user, self.instance)
             else:
+                # adding a new document
                 self.collections = collections_with_add_permission_for_user(user)
 
             if len(self.collections) == 0:

--- a/wagtail/wagtaildocs/forms.py
+++ b/wagtail/wagtaildocs/forms.py
@@ -17,7 +17,7 @@ class DocumentForm(forms.ModelForm):
         if is_using_collections:
             if user is None:
                 self.collections = Collection.objects.all()
-            elif self.instance and self.instance.collection:
+            elif self.instance and self.instance.id:
                 # editing an existing document
                 self.collections = target_collections_for_move(user, self.instance)
             else:

--- a/wagtail/wagtaildocs/migrations/0004_document_collection.py
+++ b/wagtail/wagtaildocs/migrations/0004_document_collection.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import wagtail.wagtailcore.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0021_collection_initial_data'),
+        ('wagtaildocs', '0003_add_verbose_names'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='document',
+            name='collection',
+            field=models.ForeignKey(related_name='+', to='wagtailcore.Collection', verbose_name='collection', default=wagtail.wagtailcore.models.get_root_collection_id),
+            preserve_default=True,
+        ),
+    ]

--- a/wagtail/wagtaildocs/migrations/0005_copy_document_permissions_to_collections.py
+++ b/wagtail/wagtaildocs/migrations/0005_copy_document_permissions_to_collections.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django import VERSION as DJANGO_VERSION
-from django.db import models, migrations
+from django.db import migrations
 
 
 def get_document_permissions(apps):

--- a/wagtail/wagtaildocs/migrations/0005_copy_document_permissions_to_collections.py
+++ b/wagtail/wagtaildocs/migrations/0005_copy_document_permissions_to_collections.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django import VERSION as DJANGO_VERSION
+from django.db import models, migrations
+
+
+def get_document_permissions(apps):
+    # return a queryset of the 'add_document' and 'change_document' permissions
+    Permission = apps.get_model('auth.Permission')
+    ContentType = apps.get_model('contenttypes.ContentType')
+
+    document_content_type, _created = ContentType.objects.get_or_create(
+        model='document',
+        app_label='wagtaildocs',
+        defaults={'name': 'document'} if DJANGO_VERSION < (1, 8) else {}
+    )
+    return Permission.objects.filter(content_type=document_content_type, codename__in=['add_document', 'change_document'])
+
+
+def copy_document_permissions_to_collections(apps, schema_editor):
+    Collection = apps.get_model('wagtailcore.Collection')
+    Group = apps.get_model('auth.Group')
+    GroupCollectionPermission = apps.get_model('wagtailcore.GroupCollectionPermission')
+
+    root_collection = Collection.objects.get(depth=1)
+
+    for permission in get_document_permissions(apps):
+        for group in Group.objects.filter(permissions=permission):
+            GroupCollectionPermission.objects.create(
+                group=group,
+                collection=root_collection,
+                permission=permission
+            )
+
+
+def remove_document_permissions_from_collections(apps, schema_editor):
+    GroupCollectionPermission = apps.get_model('wagtailcore.GroupCollectionPermission')
+    document_permissions = get_document_permissions(apps)
+
+    GroupCollectionPermission.objects.filter(permission__in=document_permissions).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0022_group_collection_permission'),
+        ('wagtaildocs', '0004_document_collection'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            copy_document_permissions_to_collections,
+            remove_document_permissions_from_collections),
+    ]

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -28,7 +28,7 @@ class Document(CollectionMember, TagSearchable):
 
     tags = TaggableManager(help_text=None, blank=True, verbose_name=_('Tags'))
 
-    search_fields = TagSearchable.search_fields + (
+    search_fields = TagSearchable.search_fields + CollectionMember.search_fields + (
         index.FilterField('uploaded_by_user'),
     )
 

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -15,11 +15,12 @@ from django.utils.encoding import python_2_unicode_compatible
 
 from wagtail.wagtailadmin.taggable import TagSearchable
 from wagtail.wagtailadmin.utils import get_object_usage
+from wagtail.wagtailcore.models import CollectionMember
 from wagtail.wagtailsearch import index
 
 
 @python_2_unicode_compatible
-class Document(models.Model, TagSearchable):
+class Document(CollectionMember, TagSearchable):
     title = models.CharField(max_length=255, verbose_name=_('Title'))
     file = models.FileField(upload_to='documents', verbose_name=_('File'))
     created_at = models.DateTimeField(verbose_name=_('Created at'), auto_now_add=True)

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -60,14 +60,8 @@ class Document(CollectionMember, TagSearchable):
                        args=(self.id,))
 
     def is_editable_by_user(self, user):
-        if user.has_perm('wagtaildocs.change_document'):
-            # user has global permission to change documents
-            return True
-        elif user.has_perm('wagtaildocs.add_document') and self.uploaded_by_user == user:
-            # user has document add permission, which also implicitly provides permission to edit their own documents
-            return True
-        else:
-            return False
+        from wagtail.wagtaildocs.permissions import user_can_edit_document
+        return user_can_edit_document(user, self)
 
     class Meta:
         verbose_name = _('Document')

--- a/wagtail/wagtaildocs/permissions.py
+++ b/wagtail/wagtaildocs/permissions.py
@@ -148,7 +148,9 @@ def documents_editable_by_user(user):
     """
     Return a queryset of documents editable by the given user
     """
+    collections_with_change_permission = collections_with_permission_for_user(user, 'wagtaildocs.change_document').values_list('id', flat=True)
+    collections_with_add_permission = collections_with_permission_for_user(user, 'wagtaildocs.add_document').values_list('id', flat=True)
     return Document.objects.filter(
-        Q(collection__in=collections_with_permission_for_user(user, 'wagtaildocs.change_document'))
-        | Q(collection__in=collections_with_permission_for_user(user, 'wagtaildocs.add_document'), uploaded_by_user=user)
+        Q(collection_id__in=list(collections_with_change_permission))
+        | Q(collection_id__in=list(collections_with_add_permission), uploaded_by_user=user)
     )

--- a/wagtail/wagtaildocs/permissions.py
+++ b/wagtail/wagtaildocs/permissions.py
@@ -151,6 +151,6 @@ def documents_editable_by_user(user):
     collections_with_change_permission = collections_with_permission_for_user(user, 'wagtaildocs.change_document').values_list('id', flat=True)
     collections_with_add_permission = collections_with_permission_for_user(user, 'wagtaildocs.add_document').values_list('id', flat=True)
     return Document.objects.filter(
-        Q(collection_id__in=list(collections_with_change_permission))
-        | Q(collection_id__in=list(collections_with_add_permission), uploaded_by_user=user)
+        Q(collection__in=list(collections_with_change_permission))
+        | Q(collection__in=list(collections_with_add_permission), uploaded_by_user=user)
     )

--- a/wagtail/wagtaildocs/permissions.py
+++ b/wagtail/wagtaildocs/permissions.py
@@ -1,0 +1,92 @@
+# Helper functions for permission handling.
+# These check either Django's auth framework, or wagtailcore.GroupCollectionPermission
+# depending on whether the Document model is configured to use collections.
+
+from wagtail.wagtailadmin.utils import user_passes_test
+from wagtail.wagtailcore.models import CollectionMember, GroupCollectionPermission
+from wagtail.wagtaildocs.models import Document
+
+is_using_collections = issubclass(Document, CollectionMember)
+
+
+def user_has_any_document_permission(user):
+    """
+    Return true iff user has any document-related permission anywhere in the collections tree.
+    """
+    if is_using_collections:
+        if user.is_superuser:
+            return True
+        else:
+            return GroupCollectionPermission.objects.filter(
+                permission__content_type__app_label='wagtaildocs',
+                permission__codename__in=['add_document', 'change_document'],
+                group__in=user.groups.all()
+            ).exists()
+    else:
+        return user.has_perm('wagtaildocs.add_document') or user.has_perm('wagtaildocs.change_document')
+
+
+def any_document_permission_required():
+    """
+    View decorator - the user may only proceed if they have any document-related permission.
+    """
+    return user_passes_test(user_has_any_document_permission)
+
+
+def user_has_document_permission(user, permission_name):
+    """
+    Return true iff user has the specified document permission anywhere in the collections tree.
+    """
+    if is_using_collections:
+        if user.is_superuser:
+            return True
+        else:
+            app_label, codename = permission_name.split('.')
+            return GroupCollectionPermission.objects.filter(
+                permission__content_type__app_label=app_label,
+                permission__codename=codename,
+                group__in=user.groups.all()
+            ).exists()
+    else:
+        return user.has_perm(permission_name)
+
+
+def document_permission_required(permission_name):
+    """
+    View decorator - the user may only proceed if they have the specified
+    document-related permission anywhere in the collections tree.
+    """
+    def test(user):
+        return user_has_document_permission(user, permission_name)
+
+    return user_passes_test(test)
+
+
+def user_has_permission_on_document(user, permission_name, document):
+    """
+    Return true iff user has the specified permission on the given document.
+    """
+    if is_using_collections:
+        if user.is_superuser:
+            return True
+        else:
+            app_label, codename = permission_name.split('.')
+            return GroupCollectionPermission.objects.filter(
+                permission__content_type__app_label=app_label,
+                permission__codename=codename,
+                group__in=user.groups.all(),
+                collection__in=document.collection.get_ancestors(inclusive=True),
+            ).exists()
+    else:
+        return user.has_perm(permission_name)
+
+
+def user_can_edit_document(user, document):
+    if user_has_permission_on_document(user, 'wagtaildocs.change_document', document):
+        # user has global permission to change documents
+        return True
+    elif user_has_permission_on_document(user, 'wagtaildocs.add_document', document) and document.uploaded_by_user == user:
+        # user has document add permission, which also implicitly provides permission to edit their own documents
+        return True
+    else:
+        return False

--- a/wagtail/wagtaildocs/permissions.py
+++ b/wagtail/wagtaildocs/permissions.py
@@ -128,6 +128,22 @@ def collections_with_add_permission_for_user(user):
     return collections_with_permission_for_user(user, 'wagtaildocs.add_document')
 
 
+def target_collections_for_move(user, document):
+    """
+    Return a queryset of collections that this user can move the specified document to.
+    (It is assumed that the user has edit permission for the document)
+    """
+    if is_using_collections:
+        if user.is_superuser:
+            return Collection.objects.all()
+        else:
+            # user can leave it in its current collection, or move it to one where they
+            # have 'add' permission
+            return collections_with_add_permission_for_user(user) | Collection.objects.filter(id=document.collection_id)
+    else:
+        return Collection.objects.none()
+
+
 def documents_editable_by_user(user):
     """
     Return a queryset of documents editable by the given user

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/index.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/index.html
@@ -14,7 +14,7 @@
 {% block content %}
     {% trans "Documents" as doc_str %}
 
-    {% if perms.wagtaildocs.add_document %}
+    {% if can_add_document %}
         {% trans "Add a document" as add_doc_str %}
         {% include "wagtailadmin/shared/header.html" with title=doc_str add_link="wagtaildocs:add" icon="doc-full-inverse" add_text=add_doc_str search_url="wagtaildocs:index" %}
     {% else %}

--- a/wagtail/wagtaildocs/views/chooser.py
+++ b/wagtail/wagtaildocs/views/chooser.py
@@ -6,11 +6,11 @@ from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 from wagtail.wagtailadmin.forms import SearchForm
-from wagtail.wagtailadmin.utils import permission_required
 from wagtail.wagtailsearch.backends import get_search_backends
 
 from wagtail.wagtaildocs.models import Document
 from wagtail.wagtaildocs.forms import DocumentForm
+from wagtail.wagtaildocs.permissions import document_permission_required, user_has_document_permission
 
 
 def get_document_json(document):
@@ -27,8 +27,8 @@ def get_document_json(document):
 
 
 def chooser(request):
-    if request.user.has_perm('wagtaildocs.add_document'):
-        uploadform = DocumentForm()
+    if user_has_document_permission(request.user, 'wagtaildocs.add_document'):
+        uploadform = DocumentForm(user=request.user)
     else:
         uploadform = None
 
@@ -99,11 +99,11 @@ def document_chosen(request, document_id):
     )
 
 
-@permission_required('wagtaildocs.add_document')
+@document_permission_required('wagtaildocs.add_document')
 def chooser_upload(request):
     if request.POST:
         document = Document(uploaded_by_user=request.user)
-        form = DocumentForm(request.POST, request.FILES, instance=document)
+        form = DocumentForm(request.POST, request.FILES, instance=document, user=request.user)
 
         if form.is_valid():
             form.save()
@@ -117,7 +117,7 @@ def chooser_upload(request):
                 {'document_json': get_document_json(document)}
             )
     else:
-        form = DocumentForm()
+        form = DocumentForm(user=request.user)
 
     documents = Document.objects.order_by('title')
 

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -6,15 +6,15 @@ from django.views.decorators.vary import vary_on_headers
 from django.core.urlresolvers import reverse
 
 from wagtail.wagtailadmin.forms import SearchForm
-from wagtail.wagtailadmin.utils import permission_required, any_permission_required
 from wagtail.wagtailsearch.backends import get_search_backends
 from wagtail.wagtailadmin import messages
 
 from wagtail.wagtaildocs.models import Document
+from wagtail.wagtaildocs.permissions import document_permission_required, any_document_permission_required, user_can_edit_document
 from wagtail.wagtaildocs.forms import DocumentForm
 
 
-@any_permission_required('wagtaildocs.add_document', 'wagtaildocs.change_document')
+@any_document_permission_required()
 @vary_on_headers('X-Requested-With')
 def index(request):
     # Get documents
@@ -77,7 +77,7 @@ def index(request):
         })
 
 
-@permission_required('wagtaildocs.add_document')
+@document_permission_required('wagtaildocs.add_document')
 def add(request):
     if request.POST:
         doc = Document(uploaded_by_user=request.user)
@@ -106,7 +106,7 @@ def add(request):
 def edit(request, document_id):
     doc = get_object_or_404(Document, id=document_id)
 
-    if not doc.is_editable_by_user(request.user):
+    if not user_can_edit_document(request.user, doc):
         raise PermissionDenied
 
     if request.POST:
@@ -158,7 +158,7 @@ def edit(request, document_id):
 def delete(request, document_id):
     doc = get_object_or_404(Document, id=document_id)
 
-    if not doc.is_editable_by_user(request.user):
+    if not user_can_edit_document(request.user, doc):
         raise PermissionDenied
 
     if request.POST:

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -6,7 +6,7 @@ from django.views.decorators.vary import vary_on_headers
 from django.core.urlresolvers import reverse
 
 from wagtail.wagtailadmin.forms import SearchForm
-from wagtail.wagtailsearch.backends import get_search_backends
+from wagtail.wagtailsearch.backends import get_search_backend, get_search_backends
 from wagtail.wagtailadmin import messages
 
 from wagtail.wagtaildocs.models import Document
@@ -32,8 +32,9 @@ def index(request):
     if 'q' in request.GET:
         form = SearchForm(request.GET, placeholder=_("Search documents"))
         if form.is_valid():
+            s = get_search_backend()
             query_string = form.cleaned_data['q']
-            documents = documents.search(query_string)
+            documents = s.search(query_string, documents)
     else:
         form = SearchForm(placeholder=_("Search documents"))
 

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -81,7 +81,7 @@ def index(request):
 def add(request):
     if request.POST:
         doc = Document(uploaded_by_user=request.user)
-        form = DocumentForm(request.POST, request.FILES, instance=doc)
+        form = DocumentForm(request.POST, request.FILES, instance=doc, user=request.user)
         if form.is_valid():
             form.save()
 
@@ -96,7 +96,7 @@ def add(request):
         else:
             messages.error(request, _("The document could not be saved due to errors."))
     else:
-        form = DocumentForm()
+        form = DocumentForm(user=request.user)
 
     return render(request, "wagtaildocs/documents/add.html", {
         'form': form,
@@ -111,7 +111,7 @@ def edit(request, document_id):
 
     if request.POST:
         original_file = doc.file
-        form = DocumentForm(request.POST, request.FILES, instance=doc)
+        form = DocumentForm(request.POST, request.FILES, instance=doc, user=request.user)
         if form.is_valid():
             if 'file' in form.changed_data:
                 # if providing a new document file, delete the old one.
@@ -131,7 +131,7 @@ def edit(request, document_id):
         else:
             messages.error(request, _("The document could not be saved due to errors."))
     else:
-        form = DocumentForm(instance=doc)
+        form = DocumentForm(instance=doc, user=request.user)
 
     filesize = None
 

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -10,7 +10,7 @@ from wagtail.wagtailsearch.backends import get_search_backends
 from wagtail.wagtailadmin import messages
 
 from wagtail.wagtaildocs.models import Document
-from wagtail.wagtaildocs.permissions import document_permission_required, any_document_permission_required, user_can_edit_document
+from wagtail.wagtaildocs.permissions import document_permission_required, any_document_permission_required, user_can_edit_document, user_has_document_permission
 from wagtail.wagtaildocs.forms import DocumentForm
 
 
@@ -72,6 +72,7 @@ def index(request):
             'query_string': query_string,
             'is_searching': bool(query_string),
 
+            'can_add_document': user_has_document_permission(request.user, 'wagtaildocs.add_document'),
             'search_form': form,
             'popular_tags': Document.popular_tags(),
         })

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -10,7 +10,7 @@ from wagtail.wagtailsearch.backends import get_search_backends
 from wagtail.wagtailadmin import messages
 
 from wagtail.wagtaildocs.models import Document
-from wagtail.wagtaildocs.permissions import document_permission_required, any_document_permission_required, user_can_edit_document, user_has_document_permission
+from wagtail.wagtaildocs.permissions import document_permission_required, any_document_permission_required, user_can_edit_document, user_has_document_permission, documents_editable_by_user
 from wagtail.wagtaildocs.forms import DocumentForm
 
 
@@ -18,7 +18,7 @@ from wagtail.wagtaildocs.forms import DocumentForm
 @vary_on_headers('X-Requested-With')
 def index(request):
     # Get documents
-    documents = Document.objects.all()
+    documents = documents_editable_by_user(request.user)
 
     # Ordering
     if 'ordering' in request.GET and request.GET['ordering'] in ['title', '-created_at']:
@@ -27,22 +27,13 @@ def index(request):
         ordering = '-created_at'
     documents = documents.order_by(ordering)
 
-    # Permissions
-    if not request.user.has_perm('wagtaildocs.change_document'):
-        # restrict to the user's own documents
-        documents = documents.filter(uploaded_by_user=request.user)
-
     # Search
     query_string = None
     if 'q' in request.GET:
         form = SearchForm(request.GET, placeholder=_("Search documents"))
         if form.is_valid():
             query_string = form.cleaned_data['q']
-            if not request.user.has_perm('wagtaildocs.change_document'):
-                # restrict to the user's own documents
-                documents = Document.search(query_string, filters={'uploaded_by_user_id': request.user.id})
-            else:
-                documents = Document.search(query_string)
+            documents = documents.search(query_string)
     else:
         form = SearchForm(placeholder=_("Search documents"))
 

--- a/wagtail/wagtaildocs/wagtail_hooks.py
+++ b/wagtail/wagtaildocs/wagtail_hooks.py
@@ -12,6 +12,7 @@ from wagtail.wagtailadmin.site_summary import SummaryItem
 
 from wagtail.wagtaildocs import admin_urls
 from wagtail.wagtaildocs.models import Document
+from wagtail.wagtaildocs.permissions import user_has_any_document_permission
 from wagtail.wagtaildocs.rich_text import DocumentLinkHandler
 
 
@@ -24,7 +25,7 @@ def register_admin_urls():
 
 class DocumentsMenuItem(MenuItem):
     def is_shown(self, request):
-        return request.user.has_perm('wagtaildocs.add_document') or request.user.has_perm('wagtaildocs.change_document')
+        return user_has_any_document_permission(request.user)
 
 
 @hooks.register('register_admin_menu_item')

--- a/wagtail/wagtaildocs/wagtail_hooks.py
+++ b/wagtail/wagtaildocs/wagtail_hooks.py
@@ -6,6 +6,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth.models import Permission
 
 from wagtail.wagtailcore import hooks
+from wagtail.wagtailcore.models import CollectionMember
 from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailadmin.site_summary import SummaryItem
 
@@ -51,10 +52,19 @@ def editor_js():
     )
 
 
-@hooks.register('register_permissions')
 def register_permissions():
     return Permission.objects.filter(content_type__app_label='wagtaildocs',
         codename__in=['add_document', 'change_document'])
+
+
+if issubclass(Document, CollectionMember):
+    # Register document permissions to appear within the 'Collection permissions' section
+    # of the group admin
+    hooks.register('register_collection_permissions', register_permissions)
+else:
+    # Register document permissions to appear within the main Permissions section
+    # of the group admin
+    hooks.register('register_permissions', register_permissions)
 
 
 @hooks.register('register_rich_text_link_handler')

--- a/wagtail/wagtailimages/forms.py
+++ b/wagtail/wagtailimages/forms.py
@@ -4,9 +4,12 @@ from django import forms
 from django.forms.models import modelform_factory
 from django.utils.translation import ugettext as _
 
+from wagtail.wagtailcore.models import Collection
 from wagtail.utils.deprecation import RemovedInWagtail12Warning
 from wagtail.wagtailimages.formats import get_image_formats
 from wagtail.wagtailimages.fields import WagtailImageField
+from wagtail.wagtailimages.permissions import \
+    is_using_collections, collections_with_add_permission_for_user, target_collections_for_move
 
 
 # Callback to allow us to override the default form field for the image file field
@@ -19,9 +22,50 @@ def formfield_for_dbfield(db_field, **kwargs):
     return db_field.formfield(**kwargs)
 
 
+class BaseImageForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        user = kwargs.pop('user', None)
+
+        super(BaseImageForm, self).__init__(*args, **kwargs)
+
+        if 'collection' in self.fields:
+            if is_using_collections:
+                if user is None:
+                    self.collections = Collection.objects.all()
+                elif self.instance and self.instance.id:
+                    # editing an existing image
+                    self.collections = target_collections_for_move(user, self.instance)
+                else:
+                    # adding a new image
+                    self.collections = collections_with_add_permission_for_user(user)
+
+                if len(self.collections) == 0:
+                    raise Exception("Cannot construct BaseImageForm for a user with no image collection permissions")
+                elif len(self.collections) == 1:
+                    # don't show collection field if only one collection is available
+                    del self.fields['collection']
+                else:
+                    self.fields['collection'].queryset = self.collections
+            else:
+                del self.fields['collection']
+
+    def save(self, commit=True):
+        if is_using_collections and len(self.collections) == 1:
+            # populate the instance's collection field with the one available collection
+            self.instance.collection = self.collections[0]
+
+        return super(BaseImageForm, self).save(commit=commit)
+
+
 def get_image_form(model):
     if hasattr(model, 'admin_form_fields'):
         fields = model.admin_form_fields
+        if is_using_collections and 'collection' not in fields:
+            # force addition of the 'collection' field, because leaving it out can
+            # cause dubious results when multiple collections exist (e.g adding the
+            # image to the root collection where the user may not have permission) -
+            # and when only one collection exists, it will get hidden anyway.
+            fields = list(fields) + ['collection']
     else:
         fields = '__all__'
 
@@ -33,6 +77,7 @@ def get_image_form(model):
 
     return modelform_factory(
         model,
+        form=BaseImageForm,
         fields=fields,
         formfield_callback=formfield_for_dbfield,
         # set the 'file' widget to a FileInput rather than the default ClearableFileInput

--- a/wagtail/wagtailimages/forms.py
+++ b/wagtail/wagtailimages/forms.py
@@ -4,12 +4,12 @@ from django import forms
 from django.forms.models import modelform_factory
 from django.utils.translation import ugettext as _
 
-from wagtail.wagtailcore.models import Collection
+from wagtail.wagtailcore.models import Collection, CollectionMember
 from wagtail.utils.deprecation import RemovedInWagtail12Warning
 from wagtail.wagtailimages.formats import get_image_formats
 from wagtail.wagtailimages.fields import WagtailImageField
 from wagtail.wagtailimages.permissions import \
-    is_using_collections, collections_with_add_permission_for_user, target_collections_for_move
+    collections_with_add_permission_for_user, target_collections_for_move
 
 
 # Callback to allow us to override the default form field for the image file field
@@ -28,8 +28,10 @@ class BaseImageForm(forms.ModelForm):
 
         super(BaseImageForm, self).__init__(*args, **kwargs)
 
+        self.is_using_collections = issubclass(self._meta.model, CollectionMember)
+
         if 'collection' in self.fields:
-            if is_using_collections:
+            if self.is_using_collections:
                 if user is None:
                     self.collections = Collection.objects.all()
                 elif self.instance and self.instance.id:
@@ -50,7 +52,7 @@ class BaseImageForm(forms.ModelForm):
                 del self.fields['collection']
 
     def save(self, commit=True):
-        if is_using_collections and len(self.collections) == 1:
+        if self.is_using_collections and len(self.collections) == 1:
             # populate the instance's collection field with the one available collection
             self.instance.collection = self.collections[0]
 
@@ -60,7 +62,7 @@ class BaseImageForm(forms.ModelForm):
 def get_image_form(model):
     if hasattr(model, 'admin_form_fields'):
         fields = model.admin_form_fields
-        if is_using_collections and 'collection' not in fields:
+        if issubclass(model, CollectionMember) and 'collection' not in fields:
             # force addition of the 'collection' field, because leaving it out can
             # cause dubious results when multiple collections exist (e.g adding the
             # image to the root collection where the user may not have permission) -

--- a/wagtail/wagtailimages/migrations/0009_image_collection.py
+++ b/wagtail/wagtailimages/migrations/0009_image_collection.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import wagtail.wagtailcore.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0022_group_collection_permission'),
+        ('wagtailimages', '0008_image_created_at_index'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='image',
+            name='collection',
+            field=models.ForeignKey(to='wagtailcore.Collection', verbose_name='collection', default=wagtail.wagtailcore.models.get_root_collection_id, related_name='+'),
+        ),
+    ]

--- a/wagtail/wagtailimages/migrations/0010_copy_image_permissions_to_collections.py
+++ b/wagtail/wagtailimages/migrations/0010_copy_image_permissions_to_collections.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django import VERSION as DJANGO_VERSION
+from django.db import models, migrations
+
+
+def get_image_permissions(apps):
+    # return a queryset of the 'add_image' and 'change_image' permissions
+    Permission = apps.get_model('auth.Permission')
+    ContentType = apps.get_model('contenttypes.ContentType')
+
+    image_content_type, _created = ContentType.objects.get_or_create(
+        model='image',
+        app_label='wagtailimages',
+        defaults={'name': 'image'} if DJANGO_VERSION < (1, 8) else {}
+    )
+    return Permission.objects.filter(content_type=image_content_type, codename__in=['add_image', 'change_image'])
+
+
+def copy_image_permissions_to_collections(apps, schema_editor):
+    Collection = apps.get_model('wagtailcore.Collection')
+    Group = apps.get_model('auth.Group')
+    GroupCollectionPermission = apps.get_model('wagtailcore.GroupCollectionPermission')
+
+    root_collection = Collection.objects.get(depth=1)
+
+    for permission in get_image_permissions(apps):
+        for group in Group.objects.filter(permissions=permission):
+            GroupCollectionPermission.objects.create(
+                group=group,
+                collection=root_collection,
+                permission=permission
+            )
+
+
+def remove_image_permissions_from_collections(apps, schema_editor):
+    GroupCollectionPermission = apps.get_model('wagtailcore.GroupCollectionPermission')
+    image_permissions = get_image_permissions(apps)
+
+    GroupCollectionPermission.objects.filter(permission__in=image_permissions).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0022_group_collection_permission'),
+        ('wagtailimages', '0009_image_collection'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            copy_image_permissions_to_collections,
+            remove_image_permissions_from_collections),
+    ]

--- a/wagtail/wagtailimages/migrations/0010_copy_image_permissions_to_collections.py
+++ b/wagtail/wagtailimages/migrations/0010_copy_image_permissions_to_collections.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django import VERSION as DJANGO_VERSION
-from django.db import models, migrations
+from django.db import migrations
 
 
 def get_image_permissions(apps):

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -26,6 +26,7 @@ from django.core.urlresolvers import reverse
 from unidecode import unidecode
 
 from wagtail.wagtailcore import hooks
+from wagtail.wagtailcore.models import CollectionMember
 from wagtail.wagtailadmin.taggable import TagSearchable
 from wagtail.wagtailsearch import index
 from wagtail.wagtailimages.rect import Rect
@@ -284,10 +285,13 @@ class AbstractImage(models.Model, TagSearchable):
         abstract = True
 
 
-class Image(AbstractImage):
+class Image(CollectionMember, AbstractImage):
+    search_fields = AbstractImage.search_fields + CollectionMember.search_fields
+
     admin_form_fields = (
         'title',
         'file',
+        # 'collection',
         'tags',
         'focal_point_x',
         'focal_point_y',

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -272,14 +272,8 @@ class AbstractImage(models.Model, TagSearchable):
         return self.title
 
     def is_editable_by_user(self, user):
-        if user.has_perm('wagtailimages.change_image'):
-            # user has global permission to change images
-            return True
-        elif user.has_perm('wagtailimages.add_image') and self.uploaded_by_user == user:
-            # user has image add permission, which also implicitly provides permission to edit their own images
-            return True
-        else:
-            return False
+        from wagtail.wagtailimages.permissions import user_can_edit_image
+        return user_can_edit_image(user, self)
 
     class Meta:
         abstract = True

--- a/wagtail/wagtailimages/permissions.py
+++ b/wagtail/wagtailimages/permissions.py
@@ -152,6 +152,6 @@ def images_editable_by_user(user):
     collections_with_change_permission = collections_with_permission_for_user(user, 'wagtailimages.change_image').values_list('id', flat=True)
     collections_with_add_permission = collections_with_permission_for_user(user, 'wagtailimages.add_image').values_list('id', flat=True)
     return Image.objects.filter(
-        Q(collection_id__in=list(collections_with_change_permission))
-        | Q(collection_id__in=list(collections_with_add_permission), uploaded_by_user=user)
+        Q(collection__in=list(collections_with_change_permission))
+        | Q(collection__in=list(collections_with_add_permission), uploaded_by_user=user)
     )

--- a/wagtail/wagtailimages/permissions.py
+++ b/wagtail/wagtailimages/permissions.py
@@ -1,0 +1,157 @@
+# Helper functions for permission handling.
+# These check either Django's auth framework, or wagtailcore.GroupCollectionPermission
+# depending on whether the image model is configured to use collections.
+
+from django.db.models import Q
+
+from wagtail.wagtailadmin.utils import user_passes_test
+from wagtail.wagtailcore.models import Collection, CollectionMember, GroupCollectionPermission
+from wagtail.wagtailimages.models import get_image_model
+
+Image = get_image_model()
+is_using_collections = issubclass(Image, CollectionMember)
+
+
+def user_has_any_image_permission(user):
+    """
+    Return true iff user has any image-related permission anywhere in the collections tree.
+    """
+    if is_using_collections:
+        if user.is_superuser:
+            return True
+        else:
+            return GroupCollectionPermission.objects.filter(
+                permission__content_type__app_label='wagtailimages',
+                permission__codename__in=['add_image', 'change_image'],
+                group__in=user.groups.all()
+            ).exists()
+    else:
+        return user.has_perm('wagtailimages.add_image') or user.has_perm('wagtailimages.change_image')
+
+
+def any_image_permission_required():
+    """
+    View decorator - the user may only proceed if they have any image-related permission.
+    """
+    return user_passes_test(user_has_any_image_permission)
+
+
+def user_has_image_permission(user, permission_name):
+    """
+    Return true iff user has the specified image permission anywhere in the collections tree.
+    """
+    if is_using_collections:
+        if user.is_superuser:
+            return True
+        else:
+            app_label, codename = permission_name.split('.')
+            return GroupCollectionPermission.objects.filter(
+                permission__content_type__app_label=app_label,
+                permission__codename=codename,
+                group__in=user.groups.all()
+            ).exists()
+    else:
+        return user.has_perm(permission_name)
+
+
+def image_permission_required(permission_name):
+    """
+    View decorator - the user may only proceed if they have the specified
+    image-related permission anywhere in the collections tree.
+    """
+    def test(user):
+        return user_has_image_permission(user, permission_name)
+
+    return user_passes_test(test)
+
+
+def user_has_permission_on_image(user, permission_name, image):
+    """
+    Return true iff user has the specified permission on the given image.
+    """
+    if is_using_collections:
+        if user.is_superuser:
+            return True
+        else:
+            app_label, codename = permission_name.split('.')
+            return GroupCollectionPermission.objects.filter(
+                permission__content_type__app_label=app_label,
+                permission__codename=codename,
+                group__in=user.groups.all(),
+                collection__in=image.collection.get_ancestors(inclusive=True),
+            ).exists()
+    else:
+        return user.has_perm(permission_name)
+
+
+def user_can_edit_image(user, image):
+    if user_has_permission_on_image(user, 'wagtailimages.change_image', image):
+        # user has permission to change image regardless of user
+        return True
+    elif user_has_permission_on_image(user, 'wagtailimages.add_image', image) and image.uploaded_by_user == user:
+        # user has image add permission, which also implicitly provides permission to edit their own images
+        return True
+    else:
+        return False
+
+
+def collections_with_permission_for_user(user, permission_name):
+    """
+    Return a queryset of collections that this user has the specified permission over,
+    taking permission propagation into child selections into account
+    """
+    if is_using_collections:
+        if user.is_superuser:
+            return Collection.objects.all()
+        else:
+            app_label, codename = permission_name.split('.')
+            base_paths = Collection.objects.filter(
+                group_permissions__group__in=user.groups.all(),
+                group_permissions__permission__content_type__app_label=app_label,
+                group_permissions__permission__codename=codename
+            ).values_list('path', flat=True)
+
+            if base_paths:
+                filters = Q(path__startswith=base_paths[0])
+                for path in base_paths[1:]:
+                    filters = filters | Q(path__startswith=path)
+                return Collection.objects.filter(filters)
+            else:
+                return Collection.objects.none()
+    else:
+        return Collection.objects.none()
+
+
+def collections_with_add_permission_for_user(user):
+    """
+    Return a queryset of collections that this user can add images to
+    """
+    return collections_with_permission_for_user(user, 'wagtailimages.add_image')
+
+
+def target_collections_for_move(user, image):
+    """
+    Return a queryset of collections that this user can move the specified image to.
+    (It is assumed that the user has edit permission for the image)
+    """
+    if is_using_collections:
+        if user.is_superuser:
+            return Collection.objects.all()
+        else:
+            # user can leave it in its current collection, or move it to one where they
+            # have 'add' permission
+            return collections_with_add_permission_for_user(user) | Collection.objects.filter(id=image.collection_id)
+    else:
+        return Collection.objects.none()
+
+
+def images_editable_by_user(user):
+    """
+    Return a queryset of images editable by the given user
+    """
+    collections_with_change_permission = collections_with_permission_for_user(user, 'wagtailimages.change_image').values_list('id', flat=True)
+    collections_with_add_permission = collections_with_permission_for_user(user, 'wagtailimages.add_image').values_list('id', flat=True)
+    return Image.objects.filter(
+        Q(collection_id__in=list(collections_with_change_permission))
+        | Q(collection_id__in=list(collections_with_add_permission), uploaded_by_user=user)
+    )

--- a/wagtail/wagtailimages/templates/wagtailimages/images/index.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/index.html
@@ -16,7 +16,7 @@
 {% block content %}
     {% trans "Images" as im_str %}
 
-    {% if perms.wagtailimages.add_image %}
+    {% if can_add_image %}
         {% trans "Add an image" as add_img_str %}
         {% include "wagtailadmin/shared/header.html" with title=im_str add_link="wagtailimages:add_multiple" icon="image" add_text=add_img_str search_url="wagtailimages:index" %}
     {% else %}

--- a/wagtail/wagtailimages/templates/wagtailimages/multiple/add.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/multiple/add.html
@@ -23,6 +23,18 @@
                     <input id="fileupload" type="file" name="files[]" data-url="{% url 'wagtailimages:add_multiple' %}" multiple>
                 </div>
                 {% csrf_token %}
+                {% if collections %}
+                    <div class="field">
+                        <label for="id_addimage_collection">Add to collection:</label>
+                        <div class="field-content">
+                            <select id="id_addimage_collection" name="collection">
+                                {% for collection in collections %}
+                                    <option value="{{ collection.id }}">{{ collection.name }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+                {% endif %}
             </form>
         </div>
 

--- a/wagtail/wagtailimages/tests/test_image_operations.py
+++ b/wagtail/wagtailimages/tests/test_image_operations.py
@@ -1,4 +1,4 @@
-import unittest
+from django.test import TestCase
 
 from wagtail.wagtailimages import image_operations
 from wagtail.wagtailimages.exceptions import InvalidFilterSpecError
@@ -33,7 +33,7 @@ class WillowOperationRecorder(object):
         return size
 
 
-class ImageOperationTestCase(unittest.TestCase):
+class ImageOperationTestCase(TestCase):
     operation_class = None
     filter_spec_tests = []
     filter_spec_error_tests = []
@@ -62,8 +62,10 @@ class ImageOperationTestCase(unittest.TestCase):
         return test_filter_spec_error
 
     @classmethod
-    def make_run_test(cls, filter_spec, image, expected_output):
+    def make_run_test(cls, filter_spec, image_kwargs, expected_output):
         def test_run(self):
+            image = Image(**image_kwargs)
+
             # Make operation
             operation = self.operation_class(*filter_spec.split('-'))
 
@@ -115,7 +117,7 @@ class TestDoNothingOperation(ImageOperationTestCase):
     ]
 
     run_tests = [
-        ('original', Image(width=1000, height=1000), []),
+        ('original', dict(width=1000, height=1000), []),
     ]
 
 TestDoNothingOperation.setup_test_methods()
@@ -146,26 +148,26 @@ class TestFillOperation(ImageOperationTestCase):
 
     run_tests = [
         # Basic usage
-        ('fill-800x600', Image(width=1000, height=1000), [
+        ('fill-800x600', dict(width=1000, height=1000), [
             ('crop', ((0, 125, 1000, 875), ), {}),
             ('resize', ((800, 600), ), {}),
         ]),
 
         # Basic usage with an oddly-sized original image
         # This checks for a rounding precision issue (#968)
-        ('fill-200x200', Image(width=539, height=720), [
+        ('fill-200x200', dict(width=539, height=720), [
             ('crop', ((0, 90, 539, 630), ), {}),
             ('resize', ((200, 200), ), {}),
         ]),
 
         # Closeness shouldn't have any effect when used without a focal point
-        ('fill-800x600-c100', Image(width=1000, height=1000), [
+        ('fill-800x600-c100', dict(width=1000, height=1000), [
             ('crop', ((0, 125, 1000, 875), ), {}),
             ('resize', ((800, 600), ), {}),
         ]),
 
         # Should always crop towards focal point. Even if no closeness is set
-        ('fill-80x60', Image(
+        ('fill-80x60', dict(
             width=1000,
             height=1000,
             focal_point_x=1000,
@@ -181,7 +183,7 @@ class TestFillOperation(ImageOperationTestCase):
         ]),
 
         # Should crop as close as possible without upscaling
-        ('fill-80x60-c100', Image(
+        ('fill-80x60-c100', dict(
             width=1000,
             height=1000,
             focal_point_x=1000,
@@ -197,7 +199,7 @@ class TestFillOperation(ImageOperationTestCase):
 
         # Ditto with a wide image
         # Using a different filter so method name doesn't clash
-        ('fill-100x60-c100', Image(
+        ('fill-100x60-c100', dict(
             width=2000,
             height=1000,
             focal_point_x=2000,
@@ -210,7 +212,7 @@ class TestFillOperation(ImageOperationTestCase):
         ]),
 
         # Make sure that the crop box never enters the focal point
-        ('fill-50x50-c100', Image(
+        ('fill-50x50-c100', dict(
             width=2000,
             height=1000,
             focal_point_x=1000,
@@ -226,12 +228,12 @@ class TestFillOperation(ImageOperationTestCase):
         ]),
 
         # Test that the image is never upscaled
-        ('fill-1000x800', Image(width=100, height=100), [
+        ('fill-1000x800', dict(width=100, height=100), [
             ('crop', ((0, 10, 100, 90), ), {}),
         ]),
 
         # Test that the crop closeness gets capped to prevent upscaling
-        ('fill-1000x800-c100', Image(
+        ('fill-1000x800-c100', dict(
             width=1500,
             height=1000,
             focal_point_x=750,
@@ -248,7 +250,7 @@ class TestFillOperation(ImageOperationTestCase):
         # Test for an issue where a ZeroDivisionError would occur when the
         # focal point size, image size and filter size match
         # See: #797
-        ('fill-1500x1500-c100', Image(
+        ('fill-1500x1500-c100', dict(
             width=1500,
             height=1500,
             focal_point_x=750,
@@ -263,7 +265,7 @@ class TestFillOperation(ImageOperationTestCase):
 
         # A few tests for single pixel images
 
-        ('fill-100x100', Image(
+        ('fill-100x100', dict(
             width=1,
             height=1,
         ), [
@@ -271,14 +273,14 @@ class TestFillOperation(ImageOperationTestCase):
         ]),
 
         # This one once gave a ZeroDivisionError
-        ('fill-100x150', Image(
+        ('fill-100x150', dict(
             width=1,
             height=1,
         ), [
             ('crop', ((0, 0, 1, 1), ), {}),
         ]),
 
-        ('fill-150x100', Image(
+        ('fill-150x100', dict(
             width=1,
             height=1,
         ), [
@@ -309,11 +311,11 @@ class TestMinMaxOperation(ImageOperationTestCase):
 
     run_tests = [
         # Basic usage of min
-        ('min-800x600', Image(width=1000, height=1000), [
+        ('min-800x600', dict(width=1000, height=1000), [
             ('resize', ((800, 800), ), {}),
         ]),
         # Basic usage of max
-        ('max-800x600', Image(width=1000, height=1000), [
+        ('max-800x600', dict(width=1000, height=1000), [
             ('resize', ((600, 600), ), {}),
         ]),
     ]
@@ -338,11 +340,11 @@ class TestWidthHeightOperation(ImageOperationTestCase):
 
     run_tests = [
         # Basic usage of width
-        ('width-400', Image(width=1000, height=500), [
+        ('width-400', dict(width=1000, height=500), [
             ('resize', ((400, 200), ), {}),
         ]),
         # Basic usage of height
-        ('height-400', Image(width=1000, height=500), [
+        ('height-400', dict(width=1000, height=500), [
             ('resize', ((800, 400), ), {}),
         ]),
     ]
@@ -350,7 +352,7 @@ class TestWidthHeightOperation(ImageOperationTestCase):
 TestWidthHeightOperation.setup_test_methods()
 
 
-class TestCacheKey(unittest.TestCase):
+class TestCacheKey(TestCase):
     def test_cache_key(self):
         image = Image(width=1000, height=1000)
         fil = Filter(spec='max-100x100')

--- a/wagtail/wagtailimages/tests/tests.py
+++ b/wagtail/wagtailimages/tests/tests.py
@@ -274,6 +274,7 @@ class TestGetImageForm(TestCase, WagtailTestUtils):
             'focal_point_y',
             'focal_point_width',
             'focal_point_height',
+            'collection',
         ])
 
     def test_admin_form_fields_attribute(self):

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -81,7 +81,7 @@ def edit(request, image_id):
 
     if request.POST:
         original_file = image.file
-        form = ImageForm(request.POST, request.FILES, instance=image)
+        form = ImageForm(request.POST, request.FILES, instance=image, user=request.user)
         if form.is_valid():
             if 'file' in form.changed_data:
                 # if providing a new image file, delete the old one and all renditions.
@@ -106,7 +106,7 @@ def edit(request, image_id):
         else:
             messages.error(request, _("The image could not be saved due to errors."))
     else:
-        form = ImageForm(instance=image)
+        form = ImageForm(instance=image, user=request.user)
 
     # Check if we should enable the frontend url generator
     try:
@@ -222,7 +222,7 @@ def add(request):
 
     if request.POST:
         image = ImageModel(uploaded_by_user=request.user)
-        form = ImageForm(request.POST, request.FILES, instance=image)
+        form = ImageForm(request.POST, request.FILES, instance=image, user=request.user)
         if form.is_valid():
             # Set image file size
             image.file_size = image.file.size
@@ -240,7 +240,7 @@ def add(request):
         else:
             messages.error(request, _("The image could not be created due to errors."))
     else:
-        form = ImageForm()
+        form = ImageForm(user=request.user)
 
     return render(request, "wagtailimages/images/add.html", {
         'form': form,

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -27,7 +27,7 @@ def index(request):
     Image = get_image_model()
 
     # Get images
-    images = images_editable_by_user(request.user)
+    images = images_editable_by_user(request.user).order_by('-created_at')
 
     # Search
     query_string = None

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -11,40 +11,32 @@ from django.http import HttpResponse, JsonResponse
 from wagtail.wagtailcore.models import Site
 from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailadmin import messages
-from wagtail.wagtailadmin.utils import permission_required, any_permission_required
-from wagtail.wagtailsearch.backends import get_search_backends
+from wagtail.wagtailsearch.backends import get_search_backends, get_search_backend
 
 from wagtail.wagtailimages.models import get_image_model, Filter
 from wagtail.wagtailimages.forms import get_image_form, URLGeneratorForm
+from wagtail.wagtailimages.permissions import \
+    image_permission_required, any_image_permission_required, user_can_edit_image, user_has_image_permission, images_editable_by_user
 from wagtail.wagtailimages.utils import generate_signature
 from wagtail.wagtailimages.exceptions import InvalidFilterSpecError
 
 
-@any_permission_required('wagtailimages.add_image', 'wagtailimages.change_image')
+@any_image_permission_required()
 @vary_on_headers('X-Requested-With')
 def index(request):
     Image = get_image_model()
 
     # Get images
-    images = Image.objects.order_by('-created_at')
-
-    # Permissions
-    if not request.user.has_perm('wagtailimages.change_image'):
-        # restrict to the user's own images
-        images = images.filter(uploaded_by_user=request.user)
+    images = images_editable_by_user(request.user)
 
     # Search
     query_string = None
     if 'q' in request.GET:
         form = SearchForm(request.GET, placeholder=_("Search images"))
         if form.is_valid():
+            s = get_search_backend()
             query_string = form.cleaned_data['q']
-
-            if not request.user.has_perm('wagtailimages.change_image'):
-                # restrict to the user's own images
-                images = Image.search(query_string, filters={'uploaded_by_user_id': request.user.id})
-            else:
-                images = Image.search(query_string)
+            images = s.search(query_string, images)
     else:
         form = SearchForm(placeholder=_("Search images"))
 
@@ -72,6 +64,7 @@ def index(request):
             'query_string': query_string,
             'is_searching': bool(query_string),
 
+            'can_add_image': user_has_image_permission(request.user, 'wagtailimages.add_image'),
             'search_form': form,
             'popular_tags': Image.popular_tags(),
         })
@@ -83,7 +76,7 @@ def edit(request, image_id):
 
     image = get_object_or_404(Image, id=image_id)
 
-    if not image.is_editable_by_user(request.user):
+    if not user_can_edit_image(request.user, image):
         raise PermissionDenied
 
     if request.POST:
@@ -140,7 +133,7 @@ def edit(request, image_id):
 def url_generator(request, image_id):
     image = get_object_or_404(get_image_model(), id=image_id)
 
-    if not image.is_editable_by_user(request.user):
+    if not user_can_edit_image(request.user, image):
         raise PermissionDenied
 
     form = URLGeneratorForm(initial={
@@ -166,7 +159,7 @@ def generate_url(request, image_id, filter_spec):
         }, status=404)
 
     # Check if this user has edit permission on this image
-    if not image.is_editable_by_user(request.user):
+    if not user_can_edit_image(request.user, image):
         return JsonResponse({
             'error': "You do not have permission to generate a URL for this image."
         }, status=403)
@@ -209,7 +202,7 @@ def preview(request, image_id, filter_spec):
 def delete(request, image_id):
     image = get_object_or_404(get_image_model(), id=image_id)
 
-    if not image.is_editable_by_user(request.user):
+    if not user_can_edit_image(request.user, image):
         raise PermissionDenied
 
     if request.POST:
@@ -222,7 +215,7 @@ def delete(request, image_id):
     })
 
 
-@permission_required('wagtailimages.add_image')
+@image_permission_required('wagtailimages.add_image')
 def add(request):
     ImageModel = get_image_model()
     ImageForm = get_image_form(ImageModel)

--- a/wagtail/wagtailimages/views/multiple.py
+++ b/wagtail/wagtailimages/views/multiple.py
@@ -11,7 +11,7 @@ from wagtail.wagtailimages.models import get_image_model
 from wagtail.wagtailimages.forms import get_image_form
 from wagtail.wagtailimages.fields import ALLOWED_EXTENSIONS
 from wagtail.wagtailimages.permissions import \
-    image_permission_required, user_can_edit_image
+    image_permission_required, user_can_edit_image, is_using_collections, collections_with_add_permission_for_user
 from wagtail.utils.compat import render_to_string
 
 
@@ -39,6 +39,16 @@ def add(request):
     Image = get_image_model()
     ImageForm = get_image_form(Image)
 
+    if is_using_collections:
+        collections = collections_with_add_permission_for_user(request.user)
+        if len(collections) > 1:
+            collections_to_choose = collections
+        else:
+            # no need to show a collections chooser
+            collections_to_choose = None
+    else:
+        collections_to_choose = None
+
     if request.method == 'POST':
         if not request.is_ajax():
             return HttpResponseBadRequest("Cannot POST to this view without AJAX")
@@ -49,9 +59,10 @@ def add(request):
         # Build a form for validation
         form = ImageForm({
             'title': request.FILES['files[]'].name,
+            'collection': request.POST.get('collection')
         }, {
             'file': request.FILES['files[]'],
-        })
+        }, user=request.user)
 
         if form.is_valid():
             # Save it
@@ -66,7 +77,7 @@ def add(request):
                 'image_id': int(image.id),
                 'form': render_to_string('wagtailimages/multiple/edit_form.html', {
                     'image': image,
-                    'form': get_image_edit_form(Image)(instance=image, prefix='image-%d' % image.id),
+                    'form': get_image_edit_form(Image)(instance=image, prefix='image-%d' % image.id, user=request.user),
                 }, request=request),
             })
         else:
@@ -78,7 +89,7 @@ def add(request):
                 'error_message': '\n'.join(['\n'.join([force_text(i) for i in v]) for k, v in form.errors.items()]),
             })
     else:
-        form = ImageForm()
+        form = ImageForm(user=request.user)
 
     return render(request, 'wagtailimages/multiple/add.html', {
         'max_filesize': form.fields['file'].max_upload_size,
@@ -86,6 +97,7 @@ def add(request):
         'allowed_extensions': ALLOWED_EXTENSIONS,
         'error_max_file_size': form.fields['file'].error_messages['file_too_large_unknown_size'],
         'error_accepted_file_types': form.fields['file'].error_messages['invalid_image'],
+        'collections': collections_to_choose,
     })
 
 
@@ -102,7 +114,7 @@ def edit(request, image_id, callback=None):
     if not user_can_edit_image(request.user, image):
         raise PermissionDenied
 
-    form = ImageForm(request.POST, request.FILES, instance=image, prefix='image-' + image_id)
+    form = ImageForm(request.POST, request.FILES, instance=image, prefix='image-' + image_id, user=request.user)
 
     if form.is_valid():
         form.save()

--- a/wagtail/wagtailsites/templates/wagtailsites/_form.html
+++ b/wagtail/wagtailsites/templates/wagtailsites/_form.html
@@ -1,4 +1,0 @@
-{% include "wagtailadmin/shared/field_as_li.html" with field=form.hostname %}
-{% include "wagtailadmin/shared/field_as_li.html" with field=form.port %}
-{% include "wagtailadmin/shared/field_as_li.html" with field=form.root_page %}
-{% include "wagtailadmin/shared/field_as_li.html" with field=form.is_default_site %}

--- a/wagtail/wagtailsites/templates/wagtailsites/create.html
+++ b/wagtail/wagtailsites/templates/wagtailsites/create.html
@@ -1,9 +1,5 @@
 {% extends "wagtailadmin/generic/create.html" %}
 
-{% block form %}
-    {% include "wagtailsites/_form.html" %}
-{% endblock %}
-
 {% block extra_js %}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 {% endblock %}

--- a/wagtail/wagtailsites/templates/wagtailsites/edit.html
+++ b/wagtail/wagtailsites/templates/wagtailsites/edit.html
@@ -1,9 +1,5 @@
 {% extends "wagtailadmin/generic/edit.html" %}
 
-{% block form %}
-    {% include "wagtailsites/_form.html" %}
-{% endblock %}
-
 {% block extra_js %}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 {% endblock %}

--- a/wagtail/wagtailusers/forms.py
+++ b/wagtail/wagtailusers/forms.py
@@ -7,7 +7,7 @@ from django.forms.models import inlineformset_factory
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailadmin.widgets import AdminPageChooser
 from wagtail.wagtailusers.models import UserProfile
-from wagtail.wagtailcore.models import Page, UserPagePermissionsProxy, GroupPagePermission
+from wagtail.wagtailcore.models import Page, UserPagePermissionsProxy, GroupPagePermission, GroupCollectionPermission
 
 
 User = get_user_model()
@@ -262,6 +262,35 @@ GroupPagePermissionFormSet = inlineformset_factory(
     formset=BaseGroupPagePermissionFormSet,
     extra=0,
     fields=('page', 'permission_type'),
+)
+
+
+class GroupCollectionPermissionForm(forms.ModelForm):
+    class Meta:
+        model = GroupCollectionPermission
+        fields = ('collection', 'permission')
+
+
+class BaseGroupCollectionPermissionFormSet(forms.models.BaseInlineFormSet):
+    def __init__(self, *args, **kwargs):
+        super(BaseGroupCollectionPermissionFormSet, self).__init__(*args, **kwargs)
+        self.form = GroupCollectionPermissionForm
+        for form in self.forms:
+            form.fields['DELETE'].widget = forms.HiddenInput()
+
+    @property
+    def empty_form(self):
+        empty_form = super(BaseGroupCollectionPermissionFormSet, self).empty_form
+        empty_form.fields['DELETE'].widget = forms.HiddenInput()
+        return empty_form
+
+
+GroupCollectionPermissionFormSet = inlineformset_factory(
+    Group,
+    GroupCollectionPermission,
+    formset=BaseGroupCollectionPermissionFormSet,
+    extra=0,
+    fields=('collection', 'permission'),
 )
 
 

--- a/wagtail/wagtailusers/static_src/wagtailusers/js/group-form.js
+++ b/wagtail/wagtailusers/static_src/wagtailusers/js/group-form.js
@@ -10,4 +10,16 @@ $(function() {
             });
         }
     });
+
+    buildExpandingFormset('id_collection_permissions', {
+        onInit: function(index) {
+            var deleteInputId = 'id_collection_permissions-' + index + '-DELETE';
+            var childId = 'inline_child_collection_permissions-' + index;
+            $('#' + deleteInputId + '-button').click(function() {
+                /* set 'deleted' form field to true */
+                $('#' + deleteInputId).val('1');
+                $('#' + childId).fadeOut();
+            });
+        }
+    });
 });

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/create.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/create.html
@@ -24,7 +24,10 @@
                     {% format_permissions permission_bound_field=form.permissions %}
                 </li>
                 <li>
-                    {% include "wagtailusers/groups/includes/page_permissions_formset.html" with formset=formset only %}
+                    {% include "wagtailusers/groups/includes/page_permissions_formset.html" with formset=page_permission_formset only %}
+                </li>
+                <li>
+                    {% include "wagtailusers/groups/includes/collection_permission_formset.html" with formset=collection_permission_formset only %}
                 </li>
                 <li><input type="submit" value='{% trans "Add group" %}' /></li>
             </ul>

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/edit.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/edit.html
@@ -25,7 +25,10 @@
                     {% format_permissions permission_bound_field=form.permissions %}
                 </li>
                 <li>
-                    {% include "wagtailusers/groups/includes/page_permissions_formset.html" with formset=formset only %}
+                    {% include "wagtailusers/groups/includes/page_permissions_formset.html" with formset=page_permission_formset only %}
+                </li>
+                <li>
+                    {% include "wagtailusers/groups/includes/collection_permission_formset.html" with formset=collection_permission_formset only %}
                 </li>
                 <li>
                     <input type="submit" value="{% trans 'Save' %}" />

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/includes/collection_permission_form.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/includes/collection_permission_form.html
@@ -1,0 +1,15 @@
+{% load i18n %}
+
+<td>
+    {% include "wagtailadmin/shared/field.html" with field=form.collection only %}
+</td>
+<td>
+    {% include "wagtailadmin/shared/field.html" with field=form.permission only %}
+
+    {{ form.id }}
+    {{ form.DELETE }}
+</td>
+
+<td>
+    <button class="button-secondary button-small no" type="button" id="{{ form.DELETE.id_for_label }}-button">{% trans "Delete" %}</button>
+</td>

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/includes/collection_permission_formset.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/includes/collection_permission_formset.html
@@ -1,0 +1,18 @@
+{% extends "wagtailusers/groups/includes/resource_permission_formset.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Collection permissions" %}{% endblock %}
+{% block resource_type_heading %}{% trans "Collection" %}{% endblock %}
+
+{% block form %}
+    {% include "wagtailusers/groups/includes/collection_permission_form.html" with form=form only %}
+{% endblock %}
+
+{% block empty_form %}
+    {% include "wagtailusers/groups/includes/collection_permission_form.html" with form=formset.empty_form only %}
+{% endblock %}
+
+{% block add_button %}
+    <a class="button bicolor icon icon-plus" id="id_{{ formset.prefix }}-ADD" value="Add">{% trans "Add a collection permission" %}</a>
+{% endblock %}

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/includes/page_permissions_formset.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/includes/page_permissions_formset.html
@@ -1,44 +1,18 @@
-{% load i18n wagtailadmin_tags %}
-<h2>{% trans "Page permissions" %}</h2>
+{% extends "wagtailusers/groups/includes/resource_permission_formset.html" %}
 
-{{ formset.management_form }}
+{% load i18n %}
 
-<table class="listing">
-    <col width="40%"/>
-    <col width="40%" />
-    <col />
-    <thead>
-        <tr>
-            <th>{% trans "Page" %}</th>
-            <th>{% trans "Permission type" %}</th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody id="id_{{ formset.prefix }}-FORMS">
-        {% for form in formset.forms %}
-            <tr id="inline_child_{{ form.prefix }}"{% if form.DELETE.value %} style="display: none;"{% endif %}>
-                {% if form.non_field_errors %}
-                    <p class="error-message">
-                        {% for error in form.non_field_errors %}
-                            <span>{{ error|escape }}</span>
-                        {% endfor %}
-                    </p>
-                {% endif %}
-                {% include "wagtailusers/groups/includes/page_permissions_form.html" with form=form only %}
-            </tr>
-        {% endfor %}
-    <tbody>
-</table>
+{% block title %}{% trans "Page permissions" %}{% endblock %}
+{% block resource_type_heading %}{% trans "Page" %}{% endblock %}
 
-<script type="text/django-form-template" id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
-{% escapescript %}
-    <tr id="inline_child_{{ formset.empty_form.prefix }}">
-        {% include "wagtailusers/groups/includes/page_permissions_form.html" with form=formset.empty_form only %}
-    </tr>
-{% endescapescript %}
-</script>
+{% block form %}
+    {% include "wagtailusers/groups/includes/page_permissions_form.html" with form=form only %}
+{% endblock %}
 
-<p class="add">
+{% block empty_form %}
+    {% include "wagtailusers/groups/includes/page_permissions_form.html" with form=formset.empty_form only %}
+{% endblock %}
+
+{% block add_button %}
     <a class="button bicolor icon icon-plus" id="id_{{ formset.prefix }}-ADD" value="Add">{% trans "Add a page permission" %}</a>
-</p>
-
+{% endblock %}

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/includes/resource_permission_formset.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/includes/resource_permission_formset.html
@@ -1,0 +1,45 @@
+{# common formset mechanism underpinning page_permission_formset and collection_permission_formset #}
+
+{% load i18n wagtailadmin_tags %}
+<h2>{% block title %}{% endblock %}</h2>
+
+{{ formset.management_form }}
+
+<table class="listing">
+    <col width="40%"/>
+    <col width="40%" />
+    <col />
+    <thead>
+        <tr>
+            <th>{% block resource_type_heading %}{% endblock %}</th>
+            <th>{% trans "Permission type" %}</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody id="id_{{ formset.prefix }}-FORMS">
+        {% for form in formset.forms %}
+            <tr id="inline_child_{{ form.prefix }}"{% if form.DELETE.value %} style="display: none;"{% endif %}>
+                {% if form.non_field_errors %}
+                    <p class="error-message">
+                        {% for error in form.non_field_errors %}
+                            <span>{{ error|escape }}</span>
+                        {% endfor %}
+                    </p>
+                {% endif %}
+                {% block form %}{% endblock %}
+            </tr>
+        {% endfor %}
+    <tbody>
+</table>
+
+<script type="text/django-form-template" id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
+{% escapescript %}
+    <tr id="inline_child_{{ formset.empty_form.prefix }}">
+        {% block empty_form %}{% endblock %}
+    </tr>
+{% endescapescript %}
+</script>
+
+<p class="add">
+    {% block add_button %}{% endblock %}
+</p>

--- a/wagtail/wagtailusers/tests.py
+++ b/wagtail/wagtailusers/tests.py
@@ -209,6 +209,9 @@ class TestGroupCreateView(TestCase, WagtailTestUtils):
             'page_permissions-TOTAL_FORMS': ['0'],
             'page_permissions-MAX_NUM_FORMS': ['1000'],
             'page_permissions-INITIAL_FORMS': ['0'],
+            'collection_permissions-TOTAL_FORMS': ['0'],
+            'collection_permissions-MAX_NUM_FORMS': ['1000'],
+            'collection_permissions-INITIAL_FORMS': ['0'],
         }
         for k, v in six.iteritems(post_defaults):
             post_data[k] = post_data.get(k, v)
@@ -298,7 +301,10 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
             'page_permissions-INITIAL_FORMS': ['1'],  # as we have one page permission already
             'page_permissions-0-id': [self.root_add_permission.id],
             'page_permissions-0-page': [self.root_add_permission.page.id],
-            'page_permissions-0-permission_type': [self.root_add_permission.permission_type]
+            'page_permissions-0-permission_type': [self.root_add_permission.permission_type],
+            'collection_permissions-TOTAL_FORMS': ['0'],
+            'collection_permissions-MAX_NUM_FORMS': ['1000'],
+            'collection_permissions-INITIAL_FORMS': ['0'],
         }
         for k, v in six.iteritems(post_defaults):
             post_data[k] = post_data.get(k, v)

--- a/wagtail/wagtailusers/views/groups.py
+++ b/wagtail/wagtailusers/views/groups.py
@@ -8,7 +8,7 @@ from django.views.decorators.vary import vary_on_headers
 from wagtail.wagtailadmin import messages
 from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailadmin.utils import permission_required, any_permission_required
-from wagtail.wagtailusers.forms import GroupForm, GroupPagePermissionFormSet
+from wagtail.wagtailusers.forms import GroupForm, GroupPagePermissionFormSet, GroupCollectionPermissionFormSet
 
 
 @any_permission_required('auth.add_group', 'auth.change_group', 'auth.delete_group')
@@ -72,11 +72,17 @@ def index(request):
 def create(request):
     if request.POST:
         form = GroupForm(request.POST)
-        formset = GroupPagePermissionFormSet(request.POST)
-        if form.is_valid() and formset.is_valid():
+        page_permission_formset = GroupPagePermissionFormSet(request.POST)
+        collection_permission_formset = GroupCollectionPermissionFormSet(request.POST)
+        if form.is_valid() and page_permission_formset.is_valid() and collection_permission_formset.is_valid():
             group = form.save()
-            formset.instance = group
-            formset.save()
+
+            page_permission_formset.instance = group
+            page_permission_formset.save()
+
+            collection_permission_formset.instance = group
+            collection_permission_formset.save()
+
             messages.success(request, _("Group '{0}' created.").format(group), buttons=[
                 messages.button(reverse('wagtailusers_groups:edit', args=(group.id,)), _('Edit'))
             ])
@@ -85,11 +91,13 @@ def create(request):
             messages.error(request, _("The group could not be created due to errors."))
     else:
         form = GroupForm()
-        formset = GroupPagePermissionFormSet()
+        page_permission_formset = GroupPagePermissionFormSet()
+        collection_permission_formset = GroupCollectionPermissionFormSet()
 
     return render(request, 'wagtailusers/groups/create.html', {
         'form': form,
-        'formset': formset,
+        'page_permission_formset': page_permission_formset,
+        'collection_permission_formset': collection_permission_formset,
     })
 
 
@@ -98,10 +106,12 @@ def edit(request, group_id):
     group = get_object_or_404(Group, id=group_id)
     if request.POST:
         form = GroupForm(request.POST, instance=group)
-        formset = GroupPagePermissionFormSet(request.POST, instance=group)
-        if form.is_valid() and formset.is_valid():
+        page_permission_formset = GroupPagePermissionFormSet(request.POST, instance=group)
+        collection_permission_formset = GroupCollectionPermissionFormSet(request.POST, instance=group)
+        if form.is_valid() and page_permission_formset.is_valid() and collection_permission_formset.is_valid():
             group = form.save()
-            formset.save()
+            page_permission_formset.save()
+            collection_permission_formset.save()
             messages.success(request, _("Group '{0}' updated.").format(group), buttons=[
                 messages.button(reverse('wagtailusers_groups:edit', args=(group.id,)), _('Edit'))
             ])
@@ -110,12 +120,14 @@ def edit(request, group_id):
             messages.error(request, _("The group could not be saved due to errors."))
     else:
         form = GroupForm(instance=group)
-        formset = GroupPagePermissionFormSet(instance=group)
+        page_permission_formset = GroupPagePermissionFormSet(instance=group)
+        collection_permission_formset = GroupCollectionPermissionFormSet(instance=group)
 
     return render(request, 'wagtailusers/groups/edit.html', {
         'group': group,
         'form': form,
-        'formset': formset,
+        'page_permission_formset': page_permission_formset,
+        'collection_permission_formset': collection_permission_formset,
     })
 
 


### PR DESCRIPTION
Spec: https://github.com/torchbox/wagtail/wiki/Collections-RFC, https://groups.google.com/d/msg/wagtail-developers/kE-aDrOIzRI/Cc2CP3KbAwAJ

This has been developed as a change to core Wagtail rather than a pluggable module, since it interacts with many existing areas of Wagtail, such as the permissions model, document/image edit forms, and the groups admin interface - and implementing a general-purpose extension framework in all of those areas would be a far bigger job. However, I've tried to keep the code compartmentalised enough so that it can be enabled/disabled depending on whether or not Image and Document inherit from the `CollectionMember` class. By default, custom image models do not inherit from this, so collections will be disabled for those.

As it stands this is a 'minimum viable product' and has a few rough edges:

* There is no restriction on what documents/images the user can use (i.e. see within the document/image chooser) - we agreed that this was out of scope for the initial feature.
* There is no interface for browsing documents / images by collection - the listing pages simply show all items that the user has edit permission for (meaning that currently, collections are *only* useful for permission restriction - not for general asset organisation).
* Deleting a collection will delete all documents / images within it; the 'manage collections' interface does not warn about this (since the collection management area doesn't currently know or care which models are making use of collections).
* Our aim was for the collection feature to be effectively invisible (apart from the addition of a Collections item in the settings menu) until a site is actively making use of it - i.e. a user creating a new Wagtail site would not have to understand the concept of collections up-front. We haven't entirely achieved this, because the document/image permissions within the 'edit group' UI now appear under 'collection permissions'. In order to configure these permissions, a user will have to understand what it means to be specifying those permissions on the 'root' collection.
* It hasn't had any design review yet. The UI additions here are mostly uncontroversial, as they're mainly just adding extra fields to an existing form - but the collection chooser dropdown on the 'add multiple images' view probably needs some attention.
* It hasn't been tested with custom image models yet.

This PR incorporates #1668.