### PR TITLE
Remove unused wagtailimages_tags from group edit page

### DIFF
--- a/wagtail/wagtailusers/templates/wagtailusers/groups/edit.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/edit.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailusers_tags wagtailimages_tags static compress i18n %}
+{% load wagtailusers_tags static compress i18n %}
 
 {% block titletag %}{% trans "Editing" %} {{ group.name }}{% endblock %}
 


### PR DESCRIPTION
The `wagtailimages_tags` library was needlessly loaded on the group edit page. This causes an error on installations that do not use `wagtailimages`, or test suites for Wagtail plugins that do not use images directly.