### PR TITLE
Prevent page copy from breaking when M2M / tag fields are present - fixes #1852

### DIFF
--- a/wagtail/tests/testapp/migrations/0014_m2m_blog_page.py
+++ b/wagtail/tests/testapp/migrations/0014_m2m_blog_page.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import wagtail.wagtailcore.fields
+import modelcluster.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0020_add_index_on_page_first_published_at'),
+        ('tests', '0013_iconsetting_notyetregisteredsetting_testsetting'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='BlogCategory',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True, serialize=False)),
+                ('name', models.CharField(unique=True, max_length=80)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='BlogCategoryBlogPage',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True, serialize=False)),
+                ('category', models.ForeignKey(to='tests.BlogCategory', related_name='+')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='ManyToManyBlogPage',
+            fields=[
+                ('page_ptr', models.OneToOneField(primary_key=True, serialize=False, parent_link=True, auto_created=True, to='wagtailcore.Page')),
+                ('body', wagtail.wagtailcore.fields.RichTextField(blank=True)),
+                ('adverts', models.ManyToManyField(to='tests.Advert', blank=True)),
+                ('blog_categories', models.ManyToManyField(to='tests.BlogCategory', through='tests.BlogCategoryBlogPage', blank=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('wagtailcore.page',),
+        ),
+        migrations.AddField(
+            model_name='blogcategoryblogpage',
+            name='page',
+            field=modelcluster.fields.ParentalKey(to='tests.ManyToManyBlogPage', related_name='categories'),
+        ),
+    ]

--- a/wagtail/tests/testapp/migrations/0015_genericsnippetpage.py
+++ b/wagtail/tests/testapp/migrations/0015_genericsnippetpage.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0020_add_index_on_page_first_published_at'),
+        ('contenttypes', '0001_initial'),
+        ('tests', '0014_m2m_blog_page'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='GenericSnippetPage',
+            fields=[
+                ('page_ptr', models.OneToOneField(primary_key=True, parent_link=True, auto_created=True, to='wagtailcore.Page', serialize=False)),
+                ('snippet_object_id', models.PositiveIntegerField(null=True)),
+                ('snippet_content_type', models.ForeignKey(null=True, to='contenttypes.ContentType', on_delete=django.db.models.deletion.SET_NULL)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('wagtailcore.page',),
+        ),
+    ]

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 from django.db import models
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.utils.encoding import python_2_unicode_compatible
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.models import ContentType
 
 from taggit.models import TaggedItemBase
 from taggit.managers import TaggableManager
@@ -503,3 +505,13 @@ class ManyToManyBlogPage(Page):
     adverts = models.ManyToManyField(Advert, blank=True)
     blog_categories = models.ManyToManyField(
         BlogCategory, through=BlogCategoryBlogPage, blank=True)
+
+
+class GenericSnippetPage(Page):
+    """
+    A page containing a reference to an arbitrary snippet (or any model for that matter)
+    linked by a GenericForeignKey
+    """
+    snippet_content_type = models.ForeignKey(ContentType, on_delete=models.SET_NULL, null=True)
+    snippet_object_id = models.PositiveIntegerField(null=True)
+    snippet_content_object = GenericForeignKey('snippet_content_type', 'snippet_object_id')

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -479,3 +479,27 @@ class IconSetting(BaseSetting):
 
 class NotYetRegisteredSetting(BaseSetting):
     pass
+
+
+class BlogCategory(models.Model):
+    name = models.CharField(unique=True, max_length=80)
+
+
+class BlogCategoryBlogPage(models.Model):
+    category = models.ForeignKey(BlogCategory, related_name="+")
+    page = ParentalKey('ManyToManyBlogPage', related_name='categories')
+    panels = [
+        FieldPanel('category'),
+    ]
+
+
+class ManyToManyBlogPage(Page):
+    """
+    A page type with two different kinds of M2M relation.
+    We don't formally support these, but we don't want them to cause
+    hard breakages either.
+    """
+    body = RichTextField(blank=True)
+    adverts = models.ManyToManyField(Advert, blank=True)
+    blog_categories = models.ManyToManyField(
+        BlogCategory, through=BlogCategoryBlogPage, blank=True)

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -739,6 +739,11 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
                 if field.auto_created:
                     continue
 
+                # Ignore m2m relations - they will be copied as child objects
+                # if modelcluster supports them at all (as it does for tags)
+                if field.many_to_many:
+                    continue
+
                 # Ignore parent links (page_ptr)
                 if isinstance(field, models.OneToOneField) and field.parent_link:
                     continue

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -16,7 +16,8 @@ from wagtail.wagtailcore.models import Page, Site, PAGE_MODEL_CLASSES
 from wagtail.tests.testapp.models import (
     SingleEventPage, EventPage, EventIndex, SimplePage,
     BusinessIndex, BusinessSubIndex, BusinessChild, StandardIndex,
-    MTIBasePage, MTIChildPage, AbstractPage, TaggedPage)
+    MTIBasePage, MTIChildPage, AbstractPage, TaggedPage,
+    BlogCategory, BlogCategoryBlogPage, Advert, ManyToManyBlogPage)
 
 
 class TestSiteRouting(TestCase):
@@ -665,6 +666,27 @@ class TestCopyPage(TestCase):
             item_id not in old_tagged_item_ids
             for item_id in new_tagged_item_ids
         ]))
+
+    def test_copy_page_with_m2m_relations(self):
+        # create and publish a ManyToManyBlogPage under Events
+        event_index = Page.objects.get(url_path='/home/events/')
+        category = BlogCategory.objects.create(name='Birds')
+        advert = Advert.objects.create(url='http://www.heinz.com/', text="beanz meanz heinz")
+
+        blog_page = ManyToManyBlogPage(title='My blog page', slug='my-blog-page')
+        event_index.add_child(instance=blog_page)
+
+        blog_page.adverts.add(advert)
+        BlogCategoryBlogPage.objects.create(category=category, page=blog_page)
+        blog_page.save_revision().publish()
+
+        # copy to underneath homepage
+        homepage = Page.objects.get(url_path='/home/')
+        new_blog_page = blog_page.copy(to=homepage)
+
+        # M2M relations are not formally supported, so for now we're only interested in
+        # the copy operation as a whole succeeding, rather than the child objects being copied
+        self.assertNotEqual(blog_page.id, new_blog_page.id)
 
 
 class TestSubpageTypeBusinessRules(TestCase):


### PR DESCRIPTION
https://github.com/torchbox/wagtail/commit/ae691f7ed096dd3875b02a95b2cd5263a2c0c118 updated the page copy logic to use the `get_fields()` method from the new _meta API on Django 1.8 and above. However, the result of `get_fields()` includes M2M and tag relations, which were not part of the old `_meta.fields` list - these need to be filtered out, or else we get an error when it attempts to pass these fields to the new page's constructor.

In the case of plain M2M relations (not tags), we only test that the copy completes without an error, not that the child objects are copied - I believe it's always been the case that we don't copy these, and fixing this is out of scope for this PR. I've also included a test for generic foreign key fields, as it was reported in #1852 that these might also have problems - I wasn't able to reproduce any error with these, though.