### PR TITLE
Split embed finders into separate modules

### DIFF
--- a/wagtail/wagtailcore/tests/test_rich_text.py
+++ b/wagtail/wagtailcore/tests/test_rich_text.py
@@ -97,7 +97,7 @@ class TestExpandDbHtml(TestCase):
         result = expand_db_html(html)
         self.assertEqual(result, '<a id="1">foo</a>')
 
-    @patch('wagtail.wagtailembeds.embeds.oembed')
+    @patch('wagtail.wagtailembeds.finders.oembed.find_embed')
     def test_expand_db_html_with_embed(self, oembed):
         oembed.return_value = {
             'title': 'test title',

--- a/wagtail/wagtailembeds/embeds.py
+++ b/wagtail/wagtailembeds/embeds.py
@@ -1,115 +1,12 @@
 from datetime import datetime
-import json
 
-# Needs to be imported like this to allow @patch to work in tests
-from django.utils.six.moves.urllib import request as urllib_request
-from django.utils.six.moves.urllib.request import Request
-from django.utils.six.moves.urllib.error import URLError
-from django.utils.six.moves.urllib.parse import urlencode
 from django.utils.module_loading import import_string
 from django.conf import settings
 
-from wagtail.wagtailembeds.oembed_providers import get_oembed_provider
 from wagtail.wagtailembeds.models import Embed
-
-
-class EmbedException(Exception):
-    pass
-
-
-class EmbedNotFoundException(EmbedException):
-    pass
-
-
-class EmbedlyException(EmbedException):
-    pass
-
-
-class AccessDeniedEmbedlyException(EmbedlyException):
-    pass
-
-
-def embedly(url, max_width=None, key=None):
-    from embedly import Embedly
-
-    # Get embedly key
-    if key is None:
-        key = settings.WAGTAILEMBEDS_EMBEDLY_KEY
-
-    # Get embedly client
-    client = Embedly(key=key)
-
-    # Call embedly
-    if max_width is not None:
-        oembed = client.oembed(url, maxwidth=max_width, better=False)
-    else:
-        oembed = client.oembed(url, better=False)
-
-    # Check for error
-    if oembed.get('error'):
-        if oembed['error_code'] in [401, 403]:
-            raise AccessDeniedEmbedlyException
-        elif oembed['error_code'] == 404:
-            raise EmbedNotFoundException
-        else:
-            raise EmbedlyException
-
-    # Convert photos into HTML
-    if oembed['type'] == 'photo':
-        html = '<img src="%s" />' % (oembed['url'], )
-    else:
-        html = oembed.get('html')
-
-    # Return embed as a dict
-    return {
-        'title': oembed['title'] if 'title' in oembed else '',
-        'author_name': oembed['author_name'] if 'author_name' in oembed else '',
-        'provider_name': oembed['provider_name'] if 'provider_name' in oembed else '',
-        'type': oembed['type'],
-        'thumbnail_url': oembed.get('thumbnail_url'),
-        'width': oembed.get('width'),
-        'height': oembed.get('height'),
-        'html': html,
-    }
-
-
-def oembed(url, max_width=None):
-    # Find provider
-    provider = get_oembed_provider(url)
-    if provider is None:
-        raise EmbedNotFoundException
-
-    # Work out params
-    params = {'url': url, 'format': 'json'}
-    if max_width:
-        params['maxwidth'] = max_width
-
-    # Perform request
-    request = Request(provider + '?' + urlencode(params))
-    request.add_header('User-agent', 'Mozilla/5.0')
-    try:
-        r = urllib_request.urlopen(request)
-    except URLError:
-        raise EmbedNotFoundException
-    oembed = json.loads(r.read().decode('utf-8'))
-
-    # Convert photos into HTML
-    if oembed['type'] == 'photo':
-        html = '<img src="%s" />' % (oembed['url'], )
-    else:
-        html = oembed.get('html')
-
-    # Return embed as a dict
-    return {
-        'title': oembed['title'] if 'title' in oembed else '',
-        'author_name': oembed['author_name'] if 'author_name' in oembed else '',
-        'provider_name': oembed['provider_name'] if 'provider_name' in oembed else '',
-        'type': oembed['type'],
-        'thumbnail_url': oembed.get('thumbnail_url'),
-        'width': oembed.get('width'),
-        'height': oembed.get('height'),
-        'html': html,
-    }
+from wagtail.wagtailembeds.exceptions import EmbedException, EmbedNotFoundException  # noqa
+from wagtail.wagtailembeds.finders.oembed import oembed
+from wagtail.wagtailembeds.finders.embedly import embedly
 
 
 def get_default_finder():
@@ -118,7 +15,7 @@ def get_default_finder():
         return import_string(settings.WAGTAILEMBEDS_EMBED_FINDER)
 
     # Use embedly if the embedly key is set
-    if hasattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY') or hasattr(settings, 'EMBEDLY_KEY'):
+    if hasattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY'):
         return embedly
 
     # Fall back to oembed

--- a/wagtail/wagtailembeds/embeds.py
+++ b/wagtail/wagtailembeds/embeds.py
@@ -1,25 +1,7 @@
 from datetime import datetime
 
-from django.utils.module_loading import import_string
-from django.conf import settings
-
 from wagtail.wagtailembeds.models import Embed
-from wagtail.wagtailembeds.exceptions import EmbedException, EmbedNotFoundException  # noqa
-from wagtail.wagtailembeds.finders.oembed import oembed
-from wagtail.wagtailembeds.finders.embedly import embedly
-
-
-def get_default_finder():
-    # Check if the user has set the embed finder manually
-    if hasattr(settings, 'WAGTAILEMBEDS_EMBED_FINDER'):
-        return import_string(settings.WAGTAILEMBEDS_EMBED_FINDER)
-
-    # Use embedly if the embedly key is set
-    if hasattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY'):
-        return embedly
-
-    # Fall back to oembed
-    return oembed
+from wagtail.wagtailembeds.finders import get_default_finder
 
 
 def get_embed(url, max_width=None, finder=None):

--- a/wagtail/wagtailembeds/exceptions.py
+++ b/wagtail/wagtailembeds/exceptions.py
@@ -1,0 +1,6 @@
+class EmbedException(Exception):
+    pass
+
+
+class EmbedNotFoundException(EmbedException):
+    pass

--- a/wagtail/wagtailembeds/finders/__init__.py
+++ b/wagtail/wagtailembeds/finders/__init__.py
@@ -5,10 +5,21 @@ from wagtail.wagtailembeds.finders.oembed import oembed
 from wagtail.wagtailembeds.finders.embedly import embedly
 
 
+MOVED_FINDERS = {
+    'wagtail.wagtailembeds.embeds.embedly': 'wagtail.wagtailembeds.finders.embedly.embedly',
+    'wagtail.wagtailembeds.embeds.oembed': 'wagtail.wagtailembeds.finders.oembed.oembed',
+}
+
+
 def get_default_finder():
     # Check if the user has set the embed finder manually
     if hasattr(settings, 'WAGTAILEMBEDS_EMBED_FINDER'):
-        return import_string(settings.WAGTAILEMBEDS_EMBED_FINDER)
+        finder_name = settings.WAGTAILEMBEDS_EMBED_FINDER
+
+        if finder_name in MOVED_FINDERS:
+            finder_name = MOVED_FINDERS[finder_name]
+
+        return import_string(finder_name)
 
     # Use embedly if the embedly key is set
     if hasattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY'):

--- a/wagtail/wagtailembeds/finders/__init__.py
+++ b/wagtail/wagtailembeds/finders/__init__.py
@@ -1,9 +1,6 @@
 from django.utils.module_loading import import_string
 from django.conf import settings
 
-from wagtail.wagtailembeds.finders.oembed import oembed
-from wagtail.wagtailembeds.finders.embedly import embedly
-
 
 MOVED_FINDERS = {
     'wagtail.wagtailembeds.embeds.embedly': 'wagtail.wagtailembeds.finders.embedly.embedly',
@@ -19,11 +16,12 @@ def get_default_finder():
         if finder_name in MOVED_FINDERS:
             finder_name = MOVED_FINDERS[finder_name]
 
-        return import_string(finder_name)
+    elif hasattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY'):
+        # Default to Embedly as an embedly key is set
+        finder_name = 'wagtail.wagtailembeds.finders.embedly.embedly'
 
-    # Use embedly if the embedly key is set
-    if hasattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY'):
-        return embedly
+    else:
+        # Default to oembed
+        finder_name = 'wagtail.wagtailembeds.finders.oembed.oembed'
 
-    # Fall back to oembed
-    return oembed
+    return import_string(finder_name)

--- a/wagtail/wagtailembeds/finders/__init__.py
+++ b/wagtail/wagtailembeds/finders/__init__.py
@@ -1,0 +1,18 @@
+from django.utils.module_loading import import_string
+from django.conf import settings
+
+from wagtail.wagtailembeds.finders.oembed import oembed
+from wagtail.wagtailembeds.finders.embedly import embedly
+
+
+def get_default_finder():
+    # Check if the user has set the embed finder manually
+    if hasattr(settings, 'WAGTAILEMBEDS_EMBED_FINDER'):
+        return import_string(settings.WAGTAILEMBEDS_EMBED_FINDER)
+
+    # Use embedly if the embedly key is set
+    if hasattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY'):
+        return embedly
+
+    # Fall back to oembed
+    return oembed

--- a/wagtail/wagtailembeds/finders/__init__.py
+++ b/wagtail/wagtailembeds/finders/__init__.py
@@ -1,11 +1,33 @@
+import sys
+from importlib import import_module
+
 from django.utils.module_loading import import_string
+from django.utils import six
 from django.conf import settings
 
 
 MOVED_FINDERS = {
-    'wagtail.wagtailembeds.embeds.embedly': 'wagtail.wagtailembeds.finders.embedly.embedly',
-    'wagtail.wagtailembeds.embeds.oembed': 'wagtail.wagtailembeds.finders.oembed.oembed',
+    'wagtail.wagtailembeds.embeds.embedly': 'wagtail.wagtailembeds.finders.embedly',
+    'wagtail.wagtailembeds.embeds.oembed': 'wagtail.wagtailembeds.finders.oembed',
 }
+
+
+def import_finder(dotted_path):
+    """
+    Imports a finder function from a dotted path. If the dotted path points to a
+    module, that module is imported and its "find_embed" function returned.
+
+    If not, this will assume the dotted path points to directly a function and
+    will attempt to import that instead.
+    """
+    try:
+        finder_module = import_module(dotted_path)
+        return finder_module.find_embed
+    except ImportError as e:
+        try:
+            return import_string(dotted_path)
+        except ImportError:
+            six.reraise(ImportError, e, sys.exc_info()[2])
 
 
 def get_default_finder():
@@ -18,10 +40,10 @@ def get_default_finder():
 
     elif hasattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY'):
         # Default to Embedly as an embedly key is set
-        finder_name = 'wagtail.wagtailembeds.finders.embedly.embedly'
+        finder_name = 'wagtail.wagtailembeds.finders.embedly'
 
     else:
         # Default to oembed
-        finder_name = 'wagtail.wagtailembeds.finders.oembed.oembed'
+        finder_name = 'wagtail.wagtailembeds.finders.oembed'
 
-    return import_string(finder_name)
+    return import_finder(finder_name)

--- a/wagtail/wagtailembeds/finders/embedly.py
+++ b/wagtail/wagtailembeds/finders/embedly.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+
+from django.conf import settings
+
+from wagtail.wagtailembeds.exceptions import EmbedException, EmbedNotFoundException
+
+
+class EmbedlyException(EmbedException):
+    pass
+
+
+class AccessDeniedEmbedlyException(EmbedlyException):
+    pass
+
+
+def embedly(url, max_width=None, key=None):
+    from embedly import Embedly
+
+    # Get embedly key
+    if key is None:
+        key = settings.WAGTAILEMBEDS_EMBEDLY_KEY
+
+    # Get embedly client
+    client = Embedly(key=key)
+
+    # Call embedly
+    if max_width is not None:
+        oembed = client.oembed(url, maxwidth=max_width, better=False)
+    else:
+        oembed = client.oembed(url, better=False)
+
+    # Check for error
+    if oembed.get('error'):
+        if oembed['error_code'] in [401, 403]:
+            raise AccessDeniedEmbedlyException
+        elif oembed['error_code'] == 404:
+            raise EmbedNotFoundException
+        else:
+            raise EmbedlyException
+
+    # Convert photos into HTML
+    if oembed['type'] == 'photo':
+        html = '<img src="%s" />' % (oembed['url'], )
+    else:
+        html = oembed.get('html')
+
+    # Return embed as a dict
+    return {
+        'title': oembed['title'] if 'title' in oembed else '',
+        'author_name': oembed['author_name'] if 'author_name' in oembed else '',
+        'provider_name': oembed['provider_name'] if 'provider_name' in oembed else '',
+        'type': oembed['type'],
+        'thumbnail_url': oembed.get('thumbnail_url'),
+        'width': oembed.get('width'),
+        'height': oembed.get('height'),
+        'html': html,
+    }

--- a/wagtail/wagtailembeds/finders/embedly.py
+++ b/wagtail/wagtailembeds/finders/embedly.py
@@ -55,3 +55,6 @@ def embedly(url, max_width=None, key=None):
         'height': oembed.get('height'),
         'html': html,
     }
+
+
+find_embed = embedly

--- a/wagtail/wagtailembeds/finders/oembed.py
+++ b/wagtail/wagtailembeds/finders/oembed.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+
+import json
+
+# Needs to be imported like this to allow @patch to work in tests
+from django.utils.six.moves.urllib import request as urllib_request
+from django.utils.six.moves.urllib.request import Request
+from django.utils.six.moves.urllib.error import URLError
+from django.utils.six.moves.urllib.parse import urlencode
+
+from wagtail.wagtailembeds.oembed_providers import get_oembed_provider
+from wagtail.wagtailembeds.exceptions import EmbedNotFoundException
+
+
+def oembed(url, max_width=None):
+    # Find provider
+    provider = get_oembed_provider(url)
+    if provider is None:
+        raise EmbedNotFoundException
+
+    # Work out params
+    params = {'url': url, 'format': 'json'}
+    if max_width:
+        params['maxwidth'] = max_width
+
+    # Perform request
+    request = Request(provider + '?' + urlencode(params))
+    request.add_header('User-agent', 'Mozilla/5.0')
+    try:
+        r = urllib_request.urlopen(request)
+    except URLError:
+        raise EmbedNotFoundException
+    oembed = json.loads(r.read().decode('utf-8'))
+
+    # Convert photos into HTML
+    if oembed['type'] == 'photo':
+        html = '<img src="%s" />' % (oembed['url'], )
+    else:
+        html = oembed.get('html')
+
+    # Return embed as a dict
+    return {
+        'title': oembed['title'] if 'title' in oembed else '',
+        'author_name': oembed['author_name'] if 'author_name' in oembed else '',
+        'provider_name': oembed['provider_name'] if 'provider_name' in oembed else '',
+        'type': oembed['type'],
+        'thumbnail_url': oembed.get('thumbnail_url'),
+        'width': oembed.get('width'),
+        'height': oembed.get('height'),
+        'html': html,
+    }

--- a/wagtail/wagtailembeds/finders/oembed.py
+++ b/wagtail/wagtailembeds/finders/oembed.py
@@ -49,3 +49,6 @@ def oembed(url, max_width=None):
         'height': oembed.get('height'),
         'html': html,
     }
