### PR TITLE
Fix regressions in page chooser navigation

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/_link_types.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/_link_types.html
@@ -1,22 +1,22 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 {% if allow_external_link or allow_email_link or current == 'external' or current == 'email' %}
     <p class="link-types">
         {% if current == 'internal' %}
             <b>{% trans "Internal link" %}</b>
         {% else %}
-            <a href="{% url 'wagtailadmin_choose_page' %}?{{ querystring }}">{% trans "Internal link" %}</a>
+            <a href="{% url 'wagtailadmin_choose_page' %}{% querystring p=None %}">{% trans "Internal link" %}</a>
         {% endif %}
 
         {% if current == 'external' %}
             | <b>{% trans "External link" %}</b>
         {% elif allow_external_link %}
-            | <a href="{% url 'wagtailadmin_choose_page_external_link' %}?{{ querystring }}">{% trans "External link" %}</a>
+            | <a href="{% url 'wagtailadmin_choose_page_external_link' %}{% querystring p=None %}">{% trans "External link" %}</a>
         {% endif %}
 
         {% if current == 'email' %}
             | <b>{% trans "Email link" %}</b>
         {% elif allow_email_link %}
-            | <a href="{% url 'wagtailadmin_choose_page_email_link' %}?{{ querystring }}">{% trans "Email link" %}</a>
+            | <a href="{% url 'wagtailadmin_choose_page_email_link' %}{% querystring p=None %}">{% trans "Email link" %}</a>
         {% endif %}
     </p>
 {% endif %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/email_link.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/email_link.html
@@ -5,7 +5,7 @@
 <div class="nice-padding">
     {% include 'wagtailadmin/chooser/_link_types.html' with current='email' %}
 
-    <form action="{% url 'wagtailadmin_choose_page_email_link' %}?{% querystring %}" method="post">
+    <form action="{% url 'wagtailadmin_choose_page_email_link' %}{% querystring %}" method="post">
         {% csrf_token %}
         <ul class="fields">
             {% for field in form %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link.html
@@ -5,7 +5,7 @@
 <div class="nice-padding">
     {% include 'wagtailadmin/chooser/_link_types.html' with current='external' %}
 
-    <form action="{% url 'wagtailadmin_choose_page_external_link' %}?{% querystring %}" method="post">
+    <form action="{% url 'wagtailadmin_choose_page_external_link' %}{% querystring %}" method="post">
         {% csrf_token %}
         <ul class="fields">
             {% for field in form %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_navigation_choose.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_navigation_choose.html
@@ -6,6 +6,6 @@ Navigation controls for the page listing in 'choose' mode
 
 <td class="{% if allow_navigation and page.can_descend %}children{% endif %}">
     {% if allow_navigation and page.can_descend %}
-        <a href="{% url 'wagtailadmin_choose_page_child' page.id %}?{% querystring page=None %}" class="icon text-replace icon-arrow-right navigate-pages" title="{% blocktrans with title=page.title %}Explore subpages of '{{ title }}'{% endblocktrans %}">{% trans 'Explore' %}</a>
+        <a href="{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring page=None %}" class="icon text-replace icon-arrow-right navigate-pages" title="{% blocktrans with title=page.title %}Explore subpages of '{{ title }}'{% endblocktrans %}">{% trans 'Explore' %}</a>
     {% endif %}
 </td>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_navigation_choose.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_navigation_choose.html
@@ -6,6 +6,6 @@ Navigation controls for the page listing in 'choose' mode
 
 <td class="{% if allow_navigation and page.can_descend %}children{% endif %}">
     {% if allow_navigation and page.can_descend %}
-        <a href="{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring page=None %}" class="icon text-replace icon-arrow-right navigate-pages" title="{% blocktrans with title=page.title %}Explore subpages of '{{ title }}'{% endblocktrans %}">{% trans 'Explore' %}</a>
+        <a href="{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}" class="icon text-replace icon-arrow-right navigate-pages" title="{% blocktrans with title=page.title %}Explore subpages of '{{ title }}'{% endblocktrans %}">{% trans 'Explore' %}</a>
     {% endif %}
 </td>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/breadcrumb.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/breadcrumb.html
@@ -1,14 +1,14 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 <ul class="breadcrumb">
     {% for page in page.get_ancestors %}
         {% if page.is_root %}
-            <li class="home"><a href="{% if choosing %}{% url 'wagtailadmin_choose_page_child' page.id %}?{{ querystring }}{% else %}{% url 'wagtailadmin_explore_root' %}{% endif %}" class="{% if choosing %}navigate-pages{% endif %} icon icon-home text-replace">{% trans 'Home' %}</a></li>
+            <li class="home"><a href="{% if choosing %}{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}{% else %}{% url 'wagtailadmin_explore_root' %}{% endif %}" class="{% if choosing %}navigate-pages{% endif %} icon icon-home text-replace">{% trans 'Home' %}</a></li>
         {% else %}
-            <li><a href="{% if choosing %}{% url 'wagtailadmin_choose_page_child' page.id %}?{{ querystring }}{% else %}{% url 'wagtailadmin_explore' page.id %}{% endif %}" {% if choosing %}class="navigate-pages"{% endif %}>{{ page.title }}</a></li>
+            <li><a href="{% if choosing %}{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}{% else %}{% url 'wagtailadmin_explore' page.id %}{% endif %}" {% if choosing %}class="navigate-pages"{% endif %}>{{ page.title }}</a></li>
         {% endif %}
     {% endfor %}
     {% if include_self %}
-        <li><a href="{% if choosing %}{% url 'wagtailadmin_choose_page_child' page.id %}?{{ querystring }}{% else %}{% url 'wagtailadmin_explore' page.id %}{% endif %}" {% if choosing %}class="navigate-pages"{% endif %}>{{ page.title }}</a></li>
+        <li><a href="{% if choosing %}{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}{% else %}{% url 'wagtailadmin_explore' page.id %}{% endif %}" {% if choosing %}class="navigate-pages"{% endif %}>{{ page.title }}</a></li>
     {% endif %}
 </ul>


### PR DESCRIPTION
Fixing some subtle but important regressions in the way that querystrings are passed on in navigation within the page chooser. Primarily these affected the 'link type' (internal/external/email) navigation links that appear when launching the chooser from the rich text editor; the parameters controlling the display of these (`allow_external_link` and `allow_email_link`) would get lost when navigating the tree:

* The breadcrumb and link type navigation links were still referencing the `{{ querystring }}` context var which has now been removed; these have been updated to use the `{% querystring %}` tag
* Some links that use the `{% querystring %}` tag were inserting their own `?` character, duplicating the one that the tag provides. This was causing the first parameter in the querystring to get swallowed up, as the second `?` was interpreted as part of the parameter name
* The 'browse child' navigation links were using `{% querystring page=None %}` when in fact the correct parameter is `{% querystring p=None %}`. Nullifying the wrong parameter meant that the page number would persist when browsing to a child (e.g. following a child link on page 2 of a listing would take you to page 2 of the child's listing).