### PR TITLE
Fix expectedFailures for StreamFields

### DIFF
--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -228,6 +228,20 @@ class ChoiceBlock(FieldBlock):
         """
         return ('wagtail.wagtailcore.blocks.ChoiceBlock', [], self._constructor_kwargs)
 
+    def get_searchable_content(self, value):
+        # Return the display value as the searchable value
+        text_value = force_text(value)
+        for k, v in self.field.choices:
+            if isinstance(v, (list, tuple)):
+                # This is an optgroup, so look inside the group for options
+                for k2, v2 in v:
+                    if value == k2 or text_value == force_text(k2):
+                        return [k, v2]
+            else:
+                if value == k or text_value == force_text(k):
+                    return [v]
+        return []  # Value was not found in the list of choices
+
 
 class RichTextBlock(FieldBlock):
 

--- a/wagtail/wagtailcore/blocks/struct_block.py
+++ b/wagtail/wagtailcore/blocks/struct_block.py
@@ -160,6 +160,11 @@ class BaseStructBlock(Block):
 
         return errors
 
+    def render(self, value):
+        value = collections.OrderedDict(
+            (key, value.get(key)) for key in self.child_blocks.keys())
+        return super(BaseStructBlock, self).render(value)
+
 
 class StructBlock(six.with_metaclass(DeclarativeSubBlocksMetaclass, BaseStructBlock)):
     pass

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -6,7 +6,7 @@ import unittest
 from django import forms
 from django.forms.utils import ErrorList
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from django.test import TestCase, SimpleTestCase
 from django.utils.safestring import mark_safe, SafeData
 
 from wagtail.wagtailcore import blocks
@@ -447,7 +447,7 @@ class TestMeta(unittest.TestCase):
         self.assertEqual(block.meta.test, 'Foo')
 
 
-class TestStructBlock(unittest.TestCase):
+class TestStructBlock(SimpleTestCase):
     def test_initialisation(self):
         block = blocks.StructBlock([
             ('title', blocks.CharBlock()),
@@ -514,13 +514,17 @@ class TestStructBlock(unittest.TestCase):
             'title': "Wagtail site",
             'link': 'http://www.wagtail.io',
         })
+        expected_html = '\n'.join([
+            '<dl>',
+            '<dt>title</dt>',
+            '<dd>Wagtail site</dd>',
+            '<dt>link</dt>',
+            '<dd>http://www.wagtail.io</dd>',
+            '</dl>',
+        ])
 
-        self.assertIn('<dt>title</dt>', html)
-        self.assertIn('<dd>Wagtail site</dd>', html)
-        self.assertIn('<dt>link</dt>', html)
-        self.assertIn('<dd>http://www.wagtail.io</dd>', html)
+        self.assertHTMLEqual(html, expected_html)
 
-    @unittest.expectedFailure
     def test_render_unknown_field(self):
         class LinkBlock(blocks.StructBlock):
             title = blocks.CharBlock()


### PR DESCRIPTION
There are three commits, which fix three groups of expectedFailures:

* FieldsBlocks with ChoiceBlocks now return their display value in `get_searchable_content()`;
* StructBlocks now only render a `<dt>`/`<dd>` pair for defined fields; and
* Multiply inherited StructBlocks and StreamBlocks now correctly order their inherited children.

This PR was broken out of #1778