### PR TITLE
Fix expectedFailures for Documents

### DIFF
--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -594,10 +594,15 @@ class TestServeView(TestCase):
         response = self.client.get(reverse('wagtaildocs_serve', args=(1000, 'blahblahblah', )))
         self.assertEqual(response.status_code, 404)
 
-    @unittest.expectedFailure
     def test_with_incorrect_filename(self):
+        """
+        Wagtail should be forgiving with filenames at the end of the URL. These
+        filenames are to make the URL look nice, and to provide a fallback for
+        browsers that do not handle the 'Content-Disposition' header filename
+        component. They should not be validated.
+        """
         response = self.client.get(reverse('wagtaildocs_serve', args=(self.document.id, 'incorrectfilename')))
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
 
     def clear_sendfile_cache(self):
         from wagtail.utils.sendfile import _get_sendfile

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -563,9 +563,10 @@ class TestServeView(TestCase):
     def test_response_code(self):
         self.assertEqual(self.get().status_code, 200)
 
-    @unittest.expectedFailure  # Filename has a random string appended to it
     def test_content_disposition_header(self):
-        self.assertEqual(self.get()['Content-Disposition'], 'attachment; filename=example.doc')
+        self.assertEqual(
+            self.get()['Content-Disposition'],
+            'attachment; filename="{}"'.format(self.document.filename))
 
     def test_content_length_header(self):
         self.assertEqual(self.get()['Content-Length'], '25')


### PR DESCRIPTION
This PR fixes two expectedFailures for Documents:

* The documents are given a random suffix to prevent filename collision, and this was not taken in to account in the tests. Serving documents with the original, uploaded filename would require a new field being added to record the initial name, which does not seem worth the cost. Now, the tests check the document is served with the suggested filename including the random suffix.
* Accessing the serve method with an incorrect filename was expected to return a 404 response, but it was instead serving the file. In my opinion, this is the correct behaviour, so the test has been updated to match, and my opinion has been added as a docstring.

Both of these are opinionated changes, but in my opinion these are the right changes to make.

This PR was broken out of #1778