### PR TITLE
Use six from Django, remove six from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,6 @@ deps =
     beautifulsoup4>=4.3.2
     html5lib==0.999
     Unidecode>=0.04.14
-    six==1.7.3
     elasticsearch==1.1.0
     mock==1.0.1
     python-dateutil==2.2

--- a/wagtail/wagtailsearch/backends/__init__.py
+++ b/wagtail/wagtailsearch/backends/__init__.py
@@ -3,9 +3,9 @@
 # https://github.com/django/django/blob/5d263dee304fdaf95e18d2f0619d6925984a7f02/django/core/cache/__init__.py
 
 import sys
-import six
 from importlib import import_module
 
+from django.utils import six
 from django.utils.module_loading import import_string
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 
 import json
-import six
 import warnings
 
+from django.utils import six
 from django.utils.six.moves.urllib.parse import urlparse
 
 from elasticsearch import Elasticsearch, NotFoundError


### PR DESCRIPTION
All referencs to `six` were removed in #1411 favouring `django.utils.six`, except for one in `tox.ini` where it was installed as a dependency. Because it was still installed in the test environment, a few references to `six` crept back in. These will cause an ImportError when users do not have `six` installed.

These references have been fixed, and `six` has been removed from `tox.ini`