### PR TITLE
Add test helpers for Wagtail sites

### DIFF
--- a/docs/advanced_topics/index.rst
+++ b/docs/advanced_topics/index.rst
@@ -13,3 +13,4 @@ Advanced topics
     customisation/index
     third_party_tutorials
     jinja2
+    testing

--- a/docs/advanced_topics/testing.rst
+++ b/docs/advanced_topics/testing.rst
@@ -1,0 +1,81 @@
+.. _reference:
+
+=========================
+Testing your Wagtail site
+=========================
+
+Wagtail comes with some utilities that simplify writing tests for your site.
+
+.. automodule:: wagtail.tests.utils
+
+WagtailPageTests
+================
+
+.. class:: WagtailPageTests
+
+    ``WagtailPageTests`` extends ``django.test.TestCase``, adding a few new ``assert`` methods. You should extend this class to make use of its methods:
+
+    .. code-block:: python
+
+        from wagtail.tests.utils import WagtailPageTests
+        from myapp.models import MyPage
+
+        class MyPageTests(WagtailPageTests):
+            def test_can_create_a_page(self):
+                ...
+
+    .. automethod:: assertCanCreateAt
+
+        .. code-block:: python
+
+            def test_can_create_under_home_page(self):
+                # You can create a ContentPage under a HomePage
+                self.assertCanCreateAt(HomePage, ContentPage)
+
+    .. automethod:: assertCanNotCreateAt
+
+        .. code-block:: python
+
+            def test_cant_create_under_event_page(self):
+                # You can not create a ContentPage under an EventPage
+                self.assertCanNotCreateAt(EventPage, ContentPage)
+
+    .. automethod:: assertCanCreate
+
+        .. code-block:: python
+
+            def test_can_create_content_page(self):
+                # Get the HomePage
+                root_page = HomePage.objects.get(pk=2)
+
+                # Assert that a ContentPage can be made here, with this POST data
+                self.assertCanCreate(root_page, ContentPage, {
+                    'title': 'About us',
+                    'body': 'Lorem ipsum dolor sit amet')
+
+    .. automethod:: assertAllowedParentPageTypes
+
+        .. code-block:: python
+
+            def test_content_page_parent_pages(self):
+                # A ContentPage can only be created under a HomePage
+                # or another ContentPage
+                self.assertAllowedParentPageTypes(
+                    ContentPage, {HomePage, ContentPage})
+
+                # An EventPage can only be created under an EventIndex
+                self.assertAllowedParentPageTypes(
+                    EventPage, {EventIndex})
+
+    .. automethod:: assertAllowedSubpageTypes
+
+        .. code-block:: python
+
+            def test_content_page_subpages(self):
+                # A ContentPage can only have other ContentPage children
+                self.assertAllowedSubpageTypes(
+                    ContentPage, {ContentPage})
+
+                # A HomePage can have ContentPage and EventIndex children
+                self.assertAllowedParentPageTypes(
+                    HomePage, {ContentPage, EventIndex})

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -403,8 +403,11 @@ class BusinessIndex(Page):
 
 class BusinessSubIndex(Page):
     """ Can be placed under BusinessIndex, and have BusinessChild children """
-    subpage_types = ['tests.BusinessChild']
-    parent_page_types = ['tests.BusinessIndex']
+
+    # BusinessNowherePage is 'incorrectly' added here as a possible child.
+    # The rules on BusinessNowherePage prevent it from being a child here though.
+    subpage_types = ['tests.BusinessChild', 'tests.BusinessNowherePage']
+    parent_page_types = ['tests.BusinessIndex', 'tests.BusinessChild']
 
 
 class BusinessChild(Page):

--- a/wagtail/tests/utils.py
+++ b/wagtail/tests/utils.py
@@ -4,6 +4,7 @@ import sys
 import warnings
 from contextlib import contextmanager
 
+import django
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
@@ -141,7 +142,10 @@ class WagtailPageTests(WagtailTestUtils, TestCase):
                 child_model._meta.app_label, child_model._meta.model_name, errors))
             raise self.failureException(msg)
 
