### PR TITLE
Enable rest framework's browsable API

### DIFF
--- a/wagtail/contrib/wagtailapi/apps.py
+++ b/wagtail/contrib/wagtailapi/apps.py
@@ -1,6 +1,10 @@
+import warnings
+
 from django.apps import AppConfig, apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+
+from wagtail.utils.deprecation import RemovedInWagtail14Warning
 
 
 class WagtailAPIAppConfig(AppConfig):
@@ -16,3 +20,9 @@ class WagtailAPIAppConfig(AppConfig):
                 register_signal_handlers()
             else:
                 raise ImproperlyConfigured("The setting 'WAGTAILAPI_USE_FRONTENDCACHE' is True but 'wagtail.contrib.wagtailfrontendcache' is not in INSTALLED_APPS.")
+
+        if not apps.is_installed('rest_framework'):
+            warnings.warn(
+                "The 'wagtailapi' module now requires 'rest_framework' to be installed. "
+                "Please add 'rest_framework' to INSTALLED_APPS.",
+                RemovedInWagtail14Warning)

--- a/wagtail/contrib/wagtailapi/endpoints.py
+++ b/wagtail/contrib/wagtailapi/endpoints.py
@@ -41,6 +41,9 @@ class BaseAPIEndpoint(GenericViewSet):
 
         # Used by jQuery for cache-busting. See #1671
         '_',
+
+        # Required by BrowsableAPIRenderer
+        'format',
     ])
     extra_api_fields = []
     name = None  # Set on subclass.

--- a/wagtail/contrib/wagtailapi/endpoints.py
+++ b/wagtail/contrib/wagtailapi/endpoints.py
@@ -9,7 +9,7 @@ from django.core.urlresolvers import reverse
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
-from rest_framework.renderers import JSONRenderer
+from rest_framework.renderers import JSONRenderer, BrowsableAPIRenderer
 
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailimages.models import get_image_model
@@ -26,7 +26,7 @@ from .utils import BadRequestError
 
 
 class BaseAPIEndpoint(GenericViewSet):
-    renderer_classes = [JSONRenderer]
+    renderer_classes = [JSONRenderer, BrowsableAPIRenderer]
     pagination_class = WagtailPagination
     base_serializer_class = BaseSerializer
     filter_backends = []

--- a/wagtail/contrib/wagtailapi/endpoints.py
+++ b/wagtail/contrib/wagtailapi/endpoints.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from django.conf.urls import url
 from django.http import Http404
 from django.core.urlresolvers import reverse
+from django.apps import apps
 
 from rest_framework import status
 from rest_framework.response import Response
@@ -26,7 +27,14 @@ from .utils import BadRequestError
 
 
 class BaseAPIEndpoint(GenericViewSet):
-    renderer_classes = [JSONRenderer, BrowsableAPIRenderer]
+    renderer_classes = [JSONRenderer]
+
+    # The BrowsableAPIRenderer requires rest_framework to be installed
+    # Remove this check in Wagtail 1.4 as rest_framwork will be required
+    # RemovedInWagtail14Warning
+    if apps.is_installed('rest_framework'):
+        renderer_classes.append(BrowsableAPIRenderer)
+
     pagination_class = WagtailPagination
     base_serializer_class = BaseSerializer
     filter_backends = []


### PR DESCRIPTION
This pull request switches on the ``BrowsableAPIRenderer`` class. This renderer displays the endpoint in a nice HTML page which is enabled when an ``Accept: text/html`` header is sent by the client (which would only be true when browsing to it directly).