### PR TITLE
Raise ValueError from `resolve_model_string` for unknown types

### DIFF
--- a/wagtail/wagtailcore/tests/tests.py
+++ b/wagtail/wagtailcore/tests/tests.py
@@ -1,5 +1,3 @@
-import unittest
-
 from django.test import TestCase
 from django.core.cache import cache
 from django.utils.safestring import SafeString
@@ -176,16 +174,20 @@ class TestResolveModelString(TestCase):
     def test_resolve_from_string_with_incorrect_default_app(self):
         self.assertRaises(LookupError, resolve_model_string, 'Page', default_app='wagtailadmin')
 
+    def test_resolve_from_string_with_unknown_model_string(self):
+        self.assertRaises(LookupError, resolve_model_string, 'wagtailadmin.Page')
+
     def test_resolve_from_string_with_no_default_app(self):
         self.assertRaises(ValueError, resolve_model_string, 'Page')
 
-    @unittest.expectedFailure # Raising LookupError instead
     def test_resolve_from_class_that_isnt_a_model(self):
         self.assertRaises(ValueError, resolve_model_string, object)
 
-    @unittest.expectedFailure # Raising LookupError instead
     def test_resolve_from_bad_type(self):
         self.assertRaises(ValueError, resolve_model_string, resolve_model_string)
+
+    def test_resolve_from_none(self):
+        self.assertRaises(ValueError, resolve_model_string, None)
 
 
 class TestRichtextTag(TestCase):

--- a/wagtail/wagtailcore/utils.py
+++ b/wagtail/wagtailcore/utils.py
@@ -17,6 +17,9 @@ def resolve_model_string(model_string, default_app=None):
     """
     Resolve an 'app_label.model_name' string into an actual model class.
     If a model class is passed in, just return that.
+
+    Raises a LookupError if a model can not be found, or ValueError if passed
+    something that is neither a model or a string.
     """
     if isinstance(model_string, string_types):
         try:
@@ -37,10 +40,12 @@ def resolve_model_string(model_string, default_app=None):
         return model_string
 
     else:
-        raise LookupError("Can not resolve {0!r} into a model".format(model_string), model_string)
+        raise ValueError("Can not resolve {0!r} into a model".format(model_string), model_string)
 
 
 SCRIPT_RE = re.compile(r'<(-*)/script>')
+
+
 def escape_script(text):
     """
     Escape `</script>` tags in 'text' so that it can be placed within a `<script>` block without


### PR DESCRIPTION
A `LookupError` is raised by `apps.get_model` for an unknown model, but this `LookupError` was being raised when values with unhandled types were passed in. This should be a `ValueError` instead. The docstring has been amended document the errors raised.

This PR was broken out of #1778