### PR TITLE
Add site name to sites

### DIFF
--- a/wagtail/wagtailcore/migrations/0020_add_site_name.py
+++ b/wagtail/wagtailcore/migrations/0020_add_site_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0019_verbose_names_cleanup'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='site',
+            name='site_name',
+            field=models.CharField(db_index=True, verbose_name='Site name', null=True, blank=True, max_length=255, help_text="Human-readable name for the site."),
+        ),
+    ]

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -58,9 +58,30 @@ class SiteManager(models.Manager):
 @python_2_unicode_compatible
 class Site(models.Model):
     hostname = models.CharField(verbose_name=_('Hostname'), max_length=255, db_index=True)
-    port = models.IntegerField(verbose_name=_('Port'), default=80, help_text=_("Set this to something other than 80 if you need a specific port number to appear in URLs (e.g. development on port 8000). Does not affect request handling (so port forwarding still works)."))
+    port = models.IntegerField(
+        verbose_name=_('Port'),
+        default=80,
+        help_text=_(
+            "Set this to something other than 80 if you need a specific port number to appear in URLs (e.g. "
+            "development on port 8000). Does not affect request handling (so port forwarding still works)."
+        )
+    )
+    site_name = models.CharField(
+        verbose_name=_('Site name'),
+        max_length=255,
+        db_index=True,
+        null=True,
+        blank=True,
+        help_text=_("Human-readable name for the site.")
+    )
     root_page = models.ForeignKey('Page', verbose_name=_('Root page'), related_name='sites_rooted_here')
-    is_default_site = models.BooleanField(verbose_name=_('Is default site'), default=False, help_text=_("If true, this site will handle requests for all other hostnames that do not have a site entry of their own"))
+    is_default_site = models.BooleanField(
+        verbose_name=_('Is default site'),
+        default=False,
+        help_text=_(
+            "If true, this site will handle requests for all other hostnames that do not have a site entry of their own"
+        )
+    )
 
     class Meta:
         unique_together = ('hostname', 'port')

--- a/wagtail/wagtailsites/forms.py
+++ b/wagtail/wagtailsites/forms.py
@@ -16,4 +16,4 @@ class SiteForm(forms.ModelForm):
 
     class Meta:
         model = Site
-        fields = ('hostname', 'port', 'root_page', 'is_default_site')
+        fields = ('hostname', 'port', 'site_name', 'root_page', 'is_default_site')

--- a/wagtail/wagtailsites/templates/wagtailsites/index.html
+++ b/wagtail/wagtailsites/templates/wagtailsites/index.html
@@ -16,6 +16,7 @@
                             {% endif %}
                         </th>
                         <th class="port">{% trans "Port" %}</th>
+                        <th class="site-name">{% trans "Site name" %}</th>
                         <th class="root-page">{% trans "Root page" %}</th>
                         <th class="is-default-site">{% trans "Default?" %}</th>
                     </tr>
@@ -29,6 +30,9 @@
                                 </h2>
                             </td>
                             <td class="port">{{ site.port }}</td>
+                            <td class="site-name">
+                                {% if site.site_name %}{{ site.site_name }}{% endif %}
+                            </td>
                             <td class="root-page">{{ site.root_page }}</td>
                             <td class="is-default-site">
                                 {% if site.is_default_site %}<div class="status-tag primary">{% trans "Default" %}</div>{% endif %}


### PR DESCRIPTION
This PR addresses #1194. Right now this PR simply adds `site_name` to the `Site` model and form.

As #1194 is currently labeled "For team discussion" here are some thoughts of mine:

* Should `site_name` be mandatory? If yes, what do you think about the migration/initial data? Simply use `hostname`?
* How do you think about the field ordering? If it were mandatory I would put it at first position.
* Should the page explorer show the site a page belongs to? At least on the root pages authors could benefit from this contextual information.
* I think there is a semantic impact on `WAGTAIL_SITE_NAME`. It now has a more generic meaning for the whole wagtail instance as every site has its own name. Nevertheless I kept the usages "as is", because I found it only used at the admin home screen, which is "instance-wide". Perhaps the setting should be renamed in a future release.