### PR TITLE
Issue #1638: The (admin) search bar only searches for pages

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -195,6 +195,35 @@ The available hooks are:
       if request.user.username == 'frank':
         menu_items[:] = [item for item in menu_items if item.name != 'explorer']
 
+.. _register_admin_search_area:
+
+``register_admin_search_area``
+
+  Add an item to the Wagtail admin search "Other Searches". Behaviour of this hook is similar to ``register_admin_menu_item``. The callable passed to this hook must return an instance of ``wagtail.wagtailadmin.search.SearchArea``. New items can be constructed from the ``SearchArea`` class by passing the following parameters:
+
+  :label: text displayed in the "Other Searches" option box.
+  :name: an internal name used to identify the search option; defaults to the slugified form of the label.
+  :url: the URL of the target search page.
+  :classnames: additional CSS classnames applied to the link, used to give it an icon.
+  :attrs: additional HTML attributes to apply to the link.
+  :order: an integer which determines the item's position in the list of options.
+
+  Setting the URL can be achieved using reverse() on the target search page. The GET parameter 'q' will appended to the given URL.
+
+  A template tag, ``search_other`` is provided by the ``wagtailadmin_tags`` template module. This tag takes a single, optional parameter, ``current``, which allows you to specify the ``name`` of the search option currently active. If the parameter is not given, the hook defaults to a reverse lookup of the page's URL for comparison against the ``url`` parameter.
+
+
+  ``SearchArea`` can be subclassed to customise the HTML output, specify Javascript files required by the option, or conditionally show or hide the item for specific requests (for example, to apply permission checks); see the source code (``wagtail/wagtailadmin/search.py``) for details.
+
+  .. code-block:: python
+
+    from django.core.urlresolvers import reverse
+    from wagtail.wagtailcore import hooks
+    from wagtail.wagtailadmin.search import SearchArea
+
+    @hooks.register('register_admin_search_area')
+    def register_frank_search_area():
+      return SearchArea('Frank', reverse('frank'), classnames='icon icon-folder-inverse', order=10000)
 
 .. _insert_editor_js:
 

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -208,7 +208,7 @@ The available hooks are:
   :attrs: additional HTML attributes to apply to the link.
   :order: an integer which determines the item's position in the list of options.
 
-  Setting the URL can be achieved using reverse() on the target search page. The GET parameter 'q' will appended to the given URL.
+  Setting the URL can be achieved using reverse() on the target search page. The GET parameter 'q' will be appended to the given URL.
 
   A template tag, ``search_other`` is provided by the ``wagtailadmin_tags`` template module. This tag takes a single, optional parameter, ``current``, which allows you to specify the ``name`` of the search option currently active. If the parameter is not given, the hook defaults to a reverse lookup of the page's URL for comparison against the ``url`` parameter.
 

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -3,6 +3,7 @@ from django.http import HttpResponse
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.whitelist import attribute_rule, check_url, allow_without_attributes
 from wagtail.wagtailadmin.menu import MenuItem
+from wagtail.wagtailadmin.search import SearchArea
 
 
 # Register one hook using decorators...
@@ -38,3 +39,22 @@ class KittensMenuItem(MenuItem):
 @hooks.register('register_admin_menu_item')
 def register_kittens_menu_item():
     return KittensMenuItem('Kittens!', 'http://www.tomroyal.com/teaandkittens/', classnames='icon icon-kitten', attrs={'data-fluffy': 'yes'}, order=10000)
+
+
+# Admin Other Searches hook
+class MyCustomSearchArea(SearchArea):
+    def is_shown(self, request):
+        return not request.GET.get('hide-option', False)
+
+    def is_active(self, request, current=None):
+        return request.GET.get('active-option', False)
+
+
+@hooks.register('register_admin_search_area')
+def register_custom_search_area():
+    return MyCustomSearchArea(
+        'My Search',
+        '/customsearch/',
+        classnames='icon icon-custom',
+        attrs={'is-custom': 'true'},
+        order=10000)

