### PR TITLE
Remove HTML comments from rich text

### DIFF
--- a/wagtail/wagtailcore/tests/test_whitelist.py
+++ b/wagtail/wagtailcore/tests/test_whitelist.py
@@ -143,3 +143,8 @@ class TestWhitelister(TestCase):
         string = '<b foo="bar">snowman <barbecue>Yorkshire</barbecue></b>'
         cleaned_string = Whitelister.clean(string)
         self.assertEqual(cleaned_string, '<b>snowman Yorkshire</b>')
+
+    def test_clean_comments(self):
+        string = '<b>snowman Yorkshire<!--[if gte mso 10]>MS word junk<![endif]--></b>'
+        cleaned_string = Whitelister.clean(string)
+        self.assertEqual(cleaned_string, '<b>snowman Yorkshire</b>')

--- a/wagtail/wagtailcore/whitelist.py
+++ b/wagtail/wagtailcore/whitelist.py
@@ -3,7 +3,7 @@ A generic HTML whitelisting engine, designed to accommodate subclassing to overr
 specific rules.
 """
 import re
-from bs4 import BeautifulSoup, NavigableString, Tag
+from bs4 import BeautifulSoup, NavigableString, Tag, Comment
 
 
 ALLOWED_URL_SCHEMES = ['http', 'https', 'ftp', 'mailto', 'tel']
@@ -111,7 +111,12 @@ class Whitelister(object):
             cls.clean_unknown_node(doc, node)
 
     @classmethod
-    def clean_string_node(cls, doc, str):
+    def clean_string_node(cls, doc, node):
+        # Remove comments
+        if isinstance(node, Comment):
+            node.extract()
+            return
+
         # by default, nothing needs to be done to whitelist string nodes
         pass
 


### PR DESCRIPTION
When text is pasted into a rich text block from MS word, HTML comments are created that contain lots of data that we don't need.

This commit changes the whitelister to remove all comment nodes.