### PR TITLE
Allow subclasses of CreateView/EditView to omit template_name

### DIFF
--- a/wagtail/wagtailadmin/views/generic.py
+++ b/wagtail/wagtailadmin/views/generic.py
@@ -58,6 +58,8 @@ class IndexView(PermissionCheckedMixin, View):
 
 
 class CreateView(PermissionCheckedMixin, View):
+    template_name = 'wagtailadmin/generic/create.html'
+
     def get_add_url(self):
         return reverse(self.add_url_name)
 
@@ -87,6 +89,7 @@ class CreateView(PermissionCheckedMixin, View):
 class EditView(PermissionCheckedMixin, View):
     page_title = __("Editing")
     context_object_name = None
+    template_name = 'wagtailadmin/generic/edit.html'
 
     def get_page_subtitle(self):
         return str(self.instance)


### PR DESCRIPTION
A pre-requisite for collections (#1751) - decoupling from that PR to be reviewed independently.

As of #1668, the create.html and edit.html templates in wagtailadmin/generic provide a usable form rendering in their own right, so apps based on generic views can now use those templates directly rather than inheriting from them. This PR sets a default `template_name` on the generic views so that subclasses can omit this parameter in this case.