+
+
+find_embed = oembed

--- a/wagtail/wagtailembeds/format.py
+++ b/wagtail/wagtailembeds/format.py
@@ -3,6 +3,7 @@ from __future__ import division  # Use true division
 from django.template.loader import render_to_string
 
 from wagtail.wagtailembeds import embeds
+from wagtail.wagtailembeds.exceptions import EmbedException
 
 
 def embed_to_frontend_html(url):
@@ -20,7 +21,7 @@ def embed_to_frontend_html(url):
             'embed': embed,
             'ratio': ratio,
         })
-    except embeds.EmbedException:
+    except EmbedException:
         # silently ignore failed embeds, rather than letting them crash the page
         return ''
 

--- a/wagtail/wagtailembeds/rich_text.py
+++ b/wagtail/wagtailembeds/rich_text.py
@@ -1,4 +1,5 @@
-from wagtail.wagtailembeds import format, embeds
+from wagtail.wagtailembeds import format
+from wagtail.wagtailembeds.exceptions import EmbedException
 
 
 class MediaEmbedHandler(object):
@@ -28,7 +29,7 @@ class MediaEmbedHandler(object):
         if for_editor:
             try:
                 return format.embed_to_editor_html(attrs['url'])
-            except embeds.EmbedException:
+            except EmbedException:
                 # Could be replaced with a nice error message
                 return ''
         else:

