### PR TITLE
Allow custom ordering in search

### DIFF
--- a/docs/topics/search/searching.rst
+++ b/docs/topics/search/searching.rst
@@ -138,7 +138,6 @@ Here's an example of using the "operator" keyword argument:
     # Only "hello world" returned as that's the only item that contains both terms
     [<Thing: Hello world>]
 
-
 For page, image and document models, the ``operator`` keyword argument is also supported on the QuerySet's ``search`` method:
 
 .. code-block:: python
@@ -147,6 +146,24 @@ For page, image and document models, the ``operator`` keyword argument is also s
 
     # All pages containing either "hello" or "world" are returned
     [<Page: Hello World>, <Page: Hello>, <Page: World>]
+
+
+Custom ordering
+^^^^^^^^^^^^^^^
+
+.. versionadded:: 1.2
+
+By default, search results are ordered by relevance, if the backend supports it. To order by a custom field, the ``order_by_relevance`` keyword argument needs to be set to ``False`` on the ``search()`` method.
+
+For example:
+
+.. code-block:: python
+
+    # Get a list of events ordered by date
+    >>> EventPage.objects.order_by('date').search("Event", order_by_relevance=False)
+
+    # Events ordered by date
+    [<EventPage: Easter>, <EventPage: Haloween>, <EventPage: Christmas>]
 
 
 .. _wagtailsearch_frontend_views:

--- a/docs/topics/search/searching.rst
+++ b/docs/topics/search/searching.rst
@@ -153,7 +153,7 @@ Custom ordering
 
 .. versionadded:: 1.2
 
-By default, search results are ordered by relevance, if the backend supports it. To order by a custom field, the ``order_by_relevance`` keyword argument needs to be set to ``False`` on the ``search()`` method.
+By default, search results are ordered by relevance, if the backend supports it. To preserve the QuerySet's existing ordering, the ``order_by_relevance`` keyword argument needs to be set to ``False`` on the ``search()`` method.
 
 For example:
 
@@ -163,7 +163,7 @@ For example:
     >>> EventPage.objects.order_by('date').search("Event", order_by_relevance=False)
 
     # Events ordered by date
-    [<EventPage: Easter>, <EventPage: Haloween>, <EventPage: Christmas>]
+    [<EventPage: Easter>, <EventPage: Halloween>, <EventPage: Christmas>]
 
 
 .. _wagtailsearch_frontend_views:

--- a/wagtail/tests/search/models.py
+++ b/wagtail/tests/search/models.py
@@ -43,6 +43,9 @@ class SearchTest(models.Model, index.Indexed):
         # Return the child if there is one, otherwise return self
         return child or self
 
+    def __str__(self):
+        return self.title
+
 
 class SearchTestChild(SearchTest):
     subtitle = models.CharField(max_length=255, null=True, blank=True)

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -235,8 +235,10 @@ class PageManager(models.Manager):
     def not_public(self):
         return self.get_queryset().not_public()
 
-    def search(self, query_string, fields=None, backend='default'):
-        return self.get_queryset().search(query_string, fields=fields, backend=backend)
+    def search(self, query_string, fields=None,
+            operator=None, order_by_relevance=True, backend='default'):
+        return self.get_queryset().search(query_string, fields=fields,
+            operator=operator, order_by_relevance=order_by_relevance, backend=backend)
 
     def specific(self):
         return self.get_queryset().specific()

--- a/wagtail/wagtailcore/query.py
+++ b/wagtail/wagtailcore/query.py
@@ -7,10 +7,10 @@ from django.apps import apps
 
 from treebeard.mp_tree import MP_NodeQuerySet
 
-from wagtail.wagtailsearch.backends import get_search_backend
+from wagtail.wagtailsearch.queryset import SearchableQuerySetMixin
 
 
-class PageQuerySet(MP_NodeQuerySet):
+class PageQuerySet(SearchableQuerySetMixin, MP_NodeQuerySet):
     def live_q(self):
         return Q(live=True)
 
@@ -196,15 +196,6 @@ class PageQuerySet(MP_NodeQuerySet):
         This filters the QuerySet to only contain pages that are in a private section
         """
         return self.exclude(self.public_q())
-
-    def search(self, query_string, fields=None,
-            operator=None, order_by_relevance=True, backend='default'):
-        """
-        This runs a search query on all the pages in the QuerySet
-        """
-        search_backend = get_search_backend(backend)
-        return search_backend.search(query_string, self, fields=fields,
-            operator=operator, order_by_relevance=order_by_relevance)
 
     def unpublish(self):
         """

