### PR TITLE
Pass flag marking preview mode into template

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -512,6 +512,8 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
             return self.template
 
     def serve(self, request, *args, **kwargs):
+        request.is_preview = getattr(request, 'is_preview', False)
+
         return TemplateResponse(
             request,
             self.get_template(request, *args, **kwargs),
@@ -937,6 +939,8 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         here - this ensures that request.user and other properties are set appropriately for
         the wagtail user bar to be displayed. This request will always be a GET.
         """
+        request.is_preview = True
+
         return self.serve(request)
 
     def get_cached_paths(self):


### PR DESCRIPTION
This is an attempt to distinguish preview mode from live page to solve the issue mentioned in #1394 

One can use `request.is_preview` in site templates to see whether the page is in preview and switch off some code on this, like GA tracking etc.