--- a/wagtail/wagtailembeds/templatetags/wagtailembeds_tags.py
+++ b/wagtail/wagtailembeds/templatetags/wagtailembeds_tags.py
@@ -2,7 +2,7 @@ from django import template
 from django.utils.safestring import mark_safe
 
 from wagtail.wagtailembeds import embeds
-
+from wagtail.wagtailembeds.exceptions import EmbedException
 
 register = template.Library()
 
@@ -12,5 +12,5 @@ def embed(url, max_width=None):
     try:
         embed = embeds.get_embed(url, max_width=max_width)
         return mark_safe(embed.html)
-    except embeds.EmbedException:
+    except EmbedException:
         return ''

--- a/wagtail/wagtailembeds/tests.py
+++ b/wagtail/wagtailembeds/tests.py
@@ -10,7 +10,7 @@ except ImportError:
 
 import django.utils.six.moves.urllib.request
 from django import template
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.utils.six.moves.urllib.error import URLError
@@ -27,9 +27,40 @@ from wagtail.wagtailembeds.finders.embedly import (
     embedly as wagtail_embedly,
 )
 from wagtail.wagtailembeds.finders.oembed import oembed as wagtail_oembed
+from wagtail.wagtailembeds.finders import get_default_finder
 from wagtail.wagtailembeds.templatetags.wagtailembeds_tags import embed as embed_filter
 from wagtail.wagtailembeds.blocks import EmbedBlock, EmbedValue
 from wagtail.wagtailembeds.models import Embed
