### PR TITLE
Fix search on specific page class using the page queryset.

### DIFF
--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -71,6 +71,10 @@ class BaseSearchQuery(object):
             lookup = where_node.lookup_name
             value = where_node.rhs
 
+            # Ignore pointer fields that show up in specific page type queries
+            if field_attname.endswith('_ptr_id'):
+                return
+
             # Process the filter
             return self._process_filter(field_attname, lookup, value)
 

--- a/wagtail/wagtailsearch/tests/test_backends.py
+++ b/wagtail/wagtailsearch/tests/test_backends.py
@@ -117,6 +117,10 @@ class BackendTests(WagtailTestUtils):
         results = self.backend.search(None, models.SearchTestChild)
         self.assertEqual(set(results), {self.testc, self.testd})
 
+    def test_child_model_with_id_filter(self):
+        results = self.backend.search("World", models.SearchTestChild.objects.filter(id=self.testd.id))
+        self.assertEqual(set(results), {self.testd})
+
     def test_delete(self):
         # Delete one of the objects
         self.backend.delete(self.testa)


### PR DESCRIPTION
Fixes #1721 

This search bug will appear on any specific page type classes that use the page queryset,
that includes page, child_of, descendant_of, ascendant_of, and sibling_of as well all the negative
versions.

Searching on a specific page type and using the page queryset
results in a missing FilterField message for "page_ptr_id".
The where node query is used to build the list of filters
and xxxx_ptr_id shows up when we use any inherited model and query
by the id. It's best to just ignore this as its useless to
filter search on a pointer field.

We could define it as a FilterField on the Page model, but this
way it prevents other indexed Django models from hitting the same problem.