### PR TITLE
Remove the length argument to URLify

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -296,7 +296,7 @@ function InlinePanel(opts) {
 
 function cleanForSlug(val, useURLify) {
     if (URLify != undefined && useURLify !== false) { // Check to be sure that URLify function exists, and that we want to use it.
-        return URLify(val, val.length);
+        return URLify(val);
     } else { // If not just do the "replace"
         return val.replace(/\s/g, '-').replace(/[^A-Za-z0-9\-\_]/g, '').toLowerCase();
     }


### PR DESCRIPTION
The URLify function supplied by django does not need a length argument in order to work. The problem with supplying the length argument is that when you have Unicode characters that are translated to two characters in the slug version, the resulting slug will be missing one character for each such double character.

Example:
Æ or æ is translated as ae when slugified.
A call to URLify would then be: URLify("kjaftæði", 8) which would result in the slug "kjaftaed", since the slug is 9 characters in length due to æ being expanded to two characters. URLify("kjaftæði") works fine and returns "kjaftaedi".