+
+
+class TestGetDefaultFinder(TestCase):
+    def test_defaults_to_oembed(self):
+        self.assertEqual(get_default_finder(), wagtail_oembed)
+
+    @override_settings(WAGTAILEMBEDS_EMBEDLY_KEY='test')
+    def test_defaults_to_embedly_when_embedly_key_set(self):
+        self.assertEqual(get_default_finder(), wagtail_embedly)
+
+    @override_settings(WAGTAILEMBEDS_EMBED_FINDER='wagtail.wagtailembeds.finders.embedly.embedly')
+    def test_find_embedly(self):
+        self.assertEqual(get_default_finder(), wagtail_embedly)
+
+    @override_settings(WAGTAILEMBEDS_EMBED_FINDER='wagtail.wagtailembeds.finders.oembed.oembed')
+    def test_find_oembed(self):
+        self.assertEqual(get_default_finder(), wagtail_oembed)
+
+    @override_settings(WAGTAILEMBEDS_EMBED_FINDER='wagtail.wagtailembeds.embeds.embedly')
+    def test_find_old_embedly(self):
+        self.assertEqual(get_default_finder(), wagtail_embedly)
+
+    @override_settings(WAGTAILEMBEDS_EMBED_FINDER='wagtail.wagtailembeds.embeds.oembed')
+    def test_find_old_oembed(self):
+        self.assertEqual(get_default_finder(), wagtail_oembed)
+
+    @override_settings(WAGTAILEMBEDS_EMBEDLY_KEY='test', WAGTAILEMBEDS_EMBED_FINDER='wagtail.wagtailembeds.finders.oembed.oembed')
+    def test_find_oembed_when_embedly_key_set(self):
+        # WAGTAILEMBEDS_EMBED_FINDER always takes precedence
+        self.assertEqual(get_default_finder(), wagtail_oembed)
 
 
 class TestEmbeds(TestCase):

