### PR TITLE
Normalise all code blocks in the docs

### DIFF
--- a/docs/advanced_topics/i18n/duplicate_tree.rst
+++ b/docs/advanced_topics/i18n/duplicate_tree.rst
@@ -129,7 +129,7 @@ Here's an example of how this could be implemented (with English as the main lan
 
 You can make use of these methods in your template by doing:
 
-.. code-block:: django
+.. code-block:: html+django
 
     {% if self.english_page and self.get_language != 'en' %}
         <a href="{{ self.english_page.url }}">{% trans "View in English" %}</a>

--- a/docs/advanced_topics/i18n/index.rst
+++ b/docs/advanced_topics/i18n/index.rst
@@ -196,7 +196,7 @@ For example, here's how we would apply this to the above ``BlogPage`` model:
 
 Finally, in the template, reference the accessors instead of the underlying database fields:
 
-.. code-block:: html+Django
+.. code-block:: html+django
 
     {{ self.translated_title }}
 

--- a/docs/advanced_topics/privacy.rst
+++ b/docs/advanced_topics/privacy.rst
@@ -24,7 +24,7 @@ This template will receive the same set of context variables that the blocked pa
 
 A basic template suitable for use as ``PASSWORD_REQUIRED_TEMPLATE`` might look like this:
 
- .. code-block:: django
+ .. code-block:: html+django
 
     <!DOCTYPE HTML>
     <html>

--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -192,9 +192,9 @@ Providing an API key for the Embedly service will use that as a embed backend, w
 
 To use Embedly, you must also install their Python module:
 
-.. code-block:: bash
+.. code-block:: sh
 
-  $ pip install embedly
+  pip install embedly
 
 
 Images

--- a/docs/contributing/css_guidelines.rst
+++ b/docs/contributing/css_guidelines.rst
@@ -183,6 +183,6 @@ Run the linter with ``scss-lint .`` from the wagtail project root.
 You'll need to have the linter installed to do this. You can get it by
 running:
 
-.. code-block:: bash
+.. code-block:: sh
 
     gem install scss-lint

--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -17,26 +17,26 @@ Install Node.js, any version between v0.10.x and v0.12.x. Instructions for insta
 
 Clone a copy of `the Wagtail codebase <https://github.com/torchbox/wagtail>`_:
 
-.. code-block:: bash
+.. code-block:: sh
 
     git clone https://github.com/torchbox/wagtail.git
     cd wagtail
 
 With your preferred virtualenv activated, install the Wagtail package in development mode:
 
-.. code-block:: bash
+.. code-block:: sh
 
     python setup.py develop
 
 Install the tool chain for building static assets:
 
-.. code-block:: bash
+.. code-block:: sh
 
     npm install
 
 Compile the assets:
 
-.. code-block:: bash
+.. code-block:: sh
 
     npm run build
 
@@ -104,12 +104,12 @@ All static assets such as JavaScript, CSS, images, and fonts for the Wagtail adm
 
 To compile the assets, run:
 
-.. code-block:: bash
+.. code-block:: sh
 
-    $ npm run build
+    npm run build
 
 This must be done after every change to the source files. To watch the source files for changes and then automatically recompile the assets, run:
 
-.. code-block:: bash
+.. code-block:: sh
 
-    $ npm start
+    npm start

--- a/docs/reference/contrib/forms.rst
+++ b/docs/reference/contrib/forms.rst
@@ -12,7 +12,7 @@ Usage
 
 Add ``wagtail.wagtailforms`` to your ``INSTALLED_APPS``:
 