--- a/wagtail/wagtailadmin/search.py
+++ b/wagtail/wagtailadmin/search.py
@@ -1,0 +1,103 @@
+from __future__ import unicode_literals
+
+from django.forms import MediaDefiningClass, Media
+from django.forms.utils import flatatt
+from django.utils.text import slugify
+from django.utils.safestring import mark_safe
+from django.utils.six import text_type
+
+from django.utils.six import with_metaclass
+
+from wagtail.utils.compat import render_to_string
+from wagtail.wagtailcore import hooks
+from wagtail.wagtailadmin.forms import SearchForm
+
+
+class SearchArea(with_metaclass(MediaDefiningClass)):
+    template = 'wagtailadmin/shared/search_area.html'
+
+    def __init__(self, label, url, name=None, classnames='', attrs=None, order=1000):
+        self.label = label
+        self.url = url
+        self.classnames = classnames
+        self.name = (name or slugify(text_type(label)))
+        self.order = order
+
+        if attrs:
+            self.attr_string = flatatt(attrs)
+        else:
+            self.attr_string = ""
+
+    def is_shown(self, request):
+        """
+        Whether this search area should be shown for the given request; permission
+        checks etc should go here. By default, search areas are shown all the time
+        """
+        return True
+
+    def is_active(self, request):
+        return request.path.startswith(self.url)
+
+    def render_html(self, request, query):
+        return render_to_string(self.template, {
+            'name': self.name,
+            'url': self.url,
+            'classnames': self.classnames,
+            'attr_string': self.attr_string,
+            'label': self.label,
+            'active': self.is_active(request),
+            'query_string': query
+        }, request=request)
+
+
+class Search(object):
+    def __init__(self, register_hook_name, construct_hook_name=None):
+        self.register_hook_name = register_hook_name
+        self.construct_hook_name = construct_hook_name
+        # _registered_search_areas will be populated on first access to the
+        # registered_search_areas property. We can't populate it in __init__ because
+        # we can't rely on all hooks modules to have been imported at the point that
+        # we create the admin_search and settings_search instances
+        self._registered_search_areas = None
+
+    @property
+    def registered_search_areas(self):
+        if self._registered_search_areas is None:
+            self._registered_search_areas = [fn() for fn in hooks.get_hooks(self.register_hook_name)]
+        return self._registered_search_areas
+
+    def search_items_for_request(self, request):
+        return [item for item in self.registered_search_areas if item.is_shown(request)]
+
+    def active_search(self, request):
+        return [item for item in self.search_items_for_request(request) if item.is_active(request)]
+
+    @property
+    def media(self):
+        media = Media()
+        for item in self.registered_search_areas:
+            media += item.media
+        return media
+
+    def render_html(self, request):
+        search_areas = self.search_items_for_request(request)
+
+        # Get query parameter
+        form = SearchForm(request.GET)
+        query = ''
+        if form.is_valid():
+            query = form.cleaned_data['q']
+
+        # provide a hook for modifying the search area, if construct_hook_name has been set
+        if self.construct_hook_name:
+            for fn in hooks.get_hooks(self.construct_hook_name):
+                fn(request, search_areas)
+
+        rendered_search_areas = []
+        for item in sorted(search_areas, key=lambda i: i.order):
+            rendered_search_areas.append(item.render_html(request, query))
+
+        return mark_safe(''.join(rendered_search_areas))
+
+
+admin_search_areas = Search(register_hook_name='register_admin_search_area', construct_hook_name='construct_search')

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/search_results.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/search_results.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 <div class="nice-padding">
     {% if pages %}
         <h2>
@@ -9,14 +9,7 @@
             {% endblocktrans %}
         </h2>
 
-        <nav class="listing-filter">
-            <h3 class="filter-title">{% trans "Other searches" %}</h3>
-            <ul class="filter-options">
-                <li><a href="{% url 'wagtailimages:index' %}?q={{ query_string|urlencode }}" class="icon icon-image">{% trans "Images" %}</a></li>
-                <li><a href="{% url 'wagtaildocs:index' %}?q={{ query_string|urlencode }}" class="icon icon-doc-full-inverse">{% trans "Documents" %}</a></li>
-                <li><a href="{% url 'wagtailusers_users:index' %}?q={{ query_string|urlencode }}" class="icon icon-user">{% trans "Users" %}</a></li>
-            </ul>
-        </nav>
+        {% search_other %}
 
         {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 allow_navigation=0 %}
 
@@ -24,7 +17,9 @@
         {% include "wagtailadmin/pages/listing/_pagination.html" with page=pages base_url=pagination_base_url query_params=pagination_query_params only %}
     {% else %}
         {% if query_string %}
