### PR TITLE
Fix bug where built assets may not be packaged

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,8 @@
 
 import sys
 
-from setuptools.command.sdist import sdist
-
 from wagtail.wagtailcore import __version__
-from wagtail.utils.setup import assets, add_subcommand, check_bdist_egg
+from wagtail.utils.setup import assets, sdist, check_bdist_egg
 
 try:
     from setuptools import setup, find_packages
@@ -70,7 +68,7 @@ setup(
     """,
     zip_safe=False,
     cmdclass={
-        'sdist': add_subcommand(sdist, [('assets', None)]),
+        'sdist': sdist,
         'bdist_egg': check_bdist_egg,
         'assets': assets,
     },

--- a/wagtail/utils/setup.py
+++ b/wagtail/utils/setup.py
@@ -3,13 +3,22 @@ from __future__ import absolute_import, print_function, unicode_literals
 import os
 import subprocess
 
-from distutils.core import Command
-
+from setuptools import Command
 from setuptools.command.bdist_egg import bdist_egg
+from setuptools.command.sdist import sdist as base_sdist
 
 
-class assets(Command):
+class assets_mixin(object):
 
+    def compile_assets(self):
+        try:
+            subprocess.check_call(['npm', 'run', 'build'])
+        except (OSError, subprocess.CalledProcessError) as e:
+            print('Error compiling assets: ' + str(e))
+            raise SystemExit(1)
+
+
+class assets(Command, assets_mixin):
     user_options = []
 
     def initialize_options(self):
@@ -19,11 +28,13 @@ class assets(Command):
         pass
 
     def run(self):
-        try:
-            subprocess.check_call(['npm', 'run', 'build'])
-        except (OSError, subprocess.CalledProcessError) as e:
-            print('Error compiling assets: ' + str(e))
-            raise SystemExit(1)
+        self.compile_assets()
+
+
+class sdist(base_sdist, assets_mixin):
+    def run(self):
+        self.compile_assets()
+        base_sdist.run(self)
 
 
 class check_bdist_egg(bdist_egg):
@@ -41,12 +52,3 @@ class check_bdist_egg(bdist_egg):
                 "docs/contributing/css_guidelines.rst",
                 "************************************************************",
             ]))
-
-
-def add_subcommand(command, extra_sub_commands):
-    # Sadly, as commands are old-style classes, `type()` can not be used to
-    # construct these.
-    class CompileAnd(command):
-        sub_commands = command.sub_commands + extra_sub_commands
-    CompileAnd.__name__ = command.__name__
-    return CompileAnd


### PR DESCRIPTION
The asset compilation that occurs as part of `python setup.py sdist` would find all the files to include first, then recompile all the assets, before finally packaging them all up. This means that if a new file was created as part of the asset compilation that was not there when all the files were first searched for, that file would not be included in the package.

Now, the asset compilation happens before the file system is searched for assets to include, so all assets should always be included.