### PR TITLE
Fix JavaScript style error causing CI failures

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -237,9 +237,9 @@ function InlinePanel(opts) {
             var addButton = $('#' + opts.formsetPrefix + '-ADD');
 
             if (forms.length >= opts.maxForms) {
-                addButton.addClass("disabled");
+                addButton.addClass('disabled');
             } else {
-                addButton.removeClass("disabled");
+                addButton.removeClass('disabled');
             }
         }
     };


### PR DESCRIPTION
The Drone JS style checker was complaining about the bad quotes.