### PR TITLE
Avoid auto-updating slug on live pages

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -303,15 +303,19 @@ function cleanForSlug(val, useURLify) {
 }
 
 function initSlugAutoPopulate() {
+    var slugFollowsTitle = false;
+
     $('#id_title').on('focus', function() {
-        $('#id_slug').data('previous-val', $('#id_slug').val());
-        $(this).data('previous-val', $(this).val());
+        /* slug should only follow the title field if its value matched the title's value at the time of focus */
+        var currentSlug = $('#id_slug').val();
+        var slugifiedTitle = cleanForSlug(this.value);
+        slugFollowsTitle = (currentSlug == slugifiedTitle);
     });
 
     $('#id_title').on('keyup keydown keypress blur', function() {
-        if ($('body').hasClass('create') || (!$('#id_slug').data('previous-val').length || cleanForSlug($('#id_title').data('previous-val')) === $('#id_slug').data('previous-val'))) {
-            // only update slug if the page is being created from scratch, if slug is completely blank, or if title and slug prior to typing were identical
-            $('#id_slug').val(cleanForSlug($('#id_title').val()));
+        if (slugFollowsTitle) {
+            var slugifiedTitle = cleanForSlug(this.value);
+            $('#id_slug').val(slugifiedTitle);
         }
     });
 }
@@ -364,7 +368,10 @@ function initCollapsibleBlocks() {
 }
 
 $(function() {
-    initSlugAutoPopulate();
+    /* Only non-live pages should auto-populate the slug from the title */
+    if (!$('body').hasClass('page-is-live')) {
+        initSlugAutoPopulate();
+    }
     initSlugCleaning();
     initErrorDetection();
     initCollapsibleBlocks();

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -3,7 +3,7 @@
 {% load gravatar %}
 {% load i18n %}
 {% block titletag %}{% blocktrans with title=page.title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }}: {{ title }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}page-editor model-{{ content_type.model }}{% endblock %}
+{% block bodyclass %}page-editor {% if page.live %}page-is-live{% endif %} model-{{ content_type.model }}{% endblock %}
 
 {% block content %}
     {% page_permissions page as page_perms %}


### PR DESCRIPTION
Fixes #528

Rewrite the initSlugAutoPopulate function so that the slug only tracks the
title field if the page is unpublished, AND the current slug matches the
title (indicating that it has not been edited manually, either in this editing
session or a previous one).