--- a/wagtail/wagtailembeds/tests.py
+++ b/wagtail/wagtailembeds/tests.py
@@ -19,14 +19,14 @@ from wagtail.wagtailcore import blocks
 from wagtail.tests.utils import WagtailTestUtils
 
 from wagtail.wagtailembeds.rich_text import MediaEmbedHandler
-from wagtail.wagtailembeds.embeds import (
-    EmbedNotFoundException,
+from wagtail.wagtailembeds.embeds import get_embed
+from wagtail.wagtailembeds.exceptions import EmbedNotFoundException
+from wagtail.wagtailembeds.finders.embedly import (
     EmbedlyException,
     AccessDeniedEmbedlyException,
-    get_embed,
     embedly as wagtail_embedly,
-    oembed as wagtail_oembed,
 )
+from wagtail.wagtailembeds.finders.oembed import oembed as wagtail_oembed
 from wagtail.wagtailembeds.templatetags.wagtailembeds_tags import embed as embed_filter
 from wagtail.wagtailembeds.blocks import EmbedBlock, EmbedValue
 from wagtail.wagtailembeds.models import Embed

--- a/wagtail/wagtailembeds/tests.py
+++ b/wagtail/wagtailembeds/tests.py
@@ -49,6 +49,14 @@ class TestGetDefaultFinder(TestCase):
     def test_find_oembed(self):
         self.assertEqual(get_default_finder(), wagtail_oembed)
 
+    @override_settings(WAGTAILEMBEDS_EMBED_FINDER='wagtail.wagtailembeds.finders.embedly')
+    def test_find_embedly_from_module(self):
+        self.assertEqual(get_default_finder(), wagtail_embedly)
+
+    @override_settings(WAGTAILEMBEDS_EMBED_FINDER='wagtail.wagtailembeds.finders.oembed')
+    def test_find_oembed_from_module(self):
+        self.assertEqual(get_default_finder(), wagtail_oembed)
+
     @override_settings(WAGTAILEMBEDS_EMBED_FINDER='wagtail.wagtailembeds.embeds.embedly')
     def test_find_old_embedly(self):
         self.assertEqual(get_default_finder(), wagtail_embedly)

--- a/wagtail/wagtailembeds/views/chooser.py
+++ b/wagtail/wagtailembeds/views/chooser.py
@@ -5,7 +5,8 @@ from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 from wagtail.wagtailembeds.forms import EmbedForm
 from wagtail.wagtailembeds.format import embed_to_editor_html
 
-from wagtail.wagtailembeds.embeds import EmbedNotFoundException, EmbedlyException, AccessDeniedEmbedlyException
+from wagtail.wagtailembeds.exceptions import EmbedNotFoundException
+from wagtail.wagtailembeds.finders.embedly import EmbedlyException, AccessDeniedEmbedlyException
 
 
 def chooser(request):


### PR DESCRIPTION
This pull request cleans up the ``wagtailembeds/embeds.py`` module by moving the "finders" into a separate folder.