### PR TITLE
Ensure errors in embed chooser are propagated back to the form

### DIFF
--- a/wagtail/wagtailembeds/format.py
+++ b/wagtail/wagtailembeds/format.py
@@ -21,17 +21,15 @@ def embed_to_frontend_html(url):
             'ratio': ratio,
         })
     except embeds.EmbedException:
+        # silently ignore failed embeds, rather than letting them crash the page
         return ''
 
 
 def embed_to_editor_html(url):
-    try:
-        embed = embeds.get_embed(url)
+    embed = embeds.get_embed(url)
+    # catching EmbedException is the responsibility of the caller
 
-        # Render template
-        return render_to_string('wagtailembeds/embed_editor.html', {
-            'embed': embed,
-        })
-    except embeds.EmbedException:
-        # Could be replaced with a nice error message
-        return ''
+    # Render template
+    return render_to_string('wagtailembeds/embed_editor.html', {
+        'embed': embed,
+    })

--- a/wagtail/wagtailembeds/rich_text.py
+++ b/wagtail/wagtailembeds/rich_text.py
@@ -1,4 +1,4 @@
-from wagtail.wagtailembeds import format
+from wagtail.wagtailembeds import format, embeds
 
 
 class MediaEmbedHandler(object):
@@ -26,6 +26,10 @@ class MediaEmbedHandler(object):
         representation.
         """
         if for_editor:
-            return format.embed_to_editor_html(attrs['url'])
+            try:
+                return format.embed_to_editor_html(attrs['url'])
+            except embeds.EmbedException:
+                # Could be replaced with a nice error message
+                return ''
         else:
             return format.embed_to_frontend_html(attrs['url'])

--- a/wagtail/wagtailembeds/views/chooser.py
+++ b/wagtail/wagtailembeds/views/chooser.py
@@ -8,7 +8,6 @@ from wagtail.wagtailembeds.format import embed_to_editor_html
 from wagtail.wagtailembeds.embeds import EmbedNotFoundException, EmbedlyException, AccessDeniedEmbedlyException
 
 
-
 def chooser(request):
     form = EmbedForm()
 


### PR DESCRIPTION
Fixes #1885.

In #1381 the behaviour of `wagtail.wagtailembeds.formats.embed_to_editor_html` was changed to ignore any errors in embed lookup, to prevent these from crashing the page entirely. However, this function is also used when the embed is first inserted; catching these errors meant that the error messages were never communicated back to the user (and instead hallo.js ends up throwing a JS error while trying to insert an empty embed element into the rich text area).