--- a/wagtail/wagtailcore/query.py
+++ b/wagtail/wagtailcore/query.py
@@ -197,12 +197,14 @@ class PageQuerySet(MP_NodeQuerySet):
         """
         return self.exclude(self.public_q())
 
-    def search(self, query_string, fields=None, operator=None, backend='default'):
+    def search(self, query_string, fields=None,
+            operator=None, order_by_relevance=True, backend='default'):
         """
         This runs a search query on all the pages in the QuerySet
         """
         search_backend = get_search_backend(backend)
-        return search_backend.search(query_string, self, fields=fields, operator=operator)
+        return search_backend.search(query_string, self, fields=fields,
+            operator=operator, order_by_relevance=order_by_relevance)
 
     def unpublish(self):
         """

--- a/wagtail/wagtailcore/tests/test_page_queryset.py
+++ b/wagtail/wagtailcore/tests/test_page_queryset.py
@@ -332,6 +332,20 @@ class TestPageQuerySetSearch(TestCase):
         self.assertIn(Page.objects.get(url_path='/home/events/tentative-unpublished-event/').specific, pages)
         self.assertIn(Page.objects.get(url_path='/home/events/someone-elses-event/').specific, pages)
 
+    def test_operators(self):
+        results = EventPage.objects.search("moon ponies", operator='and')
+
+        self.assertEqual(list(results), [
+            Page.objects.get(url_path='/home/events/tentative-unpublished-event/').specific
+        ])
+
+        results = EventPage.objects.search("moon ponies", operator='or')
+        sorted_results = sorted(results, key=lambda page: page.url_path)
+        self.assertEqual(sorted_results, [
+            Page.objects.get(url_path='/home/events/someone-elses-event/').specific,
+            Page.objects.get(url_path='/home/events/tentative-unpublished-event/').specific,
+        ])
+
     def test_custom_order(self):
         pages = EventPage.objects.order_by('url_path').search('moon', fields=['location'], order_by_relevance=False)
 

--- a/wagtail/wagtailcore/tests/test_page_queryset.py
+++ b/wagtail/wagtailcore/tests/test_page_queryset.py
@@ -322,6 +322,32 @@ class TestPageQuerySet(TestCase):
         self.assertTrue(pages.filter(id=event.id).exists())
 
 