-            <p>{% blocktrans %}Sorry, no pages match <em>"{{ query_string }}"</em>{% endblocktrans %}</p>
+            <h2>{% blocktrans %}Sorry, no pages match <em>"{{ query_string }}"</em>{% endblocktrans %}</h2>
+            
+            {% search_other %}
         {% else %}
             <p>{% trans 'Enter a search term above' %}</p>
         {% endif %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/search_area.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/search_area.html
@@ -1,0 +1,6 @@
+{% if not active %}
+    <li>
+        <a href="{{ url  }}?q={{ query_string|urlencode }}" class="{{ classnames }}"{{ attr_string }}>{{ label }}</a>
+     </li>
+ {% endif %}
+ 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/search_area.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/search_area.html
@@ -1,6 +1,3 @@
-{% if not active %}
-    <li>
-        <a href="{{ url  }}?q={{ query_string|urlencode }}" class="{{ classnames }}"{{ attr_string }}>{{ label }}</a>
-     </li>
- {% endif %}
- 
+<li>
+    <a href="{{ url }}?q={{ query_string|urlencode }}" class="{{ classnames }}{% if active %} nolink{% endif %}"{{ attr_string }}>{{ label }}</a>
+</li>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/search_other.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/search_other.html
@@ -1,0 +1,7 @@
+{% load i18n %}
+<nav class="listing-filter">
+    <h3 class="filter-title">{% trans "Other searches" %}</h3>
+    <ul class="filter-options">
+        {{ options_html }}
+    </ul>
+</nav>

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -42,12 +42,11 @@ def main_nav(context):
 
 
 @register.inclusion_tag('wagtailadmin/shared/search_other.html', takes_context=True)
-def search_other(context, query):
+def search_other(context):
     request = context['request']
 
     return {
         'options_html': admin_search_areas.render_html(request),
-        'query_string': query,
         'request': request,
     }
 

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -10,6 +10,7 @@ from wagtail.wagtailcore.models import get_navigation_menu_items, UserPagePermis
 from wagtail.wagtailcore.utils import camelcase_to_underscore, escape_script
 from wagtail.wagtailcore.utils import cautious_slugify as _cautious_slugify
 from wagtail.wagtailadmin.menu import admin_menu
+from wagtail.wagtailadmin.search import admin_search_areas
 
 
 register = template.Library()
@@ -38,6 +39,18 @@ def main_nav(context):
         'menu_html': admin_menu.render_html(request),
         'request': request,
     }
+
+
+@register.inclusion_tag('wagtailadmin/shared/search_other.html', takes_context=True)
+def search_other(context, query):
+    request = context['request']
+
+    return {
+        'options_html': admin_search_areas.render_html(request),
+        'query_string': query,
+        'request': request,
+    }
+
 
 @register.simple_tag
 def main_nav_js():

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -42,11 +42,11 @@ def main_nav(context):
 
 
 @register.inclusion_tag('wagtailadmin/shared/search_other.html', takes_context=True)
-def search_other(context):
+def search_other(context, current=None):
     request = context['request']
 
     return {
-        'options_html': admin_search_areas.render_html(request),
+        'options_html': admin_search_areas.render_html(request, current),
         'request': request,
     }
 

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -1128,6 +1128,25 @@ class TestPageSearch(TestCase, WagtailTestUtils):
         results = response.context['pages']
         self.assertTrue(any([r.slug == 'root' for r in results]))
 
+    def test_other_searches(self):
+        query = "Hello"
+        base_css = "icon icon-custom"
+        test_string = '<a href="/customsearch/?q=%s" class="%s" is-custom="true">My Search</a>'
+        # Testing the option link exists
+        response = self.get({'q': query})
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/pages/search.html')
+        self.assertTemplateUsed(response, 'wagtailadmin/shared/search_area.html')
+        self.assertContains(response, test_string % (query, base_css), html=True)
+
+        # Testing is_shown
+        response = self.get({'q': query, 'hide-option': "true"})
+        self.assertNotContains(response, test_string % (query, base_css), status_code=200, html=True)
+
+        # Testing is_active
+        response = self.get({'q': query, 'active-option': "true"})
+        self.assertContains(response, test_string % (query, base_css + " nolink"), status_code=200, html=True)
+
 
 class TestPageMove(TestCase, WagtailTestUtils):
     def setUp(self):

