### PR TITLE
Removed references to search picks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@
 /venv
 /node_modules/
 npm-debug.log
-/.idea
+*/.idea/
 /*.egg/

--- a/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/add.html
+++ b/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/add.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% trans "Add search pick" %}{% endblock %}
+{% block titletag %}{% trans "Add search promotion" %}{% endblock %}
 {% block content %}
     {% trans "Add search pick" as add_str %}
     {% include "wagtailadmin/shared/header.html" with title=add_str icon="pick" %}

--- a/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/list.html
+++ b/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/list.html
@@ -14,7 +14,7 @@
         {% for query in queries %}
             <tr>
                 <td class="title">
-                    <h2><a href="{% url 'wagtailsearchpromotions:edit' query.id %}" title="{% trans 'Edit this pick' %}">{{ query.query_string }}</a></h2>
+                    <h2><a href="{% url 'wagtailsearchpromotions:edit' query.id %}" title="{% trans 'Edit this promotion' %}">{{ query.query_string }}</a></h2>
                 </td>
                 <td>
                     {% for searchpick in query.editors_picks.all %}

--- a/wagtail/contrib/wagtailsearchpromotions/tests.py
+++ b/wagtail/contrib/wagtailsearchpromotions/tests.py
@@ -14,7 +14,7 @@ class TestSearchPromotions(TestCase):
             query=Query.get("root page"),
             page_id=1,
             sort_order=0,
-            description="First search pick",
+            description="First search promotion",
         )
 
         # Check

--- a/wagtail/contrib/wagtailstyleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/wagtailstyleguide/templates/wagtailstyleguide/base.html
@@ -572,7 +572,7 @@
                 <li class="icon icon-order-up">order-up</li>
                 <li class="icon icon-bin">bin</li>
                 <li class="spinner"><div class="icon icon-spinner">spinner</div> spinner</li>
-                <li class="icon icon-pick">pick</li>
+                <li class="icon icon-pick">promotion</li>
                 <li class="icon icon-redirect">redirect</li>
                 <li class="icon icon-view">view</li>
                 <li class="icon icon-no-view">no-view</li>


### PR DESCRIPTION
Changed the pick references to 'promotions' in the strings specified in #1658. Not describing as fixed, as @kaedroho mentioned some editor_picks classes that have not been renamed in this change. 