### PR TITLE
Link to homepage from dashboard page link if single site

### DIFF
--- a/wagtail/wagtailadmin/site_summary.py
+++ b/wagtail/wagtailadmin/site_summary.py
@@ -1,5 +1,5 @@
 from wagtail.wagtailcore import hooks
-from wagtail.wagtailcore.models import Page
+from wagtail.wagtailcore.models import Page, Site
 from wagtail.utils.compat import render_to_string
 
 
@@ -21,7 +21,13 @@ class PagesSummaryItem(SummaryItem):
     template = 'wagtailadmin/home/site_summary_pages.html'
 
     def get_context(self):
+        # If there is a single site, link to the homepage of that site
+        # Otherwise, if there are multiple sites, link to the root page
+        single_site = Site.objects.count() == 1
+        root = self.request.site.root_page if single_site else None
         return {
+            'single_site': single_site,
+            'root_page': root,
             'total_pages': Page.objects.count() - 1,  # subtract 1 because the root node is not a real page
         }
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/home/site_summary_pages.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/home/site_summary_pages.html
@@ -1,7 +1,7 @@
 {% load i18n wagtailadmin_tags %}
 
 <li class="icon icon-doc-empty-inverse">
-    <a href="{% url 'wagtailadmin_explore_root' %}">
+<a href="{% if single_site %}{% url 'wagtailadmin_explore' root_page.pk %}{% else %}{% url 'wagtailadmin_explore_root' %}{% endif %}">
     {% blocktrans count counter=total_pages with total_pages|intcomma as total %}
         <span>{{ total }}</span> Page
     {% plural %}

--- a/wagtail/wagtailadmin/tests/tests.py
+++ b/wagtail/wagtailadmin/tests/tests.py
@@ -4,16 +4,16 @@ from __future__ import unicode_literals
 
 import json
 
-from django.test import TestCase, override_settings
-from django.core.urlresolvers import reverse
-from django.core import mail
 from django.contrib.auth import get_user_model
-
+from django.core import mail
+from django.core.urlresolvers import reverse
+from django.test import TestCase, override_settings
 from taggit.models import Tag
 
 from wagtail.tests.utils import WagtailTestUtils
-from wagtail.wagtailcore.models import Page
+from wagtail.wagtailadmin.site_summary import PagesSummaryItem
 from wagtail.wagtailadmin.utils import send_mail
+from wagtail.wagtailcore.models import Page, Site
 
 
 class TestHome(TestCase, WagtailTestUtils):
@@ -63,6 +63,40 @@ class TestHome(TestCase, WagtailTestUtils):
         self.client.login(username='snowman', password='password')
         response = self.client.get(reverse('wagtailadmin_home'))
         self.assertEqual(response.status_code, 200)
+
+
+class TestPagesSummary(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.login()
+
+    def get_request(self):
+        """
+        Get a Django WSGI request that has been passed through middleware etc.
+        """
+        return self.client.get('/admin/').wsgi_request
+
+    def test_page_summary_single_site(self):
+        request = self.get_request()
+        root_page = request.site.root_page
+        link = '<a href="{}">'.format(reverse('wagtailadmin_explore', args=[root_page.pk]))
+        page_summary = PagesSummaryItem(request)
+        self.assertIn(link, page_summary.render())
+
+    def test_page_summary_multiple_sites(self):
+        Site.objects.create(
+            hostname='example.com',
+            root_page=Page.objects.get(pk=1))
+        request = self.get_request()
+        link = '<a href="{}">'.format(reverse('wagtailadmin_explore_root'))
+        page_summary = PagesSummaryItem(request)
+        self.assertIn(link, page_summary.render())
+
+    def test_page_summary_zero_sites(self):
+        Site.objects.all().delete()
+        request = self.get_request()
+        link = '<a href="{}">'.format(reverse('wagtailadmin_explore_root'))
+        page_summary = PagesSummaryItem(request)
+        self.assertIn(link, page_summary.render())
 
 
 class TestEditorHooks(TestCase, WagtailTestUtils):


### PR DESCRIPTION
If the Wagtail install has only one site, link to the homepage of that site from the dashboard page summary instead of the root page of the hierarchy.

Hopefully this will prevent some of the confusion causing people to create pages under the root page, where they are inaccessible. See #1612 for more information around this issue.

Wagtail installs with multiple (or zero) sites retain the old behaviour of linking to the root page.