### PR TITLE
.xdsoft_datetimepicker z-index: 5

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/datetimepicker.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/datetimepicker.scss
@@ -7,7 +7,7 @@
 	padding-left: 0px;
 	padding-top: 2px;
 	position: absolute;
-	z-index: 1;
+	z-index: 5;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 	display:none;


### PR DESCRIPTION
It could help to avoid z-index problem like:

![screen shot 2015-10-27 at 13 35 05](https://cloud.githubusercontent.com/assets/310143/10755874/7eb3d5a6-7cb1-11e5-8f21-4ba23a68f153.png)
