### PR TITLE
Pass the original StructValue to StructBlock templates so that value.bound_blocks works

### DIFF
--- a/wagtail/tests/testapp/blocks.py
+++ b/wagtail/tests/testapp/blocks.py
@@ -12,3 +12,11 @@ class LinkBlock(blocks.StructBlock):
 
     class Meta:
         template = 'tests/blocks/link_block.html'
+
+
+class SectionBlock(blocks.StructBlock):
+    title = blocks.CharBlock()
+    body = blocks.RichTextBlock()
+
+    class Meta:
+        template = 'tests/blocks/section_block.html'

--- a/wagtail/tests/testapp/templates/tests/blocks/section_block.html
+++ b/wagtail/tests/testapp/templates/tests/blocks/section_block.html
@@ -1,0 +1,1 @@
+<h1>{{ value.title }}</h1>{{ value.bound_blocks.body.render }}

--- a/wagtail/wagtailcore/blocks/struct_block.py
+++ b/wagtail/wagtailcore/blocks/struct_block.py
@@ -160,11 +160,6 @@ class BaseStructBlock(Block):
 
         return errors
 
-    def render(self, value):
-        value = collections.OrderedDict(
-            (key, value.get(key)) for key in self.child_blocks.keys())
-        return super(BaseStructBlock, self).render(value)
-
 
 class StructBlock(six.with_metaclass(DeclarativeSubBlocksMetaclass, BaseStructBlock)):
     pass

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -522,10 +522,10 @@ class TestStructBlock(SimpleTestCase):
             link = blocks.URLBlock()
 
         block = LinkBlock()
-        html = block.render({
+        html = block.render(block.to_python({
             'title': "Wagtail site",
             'link': 'http://www.wagtail.io',
-        })
+        }))
         expected_html = '\n'.join([
             '<dl>',
             '<dt>title</dt>',
@@ -543,11 +543,11 @@ class TestStructBlock(SimpleTestCase):
             link = blocks.URLBlock()
 
         block = LinkBlock()
-        html = block.render({
+        html = block.render(block.to_python({
             'title': "Wagtail site",
             'link': 'http://www.wagtail.io',
             'image': 10,
-        })
+        }))
 
         self.assertIn('<dt>title</dt>', html)
         self.assertIn('<dd>Wagtail site</dd>', html)
@@ -563,10 +563,10 @@ class TestStructBlock(SimpleTestCase):
             link = blocks.URLBlock()
 
         block = LinkBlock()
-        html = block.render_form({
+        html = block.render_form(block.to_python({
             'title': "Wagtail site",
             'link': 'http://www.wagtail.io',
-        }, prefix='mylink')
+        }), prefix='mylink')
 
         self.assertIn('<div class="struct-block">', html)
         self.assertIn('<div class="field char_field widget-text_input fieldname-title">', html)
@@ -580,11 +580,11 @@ class TestStructBlock(SimpleTestCase):
             link = blocks.URLBlock()
 
         block = LinkBlock()
-        html = block.render_form({
+        html = block.render_form(block.to_python({
             'title': "Wagtail site",
             'link': 'http://www.wagtail.io',
             'image': 10,
-        }, prefix='mylink')
+        }), prefix='mylink')
 
         self.assertIn('<input id="mylink-title" name="mylink-title" placeholder="Title" type="text" value="Wagtail site" />', html)
         self.assertIn('<input id="mylink-link" name="mylink-link" placeholder="Link" type="url" value="http://www.wagtail.io" />', html)
@@ -598,7 +598,7 @@ class TestStructBlock(SimpleTestCase):
             link = blocks.URLBlock(default="http://www.torchbox.com")
 
         block = LinkBlock()
-        html = block.render_form({}, prefix='mylink')
+        html = block.render_form(block.to_python({}), prefix='mylink')
 
         self.assertIn('<input id="mylink-title" name="mylink-title" placeholder="Title" type="text" value="Torchbox" />', html)
         self.assertIn('<input id="mylink-link" name="mylink-link" placeholder="Link" type="url" value="http://www.torchbox.com" />', html)
@@ -612,19 +612,19 @@ class TestStructBlock(SimpleTestCase):
                 help_text = "Self-promotion is encouraged"
 
         block = LinkBlock()
-        html = block.render_form({
+        html = block.render_form(block.to_python({
             'title': "Wagtail site",
             'link': 'http://www.wagtail.io',
-        }, prefix='mylink')
+        }), prefix='mylink')
 
         self.assertIn('<div class="object-help help">Self-promotion is encouraged</div>', html)
 
         # check it can be overridden in the block constructor
         block = LinkBlock(help_text="Self-promotion is discouraged")
-        html = block.render_form({
+        html = block.render_form(block.to_python({
             'title': "Wagtail site",
             'link': 'http://www.wagtail.io',
-        }, prefix='mylink')
+        }), prefix='mylink')
 
         self.assertIn('<div class="object-help help">Self-promotion is discouraged</div>', html)
 
@@ -657,10 +657,10 @@ class TestStructBlock(SimpleTestCase):
             link = blocks.URLBlock()
 
         block = LinkBlock()
-        content = block.get_searchable_content({
+        content = block.get_searchable_content(block.to_python({
             'title': "Wagtail site",
             'link': 'http://www.wagtail.io',
-        })
+        }))
 
         self.assertEqual(content, ["Wagtail site"])
 

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -13,6 +13,8 @@ from wagtail.wagtailcore import blocks
 from wagtail.wagtailcore.rich_text import RichText
 from wagtail.wagtailcore.models import Page
 
+from wagtail.tests.testapp.blocks import SectionBlock
+
 import base64
 
 
@@ -713,6 +715,16 @@ class TestStructBlock(SimpleTestCase):
         value = block.to_python({'title': 'Torchbox', 'link': 'not a url'})
         with self.assertRaises(ValidationError):
             block.clean(value)
+
+    def test_bound_blocks_are_available_on_template(self):
+        """
+        Test that we are able to use value.bound_blocks within templates
+        to access a child block's own HTML rendering
+        """
+        block = SectionBlock()
+        value = block.to_python({'title': 'Hello', 'body': '<i>italic</i> world'})
+        result = block.render(value)
+        self.assertEqual(result, """<h1>Hello</h1><div class="rich-text"><i>italic</i> world</div>""")
 
 
 class TestListBlock(unittest.TestCase):


### PR DESCRIPTION
In the process of writing #1889, I discovered that the bound_block example at the end of http://docs.wagtail.io/en/v1.1/topics/streamfield.html#template-rendering, aside from not actually being necessary for RichTextBlock, doesn't actually work on latest master. The regression was caused by b6fba1b5907ec90a7791a4fbd35d4e858eafe827, which substitutes the StructValue instance (which has a `bound_blocks` accessor) with a plain OrderedDict (which doesn't).

On further consideration, the test that was originally being fixed in b6fba1b5907ec90a7791a4fbd35d4e858eafe827 was at fault - it's passing a plain dict to `render`. The behaviour in this case is undefined - in normal circumstances `render` will receive a StructValue constructed by the block itself. When this happens, the issues with ordering / unrecognised fields don't arise.

This PR makes those tests valid by running the dict through block.to_python, backs out the unnecessary fix from b6fba1b5907ec90a7791a4fbd35d4e858eafe827, and adds a new test to confirm that value.bound_blocks is available within StructBlock templates.