### PR TITLE
Remove all ObjectDoesNotExist uses

### DIFF
--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -12,7 +12,7 @@ from django.utils.six import text_type
 from django import forms
 from django.forms.models import fields_for_model
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ObjectDoesNotExist, ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import ugettext_lazy
 
 from taggit.managers import TaggableManager
@@ -526,9 +526,11 @@ class BaseChooserPanel(BaseFieldPanel):
     """
 
     def get_chosen_item(self):
+        field = self.instance._meta.get_field(self.field_name)
+        related_model = get_related_model(field.related)
         try:
             return getattr(self.instance, self.field_name)
-        except ObjectDoesNotExist:
+        except related_model.DoesNotExist:
             # if the ForeignKey is null=False, Django decides to raise
             # a DoesNotExist exception here, rather than returning None
             # like every other unpopulated field type. Yay consistency!

--- a/wagtail/wagtailcore/management/commands/fixtree.py
+++ b/wagtail/wagtailcore/management/commands/fixtree.py
@@ -3,7 +3,6 @@ import functools
 from optparse import make_option
 
 from django.core.management.base import BaseCommand
-from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models import Q
 from django.utils import six
@@ -31,7 +30,7 @@ class Command(BaseCommand):
         for page in Page.objects.all():
             try:
                 page.specific
-            except ObjectDoesNotExist:
+            except page.specific_class.DoesNotExist:
                 self.stdout.write("Page %d (%s) is missing a subclass record; deleting." % (page.id, page.title))
                 any_problems_fixed = True
                 page.delete()

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -24,7 +24,7 @@ from django.utils import timezone
 from django.utils.six import StringIO
 from django.utils.six.moves.urllib.parse import urlparse
 from django.utils.translation import ugettext_lazy as _
-from django.core.exceptions import ValidationError, ImproperlyConfigured, ObjectDoesNotExist
+from django.core.exceptions import ValidationError, ImproperlyConfigured
 from django.utils.functional import cached_property
 from django.utils.encoding import python_2_unicode_compatible
 from django.core import checks
@@ -632,7 +632,7 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         # return None.
         try:
             return self.specific
-        except ObjectDoesNotExist:
+        except self.specific_class.DoesNotExist:
             return None
 
     @classmethod

--- a/wagtail/wagtailimages/tests/test_models.py
+++ b/wagtail/wagtailimages/tests/test_models.py
@@ -128,6 +128,9 @@ class TestRenditions(TestCase):
             file=get_test_image_file(),
         )
 
+    def test_get_rendition_model(self):
+        self.assertIs(Image.get_rendition_model(), Rendition)
+
     def test_minification(self):
         rendition = self.image.get_rendition('width-400')
 


### PR DESCRIPTION
`ObjectDoesNotExist` is usually not the correct error to catch. If you know the model class that would raise the error, you should catch its `Foo.DoesNotExist` error instead.

#1768 attempted this, but did not take in to account swappable Rendition models.