### PR TITLE
Make migrations depend on non-squashed versions

### DIFF
--- a/wagtail/wagtailcore/migrations/0017_change_edit_page_permission_description.py
+++ b/wagtail/wagtailcore/migrations/0017_change_edit_page_permission_description.py
@@ -7,7 +7,7 @@ from django.db import models, migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('wagtailcore', '0001_squashed_0016_change_page_url_path_to_text_field'),
+        ('wagtailcore', '0016_change_page_url_path_to_text_field'),
     ]
 
     operations = [


### PR DESCRIPTION
Fixes #1817

Change wagtailcore migration 0017 to depend on the non-squashed migration 0016, so that it's possible to upgrade directly from a 0.8 release.

Tested with the following commands on my developer VM:

    mkvirtualenv upgradetest
    pip install wagtail==0.8.8
    cd
    wagtail start upgrademe
    cd upgrademe
    ./manage.py migrate
        (runs migrations 0001-0010 in wagtailcore)
    cd ~/wagtail
    python ./setup.py develop
    cd ~/upgrademe
    ./manage.py migrate
        (runs migrations 0011-0020 in wagtailcore)

Before this fix, the last command failed with the error as reported by @michaelfillier in https://github.com/torchbox/wagtail/issues/1817#issue-111078560.

Have also tested that it works starting from Wagtail 1.0 (i.e. it correctly picks up from migration 0017 after having run the squashed version of 0001-0016).