### PR TITLE
Update gulp-sass to 2.0.x to support Node.js v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gulp": "~3.8.11",
     "gulp-autoprefixer": "~1.0.1",
     "gulp-rename": "^1.2.2",
-    "gulp-sass": "~1.0.0",
+    "gulp-sass": "~2.0.0",
     "gulp-sourcemaps": "~1.2.2",
     "gulp-util": "~2.2.14",
     "jscs": "^1.12.0",


### PR DESCRIPTION
This small change allows assets to be built with latest Node.js (LTS version 4.2).

Here is changelog for gulp-sass: https://github.com/dlmanning/gulp-sass/blob/v2.0.4/CHANGELOG.md

So by using new gulp-sass we could drop ancient node-sass 0.9 and use its live 3.3.x branch.