### PR TITLE
Add editor name to moderation notification

### DIFF
--- a/wagtail/wagtailadmin/locale/en/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/en/LC_MESSAGES/django.po
@@ -520,7 +520,7 @@ msgstr ""
 
 #: templates/wagtailadmin/notifications/submitted.html:2
 #, python-format
-msgid "The page \"%(page)s\" has been submitted for moderation."
+msgid "The page \"%(page)s\" has been submitted for moderation by %(editor)s."
 msgstr ""
 
 #: templates/wagtailadmin/notifications/submitted.html:4

--- a/wagtail/wagtailadmin/templates/wagtailadmin/notifications/submitted.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/notifications/submitted.html
@@ -1,5 +1,5 @@
 {% extends 'wagtailadmin/notifications/base_notification.html' %}{% block notification %}{% load i18n %}{% blocktrans with page=revision.page|safe %}The page "{{ page }}" has been submitted for moderation{% endblocktrans %}
-{% blocktrans with page=revision.page|safe %}The page "{{ page }}" has been submitted for moderation.{% endblocktrans %}
+{% blocktrans with page=revision.page|safe editor=revision.user.get_full_name|default:revision.user.get_username %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}
 
 {% trans "You can preview the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}
 {% trans "You can edit the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}{% endblock %}


### PR DESCRIPTION
A minor moderation notification change proposed in #1322.

How do we push new translation strings to Transifex? Should I include it into PR somehow?