### PR TITLE
Use os.path.splitext() instead of custom logic in Document.file_extension

### DIFF
--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -40,11 +40,7 @@ class Document(models.Model, TagSearchable):
 
     @property
     def file_extension(self):
-        parts = self.filename.split('.')
-        if len(parts) > 1:
-            return parts[-1]
-        else:
-            return ''
+        return os.path.splitext(self.filename)[1][1:]
 
     @property
     def url(self):


### PR DESCRIPTION
No point in rolling your own logic when it already exists in the stdlib. As a bonus, does not treat `.bashrc` as having an extension of `bashrc`.