### PR TITLE
Allow "_" GET parameter in the API

### DIFF
--- a/wagtail/contrib/wagtailapi/endpoints.py
+++ b/wagtail/contrib/wagtailapi/endpoints.py
@@ -37,6 +37,9 @@ class BaseAPIEndpoint(GenericViewSet):
         'fields',
         'order',
         'search',
+
+        # Used by jQuery for cache-busting. See #1671
+        '_',
     ])
     extra_api_fields = []
     name = None  # Set on subclass.


### PR DESCRIPTION
Fixes #1671

Used by jQuery for cache-busting