### PR TITLE
Add user_passes_test auth decorator

### DIFF
--- a/wagtail/tests/testapp/urls.py
+++ b/wagtail/tests/testapp/urls.py
@@ -1,0 +1,6 @@
+from django.conf.urls import url
+from wagtail.tests.testapp.views import bob_only_zone
+
+urlpatterns = [
+    url(r'^bob-only-zone$', bob_only_zone, name='testapp_bob_only_zone'),
+]

--- a/wagtail/tests/testapp/views.py
+++ b/wagtail/tests/testapp/views.py
@@ -1,0 +1,12 @@
+from django.http import HttpResponse
+
+from wagtail.wagtailadmin.utils import user_passes_test
+
+
+def user_is_called_bob(user):
+    return user.first_name == 'Bob'
+
+
+@user_passes_test(user_is_called_bob)
+def bob_only_zone(request):
+    return HttpResponse("Bobs of the world unite!")

--- a/wagtail/tests/urls.py
+++ b/wagtail/tests/urls.py
@@ -8,6 +8,8 @@ from wagtail.wagtailsearch import urls as wagtailsearch_urls
 from wagtail.contrib.wagtailsitemaps.views import sitemap
 from wagtail.contrib.wagtailapi import urls as wagtailapi_urls
 
+from wagtail.tests.testapp import urls as testapp_urls
+
 
 urlpatterns = [
     url(r'^admin/', include(wagtailadmin_urls)),
@@ -17,6 +19,8 @@ urlpatterns = [
 
     url(r'^api/', include(wagtailapi_urls)),
     url(r'^sitemap\.xml$', sitemap),
+
+    url(r'^testapp/', include(testapp_urls)),
 
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's serving mechanism

--- a/wagtail/wagtailadmin/tests/tests.py
+++ b/wagtail/wagtailadmin/tests/tests.py
@@ -178,3 +178,25 @@ class TestTagsAutocomplete(TestCase, WagtailTestUtils):
         data = json.loads(response.content.decode('utf-8'))
 
         self.assertEqual(data, [])
+
+
+class TestUserPassesTestPermissionDecorator(TestCase):
+    """
+    Test for custom user_passes_test permission decorators.
+    testapp_bob_only_zone is a view configured to only grant access to users with a first_name of Bob
+    """
+    def test_user_passes_test(self):
+        # create and log in as a user called Bob
+        get_user_model().objects.create_superuser(first_name='Bob', last_name='Mortimer', username='test', email='test@email.com', password='password')
+        self.client.login(username='test', password='password')
+
+        response = self.client.get(reverse('testapp_bob_only_zone'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_user_fails_test(self):
+        # create and log in as a user not called Bob
+        get_user_model().objects.create_superuser(first_name='Vic', last_name='Reeves', username='test', email='test@email.com', password='password')
+        self.client.login(username='test', password='password')
+
+        response = self.client.get(reverse('testapp_bob_only_zone'))
+        self.assertRedirects(response, reverse('wagtailadmin_home'))


### PR DESCRIPTION
A pre-requisite for collections (#1751) - decoupling from that PR to be reviewed independently.

Refactor the `permission_required` and `any_permission_required` decorators to expose a lower-level `user_passes_test` decorator that can be passed an arbitrary test function on the user object. (This mirrors the same-named decorator in django.contrib.auth, but provides a wagtailadmin-specific 'permission denied' response and avoids using LOGIN_URL.)

In particular, this means that we can restrict access based on PagePermission or CollectionPermission rules, which are distinct from the basic Permission model.