+class TestPageQuerySetSearch(TestCase):
+    fixtures = ['test.json']
+
+    def test_search(self):
+        pages = EventPage.objects.search('moon', fields=['location'])
+
+        self.assertEqual(pages.count(), 2)
+        self.assertIn(Page.objects.get(url_path='/home/events/tentative-unpublished-event/').specific, pages)
+        self.assertIn(Page.objects.get(url_path='/home/events/someone-elses-event/').specific, pages)
+
+    def test_custom_order(self):
+        pages = EventPage.objects.order_by('url_path').search('moon', fields=['location'], order_by_relevance=False)
+
+        self.assertEqual(list(pages), [
+            Page.objects.get(url_path='/home/events/someone-elses-event/').specific,
+            Page.objects.get(url_path='/home/events/tentative-unpublished-event/').specific,
+        ])
+
+        pages = EventPage.objects.order_by('-url_path').search('moon', fields=['location'], order_by_relevance=False)
+
+        self.assertEqual(list(pages), [
+            Page.objects.get(url_path='/home/events/tentative-unpublished-event/').specific,
+            Page.objects.get(url_path='/home/events/someone-elses-event/').specific,
+        ])
+
+
 class TestSpecificQuery(TestCase):
     """
     Test the .specific() queryset method. This is isolated in its own test case

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -20,12 +20,14 @@ from wagtail.wagtailsearch.backends import get_search_backend
 
 
 class DocumentQuerySet(models.QuerySet):
-    def search(self, query_string, fields=None, operator=None, backend='default'):
+    def search(self, query_string, fields=None,
+            operator=None, order_by_relevance=True, backend='default'):
         """
         This runs a search query on all the documents in the QuerySet
         """
         search_backend = get_search_backend(backend)
-        return search_backend.search(query_string, self, fields=fields, operator=operator)
+        return search_backend.search(query_string, self, fields=fields,
+            operator=operator, order_by_relevance=order_by_relevance)
 
 
 @python_2_unicode_compatible

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -16,18 +16,11 @@ from django.utils.encoding import python_2_unicode_compatible
 from wagtail.wagtailadmin.taggable import TagSearchable
 from wagtail.wagtailadmin.utils import get_object_usage
 from wagtail.wagtailsearch import index
-from wagtail.wagtailsearch.backends import get_search_backend
+from wagtail.wagtailsearch.queryset import SearchableQuerySetMixin
 
 
-class DocumentQuerySet(models.QuerySet):
-    def search(self, query_string, fields=None,
-            operator=None, order_by_relevance=True, backend='default'):
-        """
-        This runs a search query on all the documents in the QuerySet
-        """
-        search_backend = get_search_backend(backend)
-        return search_backend.search(query_string, self, fields=fields,
-            operator=operator, order_by_relevance=order_by_relevance)
+class DocumentQuerySet(SearchableQuerySetMixin, models.QuerySet):
+    pass
 
 
 @python_2_unicode_compatible

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -34,6 +34,15 @@ class TestDocumentQuerySet(TestCase):
         results = models.Document.objects.search("Test")
         self.assertEqual(list(results), [document])
 
+    def test_custom_ordering(self):
+        aaa_document = models.Document.objects.create(title="AAA Test document")
+        zzz_document = models.Document.objects.create(title="ZZZ Test document")
+
+        results = models.Document.objects.order_by('title').search("Test")
+        self.assertEqual(list(results), [aaa_document, zzz_document])
+        results = models.Document.objects.order_by('-title').search("Test")
+        self.assertEqual(list(results), [zzz_document, aaa_document])
+
 
 class TestDocumentPermissions(TestCase):
     def setUp(self):

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -34,6 +34,17 @@ class TestDocumentQuerySet(TestCase):
         results = models.Document.objects.search("Test")
         self.assertEqual(list(results), [document])
 
+    def test_operators(self):
+        aaa_document = models.Document.objects.create(title="AAA Test document")
+        zzz_document = models.Document.objects.create(title="ZZZ Test document")
+
+        results = models.Document.objects.search("aaa test", operator='and')
+        self.assertEqual(list(results), [aaa_document])
+
+        results = models.Document.objects.search("aaa test", operator='or')
+        sorted_results = sorted(results, key=lambda doc: doc.title)
+        self.assertEqual(sorted_results, [aaa_document, zzz_document])
+
     def test_custom_ordering(self):
         aaa_document = models.Document.objects.create(title="AAA Test document")
         zzz_document = models.Document.objects.create(title="ZZZ Test document")

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -28,7 +28,7 @@ from unidecode import unidecode
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailadmin.taggable import TagSearchable
 from wagtail.wagtailsearch import index
-from wagtail.wagtailsearch.backends import get_search_backend
+from wagtail.wagtailsearch.queryset import SearchableQuerySetMixin
 from wagtail.wagtailimages.rect import Rect
 from wagtail.wagtailimages.exceptions import InvalidFilterSpecError
 from wagtail.wagtailadmin.utils import get_object_usage
@@ -42,15 +42,8 @@ class SourceImageIOError(IOError):
     pass
 
 
-class ImageQuerySet(models.QuerySet):
-    def search(self, query_string, fields=None,
-            operator=None, order_by_relevance=True, backend='default'):
-        """
-        This runs a search query on all the images in the QuerySet
-        """
-        search_backend = get_search_backend(backend)
-        return search_backend.search(query_string, self, fields=fields,
-            operator=operator, order_by_relevance=order_by_relevance)
+class ImageQuerySet(SearchableQuerySetMixin, models.QuerySet):
+    pass
 
 
 def get_upload_to(instance, filename):

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -43,12 +43,14 @@ class SourceImageIOError(IOError):
 
 
 class ImageQuerySet(models.QuerySet):
-    def search(self, query_string, fields=None, operator=None, backend='default'):
+    def search(self, query_string, fields=None,
+            operator=None, order_by_relevance=True, backend='default'):
         """
         This runs a search query on all the images in the QuerySet
         """
         search_backend = get_search_backend(backend)
-        return search_backend.search(query_string, self, fields=fields, operator=operator)
+        return search_backend.search(query_string, self, fields=fields,
+            operator=operator, order_by_relevance=order_by_relevance)
 
 
 def get_upload_to(instance, filename):

--- a/wagtail/wagtailimages/tests/test_models.py
+++ b/wagtail/wagtailimages/tests/test_models.py
@@ -99,6 +99,23 @@ class TestImageQuerySet(TestCase):
         results = Image.objects.search("Test")
         self.assertEqual(list(results), [image])
 
+    def test_operators(self):
+        aaa_image = Image.objects.create(
+            title="AAA Test image",
+            file=get_test_image_file(),
+        )
+        zzz_image = Image.objects.create(
+            title="ZZZ Test image",
+            file=get_test_image_file(),
+        )
+
+        results = Image.objects.search("aaa test", operator='and')
+        self.assertEqual(list(results), [aaa_image])
+
+        results = Image.objects.search("aaa test", operator='or')
+        sorted_results = sorted(results, key=lambda img: img.title)
+        self.assertEqual(sorted_results, [aaa_image, zzz_image])
+
     def test_custom_ordering(self):
         aaa_image = Image.objects.create(
             title="AAA Test image",

--- a/wagtail/wagtailimages/tests/test_models.py
+++ b/wagtail/wagtailimages/tests/test_models.py
@@ -99,6 +99,21 @@ class TestImageQuerySet(TestCase):
         results = Image.objects.search("Test")
         self.assertEqual(list(results), [image])
 
+    def test_custom_ordering(self):
+        aaa_image = Image.objects.create(
+            title="AAA Test image",
+            file=get_test_image_file(),
+        )
+        zzz_image = Image.objects.create(
+            title="ZZZ Test image",
+            file=get_test_image_file(),
+        )
+
+        results = Image.objects.order_by('title').search("Test")
+        self.assertEqual(list(results), [aaa_image, zzz_image])
+        results = Image.objects.order_by('-title').search("Test")
+        self.assertEqual(list(results), [zzz_image, aaa_image])
+
 
 class TestImagePermissions(TestCase):
     def setUp(self):

--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -18,11 +18,12 @@ class FieldError(Exception):
 class BaseSearchQuery(object):
     DEFAULT_OPERATOR = 'or'
 
-    def __init__(self, queryset, query_string, fields=None, operator=None):
+    def __init__(self, queryset, query_string, fields=None, operator=None, order_by_relevance=True):
         self.queryset = queryset
         self.query_string = query_string
         self.fields = fields
         self.operator = operator or self.DEFAULT_OPERATOR
+        self.order_by_relevance = order_by_relevance
 
     def _get_searchable_field(self, field_attname):
         # Get field
@@ -203,7 +204,7 @@ class BaseSearch(object):
     def delete(self, obj):
         raise NotImplementedError
 
-    def search(self, query_string, model_or_queryset, fields=None, filters=None, prefetch_related=None, operator=None):
+    def search(self, query_string, model_or_queryset, fields=None, filters=None, prefetch_related=None, operator=None, order_by_relevance=True):
         # Find model/queryset
         if isinstance(model_or_queryset, QuerySet):
             model = model_or_queryset.model
@@ -236,5 +237,5 @@ class BaseSearch(object):
                 raise ValueError("operator must be either 'or' or 'and'")
 
         # Search
-        search_query = self.search_query_class(queryset, query_string, fields=fields, operator=operator)
+        search_query = self.search_query_class(queryset, query_string, fields=fields, operator=operator, order_by_relevance=order_by_relevance)
         return self.search_results_class(self, search_query)

--- a/wagtail/wagtailsearch/queryset.py
+++ b/wagtail/wagtailsearch/queryset.py
@@ -1,0 +1,12 @@
+from wagtail.wagtailsearch.backends import get_search_backend
+
+
+class SearchableQuerySetMixin(object):
+    def search(self, query_string, fields=None,
+            operator=None, order_by_relevance=True, backend='default'):
+        """
+        This runs a search query on all the items in the QuerySet
+        """
+        search_backend = get_search_backend(backend)
+        return search_backend.search(query_string, self, fields=fields,
+            operator=operator, order_by_relevance=order_by_relevance)

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -191,7 +191,7 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'prefix': {'content_type': 'searchtests_searchtest'}}, 'query': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials']}}}}
-        self.assertDictEqual(query.to_es(), expected_result)
+        self.assertDictEqual(query.get_query(), expected_result)
 
     def test_none_query_string(self):
         # Create a query
@@ -199,7 +199,7 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'prefix': {'content_type': 'searchtests_searchtest'}}, 'query': {'match_all': {}}}}
-        self.assertDictEqual(query.to_es(), expected_result)
+        self.assertDictEqual(query.get_query(), expected_result)
 
     def test_and_operator(self):
         # Create a query
@@ -207,7 +207,7 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'prefix': {'content_type': 'searchtests_searchtest'}}, 'query': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials'], 'operator': 'and'}}}}
-        self.assertDictEqual(query.to_es(), expected_result)
+        self.assertDictEqual(query.get_query(), expected_result)
 
     def test_filter(self):
         # Create a query
@@ -215,7 +215,7 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [{'prefix': {'content_type': 'searchtests_searchtest'}}, {'term': {'title_filter': 'Test'}}]}, 'query': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials']}}}}
-        self.assertDictEqual(query.to_es(), expected_result)
+        self.assertDictEqual(query.get_query(), expected_result)
 
     def test_and_filter(self):
         # Create a query
@@ -225,7 +225,7 @@ class TestElasticSearchQuery(TestCase):
         expected_result = {'filtered': {'filter': {'and': [{'prefix': {'content_type': 'searchtests_searchtest'}}, {'and': [{'term': {'live_filter': True}}, {'term': {'title_filter': 'Test'}}]}]}, 'query': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials']}}}}
 
         # Make sure field filters are sorted (as they can be in any order which may cause false positives)
-        query = query.to_es()
+        query = query.get_query()
         field_filters = query['filtered']['filter']['and'][1]['and']
         field_filters[:] = sorted(field_filters, key=lambda f: list(f['term'].keys())[0])
 
@@ -236,7 +236,7 @@ class TestElasticSearchQuery(TestCase):
         query = self.ElasticSearchQuery(models.SearchTest.objects.filter(Q(title="Test") | Q(live=True)), "Hello")
 
         # Make sure field filters are sorted (as they can be in any order which may cause false positives)
-        query = query.to_es()
+        query = query.get_query()
         field_filters = query['filtered']['filter']['and'][1]['or']
         field_filters[:] = sorted(field_filters, key=lambda f: list(f['term'].keys())[0])
 
@@ -250,7 +250,7 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [{'prefix': {'content_type': 'searchtests_searchtest'}}, {'not': {'term': {'live_filter': True}}}]}, 'query': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials']}}}}
-        self.assertDictEqual(query.to_es(), expected_result)
+        self.assertDictEqual(query.get_query(), expected_result)
 
     def test_fields(self):
         # Create a query
@@ -258,7 +258,7 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'prefix': {'content_type': 'searchtests_searchtest'}}, 'query': {'match': {'title': 'Hello'}}}}
-        self.assertDictEqual(query.to_es(), expected_result)
+        self.assertDictEqual(query.get_query(), expected_result)
 
     def test_fields_with_and_operator(self):
         # Create a query
@@ -266,7 +266,7 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'prefix': {'content_type': 'searchtests_searchtest'}}, 'query': {'match': {'title': 'Hello', 'operator': 'and'}}}}
-        self.assertDictEqual(query.to_es(), expected_result)
+        self.assertDictEqual(query.get_query(), expected_result)
 
     def test_exact_lookup(self):
         # Create a query
@@ -274,7 +274,7 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [{'prefix': {'content_type': 'searchtests_searchtest'}}, {'term': {'title_filter': 'Test'}}]}, 'query': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials']}}}}
-        self.assertDictEqual(query.to_es(), expected_result)
+        self.assertDictEqual(query.get_query(), expected_result)
 
     def test_none_lookup(self):
         # Create a query
@@ -282,7 +282,7 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [{'prefix': {'content_type': 'searchtests_searchtest'}}, {'missing': {'field': 'title_filter'}}]}, 'query': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials']}}}}
-        self.assertDictEqual(query.to_es(), expected_result)
+        self.assertDictEqual(query.get_query(), expected_result)
 
     def test_isnull_true_lookup(self):
         # Create a query
@@ -290,7 +290,7 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [{'prefix': {'content_type': 'searchtests_searchtest'}}, {'missing': {'field': 'title_filter'}}]}, 'query': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials']}}}}
-        self.assertDictEqual(query.to_es(), expected_result)
+        self.assertDictEqual(query.get_query(), expected_result)
 
     def test_isnull_false_lookup(self):
         # Create a query
@@ -298,7 +298,7 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [{'prefix': {'content_type': 'searchtests_searchtest'}}, {'not': {'missing': {'field': 'title_filter'}}}]}, 'query': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials']}}}}
-        self.assertDictEqual(query.to_es(), expected_result)
+        self.assertDictEqual(query.get_query(), expected_result)
 
     def test_startswith_lookup(self):
         # Create a query
@@ -306,7 +306,7 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [{'prefix': {'content_type': 'searchtests_searchtest'}}, {'prefix': {'title_filter': 'Test'}}]}, 'query': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials']}}}}
-        self.assertDictEqual(query.to_es(), expected_result)
+        self.assertDictEqual(query.get_query(), expected_result)
 
     def test_gt_lookup(self):
         # This also tests conversion of python dates to strings
@@ -316,7 +316,7 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [{'prefix': {'content_type': 'searchtests_searchtest'}}, {'range': {'published_date_filter': {'gt': '2014-04-29'}}}]}, 'query': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials']}}}}
-        self.assertDictEqual(query.to_es(), expected_result)
+        self.assertDictEqual(query.get_query(), expected_result)
 
     def test_lt_lookup(self):
         # Create a query
@@ -324,7 +324,7 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [{'prefix': {'content_type': 'searchtests_searchtest'}}, {'range': {'published_date_filter': {'lt': '2014-04-29'}}}]}, 'query': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials']}}}}
-        self.assertDictEqual(query.to_es(), expected_result)
+        self.assertDictEqual(query.get_query(), expected_result)
 
     def test_gte_lookup(self):
         # Create a query
@@ -332,7 +332,7 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [{'prefix': {'content_type': 'searchtests_searchtest'}}, {'range': {'published_date_filter': {'gte': '2014-04-29'}}}]}, 'query': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials']}}}}
-        self.assertDictEqual(query.to_es(), expected_result)
+        self.assertDictEqual(query.get_query(), expected_result)
 
     def test_lte_lookup(self):
         # Create a query
@@ -340,7 +340,7 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [{'prefix': {'content_type': 'searchtests_searchtest'}}, {'range': {'published_date_filter': {'lte': '2014-04-29'}}}]}, 'query': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials']}}}}
-        self.assertDictEqual(query.to_es(), expected_result)
+        self.assertDictEqual(query.get_query(), expected_result)
 
     def test_range_lookup(self):
         start_date = datetime.datetime(2014, 4, 29)
@@ -351,7 +351,7 @@ class TestElasticSearchQuery(TestCase):
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [{'prefix': {'content_type': 'searchtests_searchtest'}}, {'range': {'published_date_filter': {'gte': '2014-04-29', 'lte': '2014-08-19'}}}]}, 'query': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials']}}}}
-        self.assertDictEqual(query.to_es(), expected_result)
+        self.assertDictEqual(query.get_query(), expected_result)
 
 
 class TestElasticSearchResults(TestCase):
@@ -382,7 +382,7 @@ class TestElasticSearchResults(TestCase):
         backend = self.ElasticSearch({})
         query = mock.MagicMock()
         query.queryset = models.SearchTest.objects.all()
-        query.to_es.return_value = 'QUERY'
+        query.get_query.return_value = 'QUERY'
         return self.ElasticSearchResults(backend, query)
 
     def construct_search_response(self, results):

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -383,6 +383,7 @@ class TestElasticSearchResults(TestCase):
         query = mock.MagicMock()
         query.queryset = models.SearchTest.objects.all()
         query.get_query.return_value = 'QUERY'
+        query.get_sort.return_value = None
         return self.ElasticSearchResults(backend, query)
 
     def construct_search_response(self, results):


### PR DESCRIPTION
This pull request adds a new attribute to search methods: ``order_by_relevance``. This is a boolean that defauls to ``True``.

When set to ``False`` the ordering that is already used on the queryset is also used in the search.

For example, this will search blog pages but order them by published date:
```
blogs = BlogPage.objects.order_by('-published_date').search("Test", operator='and', order_by_relevance=False)
```