### PR TITLE
Show the live database record in the page editor if there are no draft edits

### DIFF
--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -118,6 +118,11 @@ class RelatedLink(LinkFields):
 class SimplePage(Page):
     content = models.TextField()
 
+    content_panels = [
+        FieldPanel('title', classname="full title"),
+        FieldPanel('content'),
+    ]
+
 
 class PageWithOldStyleRouteMethod(Page):
     """

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -474,6 +474,15 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         return self.revisions.order_by('-created_at', '-id').first()
 
     def get_latest_revision_as_page(self):
+        if not self.has_unpublished_changes:
+            # Use the live database copy in preference to the revision record, as:
+            # 1) this will pick up any changes that have been made directly to the model,
+            #    such as automated data imports;
+            # 2) it ensures that inline child objects pick up real database IDs even if
+            #    those are absent from the revision data. (If this wasn't the case, the child
+            #    objects would be recreated with new IDs on next publish - see #1853)
+            return self.specific
+
         latest_revision = self.get_latest_revision()
 
         if latest_revision:
@@ -826,7 +835,7 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
 
         # Create a new revision
         # This code serves a few purposes:
-        # * It makes sure update_attrs gets applied to the latest revision so the changes are reflected in the editor
+        # * It makes sure update_attrs gets applied to the latest revision
         # * It bumps the last_revision_created_at value so the new page gets ordered as if it was just created
         # * It sets the user of the new revision so it's possible to see who copied the page by looking at its history
         latest_revision = page_copy.get_latest_revision_as_page()

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -447,6 +447,13 @@ class TestCopyPage(TestCase):
         self.assertEqual(latest_revision.title, "New christmas event")
         self.assertEqual(latest_revision.slug, 'new-christmas-event')
 
+        # get_latest_revision_as_page might bypass the revisions table if it determines
+        # that there are no draft edits since publish - so retrieve it explicitly from the
+        # revision data, to ensure it's been updated there too
+        latest_revision = new_christmas_event.get_latest_revision().as_page_object()
+        self.assertEqual(latest_revision.title, "New christmas event")
+        self.assertEqual(latest_revision.slug, 'new-christmas-event')
+
         # Check that the ids within the revision were updated correctly
         new_revision = new_christmas_event.revisions.first()
         new_revision_content = json.loads(new_revision.content_json)


### PR DESCRIPTION
Return the live database record as the result of get_latest_revision_as_page if there are no draft edits.

This ensures that the live database state will be reflected in the page editor, which provides two benefits:
* any changes made directly at the model / database level (e.g. automated data imports) will be visible in the editor
* inline child objects will be associated with their actual database IDs even if this information is missing from the revision record. This ensures that their IDs will be preserved on next publish, rather than the records being deleted and recreated (#1853)