### PR TITLE
Test for correct exception in BaseChooserPanel.get_chosen_item - fixes #1834

### DIFF
--- a/wagtail/utils/compat.py
+++ b/wagtail/utils/compat.py
@@ -12,6 +12,15 @@ def get_related_model(rel):
         return rel.model
 
 
+def get_related_parent_model(rel):
+    # In Django 1.7 and under, the parent model is accessed by doing: rel.parent_model
+    # This was renamed in Django 1.8 to rel.model.
+    if django.VERSION >= (1, 8):
+        return rel.model
+    else:
+        return rel.parent_model
+
+
 def render_to_string(template_name, context=None, request=None, **kwargs):
     if django.VERSION >= (1, 8):
         return loader.render_to_string(

--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -19,7 +19,7 @@ from taggit.managers import TaggableManager
 from wagtail.wagtailadmin import widgets
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.utils import camelcase_to_underscore, resolve_model_string
-from wagtail.utils.compat import get_related_model
+from wagtail.utils.compat import get_related_model, get_related_parent_model
 
 
 # Form field properties to override whenever we encounter a model field
@@ -525,7 +525,7 @@ class BaseChooserPanel(BaseFieldPanel):
 
     def get_chosen_item(self):
         field = self.instance._meta.get_field(self.field_name)
-        related_model = get_related_model(field.related)
+        related_model = get_related_parent_model(field.related)
         try:
             return getattr(self.instance, self.field_name)
         except related_model.DoesNotExist:

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -382,6 +382,16 @@ class TestPageChooserPanel(TestCase):
             '<a href="/admin/pages/%d/edit/" class="edit-link button button-small button-secondary" target="_blank">Edit this page</a>' % self.christmas_page.id,
             result)
 
+    def test_render_as_empty_field(self):
+        test_instance = PageChooserModel()
+        form = self.PageChooserForm(instance=test_instance)
+        page_chooser_panel = self.MyPageChooserPanel(instance=test_instance, form=form)
+        result = page_chooser_panel.render_as_field()
+
+        self.assertIn('<p class="help">help text</p>', result)
+        self.assertIn('<span class="title"></span>', result)
+        self.assertIn('Choose a page', result)
+
     def test_render_error(self):
         form = self.PageChooserForm({'page': ''}, instance=self.test_instance)
         self.assertFalse(form.is_valid())

--- a/wagtail/wagtailsnippets/tests.py
+++ b/wagtail/wagtailsnippets/tests.py
@@ -255,10 +255,10 @@ class TestSnippetChooserPanel(TestCase):
         test_snippet = model.objects.create(
             advert=Advert.objects.create(text=self.advert_text))
 
-        edit_handler_class = get_snippet_edit_handler(model)
-        form_class = edit_handler_class.get_form_class(model)
-        form = form_class(instance=test_snippet)
-        edit_handler = edit_handler_class(instance=test_snippet, form=form)
+        self.edit_handler_class = get_snippet_edit_handler(model)
+        self.form_class = self.edit_handler_class.get_form_class(model)
+        form = self.form_class(instance=test_snippet)
+        edit_handler = self.edit_handler_class(instance=test_snippet, form=form)
 
         self.snippet_chooser_panel = [
             panel for panel in edit_handler.children
@@ -271,6 +271,19 @@ class TestSnippetChooserPanel(TestCase):
     def test_render_as_field(self):
         field_html = self.snippet_chooser_panel.render_as_field()
         self.assertIn(self.advert_text, field_html)
+        self.assertIn("Choose advert", field_html)
+        self.assertIn("Choose another advert", field_html)
+
+    def test_render_as_empty_field(self):
+        test_snippet = SnippetChooserModel()
+        form = self.form_class(instance=test_snippet)
+        edit_handler = self.edit_handler_class(instance=test_snippet, form=form)
+
+        snippet_chooser_panel = [
+            panel for panel in edit_handler.children
+            if getattr(panel, 'field_name', None) == 'advert'][0]
+
+        field_html = snippet_chooser_panel.render_as_field()
         self.assertIn("Choose advert", field_html)
         self.assertIn("Choose another advert", field_html)
 


### PR DESCRIPTION
When BaseChooserPanel was updated in d31e4cd032d38f6c816cf3c56115297c3c66d234 to convert `except ObjectDoesNotExist` to a more specific exception, the `get_related_model` compat function was used to retrieve the relevant model. This is incorrect, as get_related_model returns the model on which the foreign key exists, not the one being pointed to. As a result, it was failing to catch the exception thrown when retrieving the value of an empty non-nullable field, and the form field was not rendering.

This PR adds a new compat function `get_related_parent_model` to return the model on the opposite side of the relation.

Note that the line in question still throws a RemovedInDjango20Warning due to its use of `field.related`, which has been superseded by `field.rel`. We should probably update those compat functions (or provide additional ones) to take the field object rather than `RelatedObject`. But that's a separate job.

Fixes #1834