-        explore_url = 'http://testserver' + reverse('wagtailadmin_explore', args=[parent.pk])
+        if django.VERSION >= (1, 9):
+            explore_url = reverse('wagtailadmin_explore', args=[parent.pk])
+        else:
+            explore_url = 'http://testserver' + reverse('wagtailadmin_explore', args=[parent.pk])
         if response.redirect_chain != [(explore_url, 302)]:
             msg = self._formatMessage(msg, 'Creating a page %s.%s didnt redirect the user to the explorer, but to %s' % (
                 child_model._meta.app_label, child_model._meta.model_name,

--- a/wagtail/tests/utils.py
+++ b/wagtail/tests/utils.py
@@ -6,13 +6,10 @@ from contextlib import contextmanager
 
 import django
 from django.contrib.auth import get_user_model
-from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.utils import six
 from django.utils.text import slugify
-
-from wagtail.wagtailcore.models import Page
 
 
 class WagtailTestUtils(object):
@@ -71,13 +68,7 @@ class WagtailPageTests(WagtailTestUtils, TestCase):
         self.login()
 
     def _testCanCreateAt(self, parent_model, child_model):
-        child_ct = ContentType.objects.get_for_model(child_model)
-        parent_ct = ContentType.objects.get_for_model(parent_model)
-
-        return all([
-            child_ct in parent_model.allowed_subpage_types(),
-            # Anything can be created under a Page
-            parent_model is Page or parent_ct in child_model.allowed_parent_page_types()])
+        return child_model in parent_model.allowed_subpage_models()
 
     def assertCanCreateAt(self, parent_model, child_model, msg=None):
         """
@@ -162,7 +153,7 @@ class WagtailPageTests(WagtailTestUtils, TestCase):
         ``Page.parent_page_types``.
         """
         self.assertEqual(
-            set(ct.model_class() for ct in parent_model.clean_subpage_types()),
+            set(parent_model.allowed_subpage_models()),
             set(child_models),
             msg=msg)
 
@@ -176,6 +167,6 @@ class WagtailPageTests(WagtailTestUtils, TestCase):
         ``Page.subpage_types``.
         """
         self.assertEqual(
-            set(ct.model_class() for ct in child_model.clean_parent_page_types()),
+            set(child_model.allowed_parent_page_models()),
             set(parent_models),
-            msg=None)
+            msg=msg)

--- a/wagtail/tests/utils.py
+++ b/wagtail/tests/utils.py
@@ -81,7 +81,8 @@ class WagtailPageTests(WagtailTestUtils, TestCase):
     def assertCanCreateAt(self, parent_model, child_model, msg=None):
         """
         Assert a particular child Page type can be created under a parent
-        Page type.
+        Page type. ``parent_model`` and ``child_model`` should be the Page
+        classes being tested.
         """
         if not self._testCanCreateAt(parent_model, child_model):
             msg = self._formatMessage(msg, "Can not create a %s.%s under a %s.%s" % (
@@ -92,7 +93,8 @@ class WagtailPageTests(WagtailTestUtils, TestCase):
     def assertCanNotCreateAt(self, parent_model, child_model, msg=None):
         """
         Assert a particular child Page type can not be created under a parent
-        Page type.
+        Page type. ``parent_model`` and ``child_model`` should be the Page
+        classes being tested.
         """
         if self._testCanCreateAt(parent_model, child_model):
             msg = self._formatMessage(msg, "Can create a %s.%s under a %s.%s" % (
@@ -103,7 +105,11 @@ class WagtailPageTests(WagtailTestUtils, TestCase):
     def assertCanCreate(self, parent, child_model, data, msg=None):
         """
         Assert that a child of the given Page type can be created under the
-        parent, using the supplied POST data
+        parent, using the supplied POST data.
+
+        ``parent`` should be a Page instance, and ``child_model`` should be a
+        Page subclass. ``data`` should be a dict that will be POSTed at the
+        Wagtail admin Page creation method.
         """
         self.assertCanCreateAt(parent.specific_class, child_model)
 

--- a/wagtail/tests/utils.py
+++ b/wagtail/tests/utils.py
@@ -1,9 +1,17 @@
-from contextlib import contextmanager
-import warnings
+from __future__ import absolute_import, unicode_literals
+
 import sys
+import warnings
+from contextlib import contextmanager
 
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.core.urlresolvers import reverse
+from django.test import TestCase
 from django.utils import six
+from django.utils.text import slugify
+
+from wagtail.wagtailcore.models import Page
 
 
 class WagtailTestUtils(object):
@@ -51,3 +59,85 @@ class WagtailTestUtils(object):
         for mod in list(sys.modules.values()):
             if hasattr(mod, key):
                 getattr(mod, key).clear()
+
+
+class WagtailPageTests(WagtailTestUtils, TestCase):
+    """
+    A set of asserts to help write tests for your own Wagtail site.
+    """
+    def setUp(self):
+        super(WagtailPageTests, self).setUp()
+        self.login()
+
+    def _testCanCreateAt(self, parent_model, child_model):
+        child_ct = ContentType.objects.get_for_model(child_model)
+        parent_ct = ContentType.objects.get_for_model(parent_model)
+
+        return all([
+            child_ct in parent_model.allowed_subpage_types(),
+            # Anything can be created under a Page
+            parent_model is Page or parent_ct in child_model.allowed_parent_page_types()])
+
+    def assertCanCreateAt(self, parent_model, child_model, msg=None):
+        """
+        Assert a particular child Page type can be created under a parent
+        Page type.
+        """
+        if not self._testCanCreateAt(parent_model, child_model):
+            msg = self._formatMessage(msg, "Can not create a %s.%s under a %s.%s" % (
+                child_model._meta.app_label, child_model._meta.model_name,
+                parent_model._meta.app_label, parent_model._meta.model_name))
+            raise self.failureException(msg)
+
+    def assertCanNotCreateAt(self, parent_model, child_model, msg=None):
+        """
+        Assert a particular child Page type can not be created under a parent
+        Page type.
+        """
+        if self._testCanCreateAt(parent_model, child_model):
+            msg = self._formatMessage(msg, "Can create a %s.%s under a %s.%s" % (
+                child_model._meta.app_label, child_model._meta.model_name,
+                parent_model._meta.app_label, parent_model._meta.model_name))
+            raise self.failureException(msg)
+
+    def assertCanCreate(self, parent, child_model, data, msg=None):
+        """
+        Assert that a child of the given Page type can be created under the
+        parent, using the supplied POST data
+        """
+        self.assertCanCreateAt(parent.specific_class, child_model)
+
+        if 'slug' not in data and 'title' in data:
+            data['slug'] = slugify(data['title'])
+        data['action-publish'] = 'action-publish'
+
+        add_url = reverse('wagtailadmin_pages:add', args=[
+            child_model._meta.app_label, child_model._meta.model_name, parent.pk])
+        response = self.client.post(add_url, data, follow=True)
+
+        if response.status_code != 200:
+            msg = self._formatMessage(msg, 'Creating a %s.%s returned a %d' % (
+                child_model._meta.app_label, child_model._meta.model_name, response.status_code))
+            raise self.failureException(msg)
+
+        if response.redirect_chain == []:
+            if 'form' not in response.context:
+                msg = self._formatMessage(msg, 'Creating a page failed unusually')
+                raise self.failureException(msg)
+            form = response.context['form']
+            if not form.errors:
+                msg = self._formatMessage(msg, 'Creating a page failed for an unknown reason')
+                raise self.failureException(msg)
+
+            errors = '\n'.join('  %s:\n    %s' % (field, '\n    '.join(errors))
+                               for field, errors in sorted(form.errors.items()))
+            msg = self._formatMessage(msg, 'Validation errors found when creating a %s.%s:\n%s' % (
+                child_model._meta.app_label, child_model._meta.model_name, errors))
+            raise self.failureException(msg)
+
+        explore_url = 'http://testserver' + reverse('wagtailadmin_explore', args=[parent.pk])
+        if response.redirect_chain != [(explore_url, 302)]:
+            msg = self._formatMessage(msg, 'Creating a page %s.%s didnt redirect the user to the explorer, but to %s' % (
+                child_model._meta.app_label, child_model._meta.model_name,
+                response.redirect_chain))
+            raise self.failureException(msg)

--- a/wagtail/tests/utils.py
+++ b/wagtail/tests/utils.py
@@ -141,3 +141,31 @@ class WagtailPageTests(WagtailTestUtils, TestCase):
                 child_model._meta.app_label, child_model._meta.model_name,
                 response.redirect_chain))
             raise self.failureException(msg)
+
+    def assertAllowedSubpageTypes(self, parent_model, child_models, msg=None):
+        """
+        Test that the only page types that can be created under
+        ``parent_model`` are ``child_models``.
+
+        The list of allowed child models may differ from those set in
+        ``Page.subpage_types``, if the child models have set
+        ``Page.parent_page_types``.
+        """
+        self.assertEqual(
+            set(ct.model_class() for ct in parent_model.clean_subpage_types()),
+            set(child_models),
+            msg=msg)
+
+    def assertAllowedParentPageTypes(self, child_model, parent_models, msg=None):
+        """
+        Test that the only page types that ``child_model`` can be created under
+        are ``parent_models``.
+
+        The list of allowed parent models may differ from those set in
+        ``Page.parent_page_types``, if the parent models have set
+        ``Page.subpage_types``.
+        """
+        self.assertEqual(
+            set(ct.model_class() for ct in child_model.clean_parent_page_types()),
+            set(parent_models),
+            msg=None)

--- a/wagtail/wagtailcore/tests/test_tests.py
+++ b/wagtail/wagtailcore/tests/test_tests.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import, unicode_literals
+
+import json
+
+from wagtail.tests.testapp.models import (
+    BusinessChild, EventIndex, EventPage, SimplePage, StreamPage)
+from wagtail.tests.utils import WagtailPageTests
+from wagtail.wagtailcore.models import Page, Site
+
+
+class TestWagtailPageTests(WagtailPageTests):
+    def setUp(self):
+        super(TestWagtailPageTests, self).setUp()
+        site = Site.objects.get(is_default_site=True)
+        self.root = site.root_page.specific
+
+    def test_assert_can_create_at(self):
+        # It should be possible to create an EventPage under an EventIndex,
+        self.assertCanCreateAt(EventIndex, EventPage)
+        self.assertCanCreateAt(Page, EventIndex)
+        # It should not be possible to create a SimplePage under a BusinessChild
+        self.assertCanNotCreateAt(SimplePage, BusinessChild)
+
+        # This should raise, as it *is not* possible
+        with self.assertRaises(AssertionError):
+            self.assertCanCreateAt(SimplePage, BusinessChild)
+        # This should raise, as it *is* possible
+        with self.assertRaises(AssertionError):
+            self.assertCanNotCreateAt(EventIndex, EventPage)
+
+    def test_assert_can_create(self):
+
+        self.assertFalse(EventIndex.objects.exists())
+        self.assertCanCreate(self.root, EventIndex, {
+            'title': 'Event Index',
+            'intro': '<p>Event intro</p>'})
+        self.assertTrue(EventIndex.objects.exists())
+
+        self.assertCanCreate(self.root, StreamPage, {
+            'title': 'WebDev42',
+            'body': json.dumps([
+                {'type': 'text', 'value': 'Some text'},
+                {'type': 'rich_text', 'value': '<p>Some rich text</p>'},
+            ])})
+
+    def test_assert_can_create_subpage_rules(self):
+        simple_page = SimplePage(title='Simple Page', slug='simple')
+        self.root.add_child(instance=simple_page)
+        # This should raise an error, as a BusinessChild can not be created under a SimplePage
+        with self.assertRaisesRegexp(AssertionError, r'Can not create a tests.businesschild under a tests.simplepage'):
+            self.assertCanCreate(simple_page, BusinessChild, {})
+
+    def test_assert_can_create_validation_error(self):
+        # This should raise some validation errors, complaining about missing
+        # title and slug fields
+        with self.assertRaisesRegexp(AssertionError, r'\bslug:\n[\s\S]*\btitle:\n'):
+            self.assertCanCreate(self.root, SimplePage, {})

--- a/wagtail/wagtailcore/tests/test_tests.py
+++ b/wagtail/wagtailcore/tests/test_tests.py
@@ -3,9 +3,10 @@ from __future__ import absolute_import, unicode_literals
 import json
 
 from django.utils import six
+
 from wagtail.tests.testapp.models import (
-    BusinessChild, BusinessIndex, BusinessSubIndex, EventIndex, EventPage,
-    SimplePage, StreamPage)
+    BusinessChild, BusinessIndex, BusinessNowherePage, BusinessSubIndex,
+    EventIndex, EventPage, SimplePage, StreamPage)
 from wagtail.tests.utils import WagtailPageTests
 from wagtail.wagtailcore.models import PAGE_MODEL_CLASSES, Page, Site
 
@@ -67,13 +68,21 @@ class TestWagtailPageTests(WagtailPageTests):
     def test_assert_allowed_subpage_types(self):
         self.assertAllowedSubpageTypes(BusinessIndex, {BusinessChild, BusinessSubIndex})
         self.assertAllowedSubpageTypes(BusinessChild, {})
-        self.assertAllowedSubpageTypes(Page, PAGE_MODEL_CLASSES)
+        # The only page types that have rules are the Business pages. As such,
+        # everything can be created under the Page model except some of the
+        # Business pages
+        all_but_business = set(PAGE_MODEL_CLASSES) - {BusinessSubIndex, BusinessChild, BusinessNowherePage}
+        self.assertAllowedSubpageTypes(Page, all_but_business)
         with self.assertRaises(AssertionError):
             self.assertAllowedSubpageTypes(BusinessSubIndex, {BusinessSubIndex, BusinessChild})
 
     def test_assert_allowed_parent_page_types(self):
         self.assertAllowedParentPageTypes(BusinessChild, {BusinessIndex, BusinessSubIndex})
         self.assertAllowedParentPageTypes(BusinessSubIndex, {BusinessIndex})
-        self.assertAllowedParentPageTypes(BusinessIndex, PAGE_MODEL_CLASSES)
+        # The only page types that have rules are the Business pages. As such,
+        # a BusinessIndex can be created everywhere except under the other
+        # Business pages.
+        all_but_business = set(PAGE_MODEL_CLASSES) - {BusinessSubIndex, BusinessChild, BusinessIndex}
+        self.assertAllowedParentPageTypes(BusinessIndex, all_but_business)
         with self.assertRaises(AssertionError):
             self.assertAllowedParentPageTypes(BusinessSubIndex, {BusinessSubIndex, BusinessIndex})

--- a/wagtail/wagtailcore/tests/test_tests.py
+++ b/wagtail/wagtailcore/tests/test_tests.py
@@ -2,10 +2,12 @@ from __future__ import absolute_import, unicode_literals
 
 import json
 
+from django.utils import six
 from wagtail.tests.testapp.models import (
-    BusinessChild, EventIndex, EventPage, SimplePage, StreamPage)
+    BusinessChild, BusinessIndex, BusinessSubIndex, EventIndex, EventPage,
+    SimplePage, StreamPage)
 from wagtail.tests.utils import WagtailPageTests
-from wagtail.wagtailcore.models import Page, Site
+from wagtail.wagtailcore.models import PAGE_MODEL_CLASSES, Page, Site
 
 
 class TestWagtailPageTests(WagtailPageTests):
@@ -13,6 +15,12 @@ class TestWagtailPageTests(WagtailPageTests):
         super(TestWagtailPageTests, self).setUp()
         site = Site.objects.get(is_default_site=True)
         self.root = site.root_page.specific
+
+    def assertRaisesRegex(self, *args, **kwargs):
+        if six.PY3:
+            return super(TestWagtailPageTests, self).assertRaisesRegex(*args, **kwargs)
+        else:
+            return self.assertRaisesRegexp(*args, **kwargs)
 
     def test_assert_can_create_at(self):
         # It should be possible to create an EventPage under an EventIndex,
@@ -47,11 +55,25 @@ class TestWagtailPageTests(WagtailPageTests):
         simple_page = SimplePage(title='Simple Page', slug='simple')
         self.root.add_child(instance=simple_page)
         # This should raise an error, as a BusinessChild can not be created under a SimplePage
-        with self.assertRaisesRegexp(AssertionError, r'Can not create a tests.businesschild under a tests.simplepage'):
+        with self.assertRaisesRegex(AssertionError, r'Can not create a tests.businesschild under a tests.simplepage'):
             self.assertCanCreate(simple_page, BusinessChild, {})
 
     def test_assert_can_create_validation_error(self):
         # This should raise some validation errors, complaining about missing
         # title and slug fields
-        with self.assertRaisesRegexp(AssertionError, r'\bslug:\n[\s\S]*\btitle:\n'):
+        with self.assertRaisesRegex(AssertionError, r'\bslug:\n[\s\S]*\btitle:\n'):
             self.assertCanCreate(self.root, SimplePage, {})
+
+    def test_assert_allowed_subpage_types(self):
+        self.assertAllowedSubpageTypes(BusinessIndex, {BusinessChild, BusinessSubIndex})
+        self.assertAllowedSubpageTypes(BusinessChild, {})
+        self.assertAllowedSubpageTypes(Page, PAGE_MODEL_CLASSES)
+        with self.assertRaises(AssertionError):
+            self.assertAllowedSubpageTypes(BusinessSubIndex, {BusinessSubIndex, BusinessChild})
+
+    def test_assert_allowed_parent_page_types(self):
+        self.assertAllowedParentPageTypes(BusinessChild, {BusinessIndex, BusinessSubIndex})
+        self.assertAllowedParentPageTypes(BusinessSubIndex, {BusinessIndex})
+        self.assertAllowedParentPageTypes(BusinessIndex, PAGE_MODEL_CLASSES)
+        with self.assertRaises(AssertionError):
+            self.assertAllowedParentPageTypes(BusinessSubIndex, {BusinessSubIndex, BusinessIndex})


### PR DESCRIPTION
`wagtail.tests.utils.WagtailPageTests` is a new `TestCase` subclass that helps developers write tests for their Wagtail sites. It currently includes three assert methods:

`assertCanCreateAt(parent_model, child_model)`, which asserts that a child page of a certain type could be created underneath a parent page. This is useful for making assertions around the business rules of your site.

`assertCanNotCreateAt(parent_model, child_model)` is the inverse of the above.

`assertCanCreate(parent, child_model, data)` asserts that a child page can be added underneath the given parent page, by POSTing `data` at the correct page in the Wagtail admin. This checks that the developer has correctly configured their `content_panels` and related options.

These methods are just a start, and could be expanded further. More methods could be added, asserting that Snippets can be created, for example. The current methods could be extended further, to validate more about the Wagtail admin page editor.