-.. code:: python
+.. code-block:: python
 
     INSTALLED_APPS = [
        ...
@@ -22,7 +22,7 @@ Add ``wagtail.wagtailforms`` to your ``INSTALLED_APPS``:
 Within the ``models.py`` of one of your apps, create a model that extends ``wagtailforms.models.AbstractEmailForm``:
 
 
-.. code:: python
+.. code-block:: python
 
     from modelcluster.fields import ParentalKey
     from wagtail.wagtailadmin.edit_handlers import (FieldPanel, InlinePanel,
@@ -55,7 +55,7 @@ If you do not want your form page type to offer form-to-email functionality, you
 
 You now need to create two templates named ``form_page.html`` and ``form_page_landing.html`` (where ``form_page`` is the underscore-formatted version of the class name). ``form_page.html`` differs from a standard Wagtail template in that it is passed a variable ``form``, containing a Django ``Form`` object, in addition to the usual ``self`` variable. A very basic template for the form would thus be:
 
-.. code:: html
+.. code-block:: html
 
     {% load wagtailcore_tags %}
     <html>

--- a/docs/reference/contrib/searchpromotions.rst
+++ b/docs/reference/contrib/searchpromotions.rst
@@ -43,7 +43,7 @@ Displaying on a search results page
 
 To retrieve a list of promoted search results for a particular search query, you can use the ``{% get_search_promotions %}`` template tag from the ``wagtailsearchpromotions_tags`` templatetag library:
 
-.. code-block:: HTML+Django
+.. code-block:: html+django
 
     {% load wagtailcore_tags wagtailsearchpromotions_tags %}
 

--- a/docs/reference/contrib/sitemaps.rst
+++ b/docs/reference/contrib/sitemaps.rst
@@ -43,6 +43,7 @@ By default, the sitemap uses the hostname defined in the Wagtail Admin's ``Sites
 default site is called ``localhost``, then URLs in the sitemap will look like:
 
  .. code-block:: xml
+
     <url>
         <loc>http://localhost/about/</loc>
         <lastmod>2015-09-26</lastmod>
@@ -53,6 +54,7 @@ For tools like Google Search Tools to properly index your site, you need to set 
 will contain the correct URLs:
 
  .. code-block:: xml
+
     <url>
         <loc>http://mysite.com/about/</loc>
         <lastmod>2015-09-26</lastmod>

--- a/docs/reference/contrib/staticsitegen.rst
+++ b/docs/reference/contrib/staticsitegen.rst
@@ -12,13 +12,13 @@ Installing ``django-medusa``
 
 First, install ``django-medusa`` and ``django-sendfile`` from pip:
 
-.. code::
+.. code-block:: sh
 
     pip install django-medusa django-sendfile
 
 Then add ``django_medusa`` and ``wagtail.contrib.wagtailmedusa`` to ``INSTALLED_APPS``:
 
-.. code:: python
+.. code-block:: python
 
     INSTALLED_APPS = [
        ...
@@ -28,7 +28,7 @@ Then add ``django_medusa`` and ``wagtail.contrib.wagtailmedusa`` to ``INSTALLED_
 
 Define ``MEDUSA_RENDERER_CLASS``, ``MEDUSA_DEPLOY_DIR`` and ``SENDFILE_BACKEND`` in settings:
 
-.. code:: python
+.. code-block:: python
 
     MEDUSA_RENDERER_CLASS = 'django_medusa.renderers.DiskStaticSiteRenderer'
     MEDUSA_DEPLOY_DIR = os.path.join(BASE_DIR, 'build')
@@ -56,7 +56,7 @@ Wagtail provides a mixin (``wagtail.contrib.wagtailroutablepage.models.RoutableP
 
 Example:
 
-.. code:: python
+.. code-block:: python
 
     from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin, route
 
@@ -71,7 +71,7 @@ Example:
 
 Then in the template, you can use the ``{% routablepageurl %}`` tag to link between the pages:
 
-.. code:: html+Django
+.. code-block:: html+django
 
     {% load wagtailroutablepage_tags %}
 
@@ -94,7 +94,7 @@ For page types that override the ``route`` method, we need to let ``django-medus
 
 For example, the BlogIndex above would need to yield one URL for each page of results:
 
-.. code:: python
+.. code-block:: python
 
     def get_static_site_paths(self):
         # Get page count

--- a/docs/reference/management_commands.rst
+++ b/docs/reference/management_commands.rst
@@ -71,7 +71,7 @@ If you have multiple backends and would only like to update one of them, you can
 
 For example, to update just the default backend:
 
-.. code-block:: none
+.. code-block:: sh
 
     python manage.py update_index --backend default
 

--- a/docs/reference/pages/model_recipes.rst
+++ b/docs/reference/pages/model_recipes.rst
@@ -193,7 +193,7 @@ Now that we have the many-to-many tag relationship in place, we can fit in a way
 
 Here, ``blogs.filter(tags__name=tag)`` invokes a reverse Django queryset filter on the ``BlogPageTag`` model to optionally limit the ``BlogPage`` objects sent to the template for rendering. Now, lets render both sides of the relation by showing the tags associated with an object and a way of showing all of the objects associated with each tag. This could be added to the ``blog_page.html`` template:
 
-.. code-block:: django
+.. code-block:: html+django
 
     {% for tag in self.tags.all %}
         <a href="{% pageurl self.blog_index %}?tag={{ tag }}">{{ tag }}</a>

--- a/docs/reference/project_template.rst
+++ b/docs/reference/project_template.rst
@@ -21,7 +21,6 @@ The project template
         Vagrantfile
         readme.rst
         requirements.txt
-        
 
 The "core" app
 ----------------

--- a/docs/topics/images/advanced_topics.rst
+++ b/docs/topics/images/advanced_topics.rst
@@ -117,7 +117,7 @@ Installing OpenCV on Debian/Ubuntu
 
 Debian and ubuntu provide an apt-get package called ``python-opencv``:
 
- .. code-block:: bash
+ .. code-block:: sh
 
     sudo apt-get install python-opencv python-numpy
 

--- a/docs/topics/images/using_in_templates.rst
+++ b/docs/topics/images/using_in_templates.rst
@@ -11,7 +11,7 @@ The syntax for the tag is thus::
 
 For example:
 
-.. code-block:: django
+.. code-block:: html+django
 
     {% load wagtailimages_tags %}
     ...
@@ -34,7 +34,7 @@ The available resizing methods are:
     ``max`` 
         (takes two dimensions)
 
-        .. code-block:: django
+        .. code-block:: html+django
 
             {% image self.photo max-1000x500 %}
 
@@ -45,7 +45,7 @@ The available resizing methods are:
     ``min`` 
         (takes two dimensions)
 
-        .. code-block:: django
+        .. code-block:: html+django
 
             {% image self.photo min-500x200 %}
 
@@ -56,7 +56,7 @@ The available resizing methods are:
     ``width`` 
         (takes one dimension)
 
-        .. code-block:: django
+        .. code-block:: html+django
 
             {% image self.photo width-640 %}
 
@@ -65,7 +65,7 @@ The available resizing methods are:
     ``height`` 
         (takes one dimension)
 
-        .. code-block:: django
+        .. code-block:: html+django
 
             {% image self.photo height-480 %}
 
@@ -74,7 +74,7 @@ The available resizing methods are:
     ``fill`` 
         (takes two dimensions and an optional ``-c`` parameter)
 
-        .. code-block:: django
+        .. code-block:: html+django
 
             {% image self.photo fill-200x200 %}
 
@@ -96,7 +96,7 @@ The available resizing methods are:
 
         You can do this by appending ``-c<percentage>`` at the end of the method. For example, if you would like the image to be cropped as closely as possible to its focal point, add ``-c100`` to the end of the method.
 
-        .. code-block:: django
+        .. code-block:: html+django
 
             {% image self.photo fill-200x200-c100 %}
 
@@ -107,7 +107,7 @@ The available resizing methods are:
     ``original`` 
         (takes no dimensions)
 
-        .. code-block:: django
+        .. code-block:: html+django
 
             {% image self.photo original %}
 
@@ -130,7 +130,7 @@ Wagtail provides two shortcuts to give greater control over the ``img`` element:
 
 Extra attributes can be specified with the syntax ``attribute="value"``:
 
-.. code-block:: django
+.. code-block:: html+django
 
     {% image self.photo width-400 class="foo" id="bar" %}
 
@@ -141,7 +141,7 @@ No validation is performed on attributes added in this way so it's possible to a
 
 Wagtail can assign the image data to another variable using Django's ``as`` syntax:
 
-.. code-block:: django
+.. code-block:: html+django
 
     {% image self.photo width-400 as tmp_photo %}
 
@@ -167,7 +167,7 @@ The ``attrs`` shortcut
 
 You can also use the ``attrs`` property as a shorthand to output the attributes ``src``, ``width``, ``height`` and ``alt`` in one go:
 
-.. code-block:: django
+.. code-block:: html+django
 
     <img {{ tmp_photo.attrs }} class="my-custom-class" />
 

--- a/docs/topics/search/backends.rst
+++ b/docs/topics/search/backends.rst
@@ -98,7 +98,7 @@ Prerequisites are the `Elasticsearch`_ service itself and, via pip, the `elastic
 .. _Elasticsearch: https://www.elastic.co/products/elasticsearch
 
 
-.. code-block:: guess
+.. code-block:: sh
 
   pip install elasticsearch
 

--- a/docs/topics/snippets.rst
+++ b/docs/topics/snippets.rst
@@ -69,7 +69,7 @@ First, add a new python file to a ``templatetags`` folder within your app. The d
 
 Here's what's in the template used by the template tag:
 
-.. code-block:: django
+.. code-block:: html+django
 
   {% for advert in adverts %}
     <p>
@@ -81,7 +81,7 @@ Here's what's in the template used by the template tag:
 
 Then in your own page templates, you can include your snippet template tag with:
 
-.. code-block:: django
+.. code-block:: html+django
 
   {% block content %}
   
@@ -162,7 +162,7 @@ To attach multiple adverts to a page, the ``SnippetChooserPanel`` can be placed 
 
 These child objects are now accessible through the page's ``advert_placements`` property, and from there we can access the linked Advert snippet as ``advert``. In the template for ``BookPage``, we could include the following:
 
-.. code-block:: django
+.. code-block:: html+django
 
   {% for advert_placement in self.advert_placements.all %}
     <p><a href="{{ advert_placement.advert.url }}">{{ advert_placement.advert.text }}</a></p>

--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -360,14 +360,14 @@ Template rendering
 
 The simplest way to render the contents of a StreamField into your template is to output it as a variable, like any other field:
 
-.. code-block:: django
+.. code-block:: html+django
 
     {{ self.body }}
 
 
 This will render each block of the stream in turn, wrapped in a ``<div class="block-my_block_name">`` element (where ``my_block_name`` is the block name given in the StreamField definition). If you wish to provide your own HTML markup, you can instead iterate over the field's value to access each block in turn:
 
-.. code-block:: django
+.. code-block:: html+django
 
     <article>
         {% for block in self.body %}
@@ -378,7 +378,7 @@ This will render each block of the stream in turn, wrapped in a ``<div class="bl
 
 For more control over the rendering of specific block types, each block object provides ``block_type`` and ``value`` properties:
 
-.. code-block:: django
+.. code-block:: html+django
 
     <article>
         {% for block in self.body %}
@@ -428,7 +428,7 @@ Or, when defined as a subclass of StructBlock:
 
 Within the template, the block value is accessible as the variable ``self``:
 
-.. code-block:: django
+.. code-block:: html+django
 
     {% load wagtailimages_tags %}
 

--- a/docs/topics/writing_templates.rst
+++ b/docs/topics/writing_templates.rst
@@ -89,7 +89,7 @@ The syntax for the tag is thus::
 
 For example:
 
-.. code-block:: django
+.. code-block:: html+django
 
     {% load wagtailimages_tags %}
     ...
@@ -112,7 +112,7 @@ This filter takes a chunk of HTML content and renders it as safe HTML in the pag
 
 Only fields using ``RichTextField`` need this applied in the template.
 
-.. code-block:: django
+.. code-block:: html+django
 
     {% load wagtailcore_tags %}
     ...
@@ -152,7 +152,7 @@ Internal links (tag)
 
 Takes a Page object and returns a relative URL (``/foo/bar/``) if within the same site as the current page, or absolute (``http://example.com/foo/bar/``) if not.
 
-.. code-block:: django
+.. code-block:: html+django
 
     {% load wagtailcore_tags %}
     ...
@@ -163,7 +163,7 @@ slugurl
 
 Takes any ``slug`` as defined in a page's "Promote" tab and returns the URL for the matching Page. Like ``pageurl``, will try to provide a relative link if possible, but will default to an absolute link if on a different site. This is most useful when creating shared page furniture e.g top level navigation or site-wide links.
 
-.. code-block:: django
+.. code-block:: html+django
 
     {% load wagtailcore_tags %}
     ...
@@ -177,7 +177,7 @@ Static files (tag)
 
 Used to load anything from your static files directory. Use of this tag avoids rewriting all static paths if hosting arrangements change, as they might between  local and a live environments.
 
-.. code-block:: django
+.. code-block:: html+django
 
     {% load static %}
     ...
@@ -192,7 +192,7 @@ Wagtail User Bar
 
 This tag provides a contextual flyout menu on the top-right of a page for logged-in users. The menu gives editors the ability to edit the current page or add another at the same level. Moderators are also given the ability to accept or reject a page previewed as part of content moderation.
 
-.. code-block:: django
+.. code-block:: html+django
 
     {% load wagtailuserbar %}
     ...


### PR DESCRIPTION
All `.. code::` instances have been changed to use `.. code-block::`, and have been properly formatted. The syntax names have been normalised, so all django templates use the `html+django` syntax, shell commands use `bash`, and plain text uses `text`.