--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -4,6 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailadmin.menu import MenuItem, SubmenuMenuItem, settings_menu
+from wagtail.wagtailadmin.search import SearchArea
 
 
 class ExplorerMenuItem(MenuItem):
@@ -30,3 +31,16 @@ def register_settings_menu():
 @hooks.register('register_permissions')
 def register_permissions():
     return Permission.objects.filter(content_type__app_label='wagtailadmin', codename='access_admin')
+
+
+class PagesSearchArea(SearchArea):
+    pass
+
+
+@hooks.register('register_admin_search_area')
+def register_pages_search_area():
+    return PagesSearchArea(
+        _('Pages'), urlresolvers.reverse('wagtailadmin_pages:search'),
+        name='pages',
+        classnames='icon icon-folder-open-inverse',
+        order=100)

--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -33,13 +33,9 @@ def register_permissions():
     return Permission.objects.filter(content_type__app_label='wagtailadmin', codename='access_admin')
 
 
-class PagesSearchArea(SearchArea):
-    pass
-
-
 @hooks.register('register_admin_search_area')
 def register_pages_search_area():
-    return PagesSearchArea(
+    return SearchArea(
         _('Pages'), urlresolvers.reverse('wagtailadmin_pages:search'),
         name='pages',
         classnames='icon icon-folder-open-inverse',

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/results.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/results.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 {% if documents %}
     {% if is_searching %}
         <h2>
@@ -8,6 +8,8 @@
             There are {{ counter }} matches
         {% endblocktrans %}
         </h2>
+        
+        {% search_other %}
     {% endif %}
 
     {% include "wagtaildocs/documents/list.html" %}
@@ -15,7 +17,9 @@
     {% include "wagtailadmin/shared/pagination_nav.html" with items=documents is_searching=is_searching linkurl="wagtaildocs:index" %}
 {% else %}
     {% if is_searching %}
-         <p>{% blocktrans %}Sorry, no documents match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
+         <h2>{% blocktrans %}Sorry, no documents match "<em>{{ query_string }}</em>"{% endblocktrans %}</h2>
+         
+         {% search_other %}
     {% else %}
         {% url 'wagtaildocs:add' as wagtaildocs_add_document_url %}
         <p>{% blocktrans %}You haven't uploaded any documents. Why not <a href="{{ wagtaildocs_add_document_url }}">upload one now</a>?{% endblocktrans %}</p>

--- a/wagtail/wagtaildocs/wagtail_hooks.py
+++ b/wagtail/wagtaildocs/wagtail_hooks.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import Permission
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailadmin.site_summary import SummaryItem
+from wagtail.wagtailadmin.search import SearchArea
 
 from wagtail.wagtaildocs import admin_urls
 from wagtail.wagtaildocs.models import Document
@@ -75,3 +76,17 @@ class DocumentsSummaryItem(SummaryItem):
 @hooks.register('construct_homepage_summary_items')
 def add_documents_summary_item(request, items):
     items.append(DocumentsSummaryItem(request))
+
+
+class DocsSearchArea(SearchArea):
+    def is_shown(self, request):
+        return request.user.has_perm('wagtaildocs.add_document') or request.user.has_perm('wagtaildocs.change_document')
+
+
+@hooks.register('register_admin_search_area')
+def register_documents_search_area():
+    return DocsSearchArea(
+        _('Documents'), urlresolvers.reverse('wagtaildocs:index'),
+        name='documents',
+        classnames='icon icon-doc-full-inverse',
+        order=400)

--- a/wagtail/wagtailimages/templates/wagtailimages/images/results.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/results.html
@@ -9,6 +9,8 @@
             There are {{ counter }} matches
         {% endblocktrans %}
         </h2>
+        
+        {% search_other %}
     {% else %}
         <h2>{% trans "Latest images" %}</h2>
     {% endif %}
@@ -28,7 +30,9 @@
 
 {% else %}
     {% if is_searching %}
-        <p>{% blocktrans %}Sorry, no images match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
+        <h2>{% blocktrans %}Sorry, no images match "<em>{{ query_string }}</em>"{% endblocktrans %}</h2>
+        
+        {% search_other %}
     {% else %}
         {% url 'wagtailimages:add_multiple' as wagtailimages_add_image_url %}
         <p>{% blocktrans %}You've not uploaded any images. Why not <a href="{{ wagtailimages_add_image_url }}">add one now</a>?{% endblocktrans %}</p>

--- a/wagtail/wagtailimages/wagtail_hooks.py
+++ b/wagtail/wagtailimages/wagtail_hooks.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import Permission
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailadmin.site_summary import SummaryItem
+from wagtail.wagtailadmin.search import SearchArea
 
 from wagtail.wagtailimages import admin_urls, image_operations
 from wagtail.wagtailimages.models import get_image_model
@@ -87,3 +88,17 @@ class ImagesSummaryItem(SummaryItem):
 @hooks.register('construct_homepage_summary_items')
 def add_images_summary_item(request, items):
     items.append(ImagesSummaryItem(request))
+
+
+class ImagesSearchArea(SearchArea):
+    def is_shown(self, request):
+        return request.user.has_perm('wagtailimages.add_image') or request.user.has_perm('wagtailimages.change_image')
+
+
+@hooks.register('register_admin_search_area')
+def register_images_search_area():
+    return ImagesSearchArea(
+        _('Images'), urlresolvers.reverse('wagtailimages:index'),
+        name='images',
+        classnames='icon icon-image',
+        order=200)

--- a/wagtail/wagtailusers/templates/wagtailusers/users/results.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/results.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 {% if users %}
     {% if is_searching %}
         <h2>
@@ -8,6 +8,8 @@
             There are {{ counter }} matches
         {% endblocktrans %}
         </h2>
+        
+        {% search_other %}
     {% endif %}
 
     {% include "wagtailusers/users/list.html" %}
@@ -15,7 +17,9 @@
     {% include "wagtailadmin/shared/pagination_nav.html" with items=users is_searching=is_searching linkurl="wagtailusers_users:index" %}
 {% else %}
     {% if is_searching %}
-         <p>{% blocktrans %}Sorry, no users match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
+         <h2>{% blocktrans %}Sorry, no users match "<em>{{ query_string }}</em>"{% endblocktrans %}</h2>
+         
+         {% search_other %}
     {% else %}
         {% url 'wagtailusers_create' as wagtailusers_create_url %}
         <p>{% blocktrans %}There are no users configured. Why not <a href="{{ wagtailusers_create_url }}">add some</a>?{% endblocktrans %}</p>

--- a/wagtail/wagtailusers/wagtail_hooks.py
+++ b/wagtail/wagtailusers/wagtail_hooks.py
@@ -7,6 +7,7 @@ from django.utils.translation import ugettext_lazy as _
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
 from wagtail.wagtailadmin.menu import MenuItem
+from wagtail.wagtailadmin.search import SearchArea
 
 from wagtail.wagtailusers.urls import users, groups
 
@@ -65,3 +66,21 @@ def register_permissions():
     group_permissions = Q(content_type__app_label='auth', codename__in=['add_group', 'change_group', 'delete_group'])
 
     return Permission.objects.filter(user_permissions | group_permissions)
+
+
+class UsersSearchArea(SearchArea):
+    def is_shown(self, request):
+        return (
+            request.user.has_perm(add_user_perm)
+            or request.user.has_perm(change_user_perm)
+            or request.user.has_perm(delete_user_perm)
+        )
+
+
+@hooks.register('register_admin_search_area')
+def register_users_search_area():
+    return UsersSearchArea(
+        _('Users'), urlresolvers.reverse('wagtailusers_users:index'),
+        name='users',
+        classnames='icon icon-user',
+        order=600)


### PR DESCRIPTION
First (ever) pull request, so advice/guidance/feedback appreciated.

This is a fix for issue #1638, but might be a bit over the top. Originally I had just planned to tweak the template, but once I realised each app/module had its own search template I thought I'd try to go for something a bit more generic than a static template snippet.

So, borrowing/cloning the implementation of the menu hooks, I added a new hook for modules to offer their search page as an option in the "Other Searches" block:

![image](https://cloud.githubusercontent.com/assets/5417877/10334116/7aa7f4a0-6d2b-11e5-8f0c-5c9cdf99e047.png)


Regarding the core of the issue, the "other searches" option now shows itself both if there are and aren't results returned (but not if it's a blank search) and the "other searches" shows on each apps/modules search page via a template tag (search_other).

While the hook contains a fair bit of duplicate code from the menu hook, it didn't feel appropriate to just utilise the existing hook model. In future it could be expanded to provide a unified admin search page.

Anyway, this went a bit further than I was planning to on my first contribution. Hopefully the implementation isn't too bad.