### PR TITLE
Dropdowns now don't close if the click detected originated within them

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -74,19 +74,26 @@ $(function() {
         $('.tab-nav a[href="' + $(this).attr('href') + '"]').click();
     });
 
-    $('.dropdown').each(function(){
+    $('.dropdown').each(function() {
         var $dropdown = $(this);
 
         $('.dropdown-toggle', $dropdown).on('click', function(e) {
             e.stopPropagation();
             $dropdown.toggleClass('open');
-        });
 
-        $('body').on('click', function(e) {
-            var relTarg = e.relatedTarget || e.toElement;
-            // Only close dropdown if the click target wasn't a child of this dropdown
-            if (!$(relTarg).parents().is($dropdown)) {
-                $dropdown.removeClass('open');
+            if ($dropdown.hasClass('open')) {
+                // If a dropdown is opened, add an event listener for document clicks to close it
+                $(document).on('click.dropdown.cancel', function(e) {
+                    var relTarg = e.relatedTarget || e.toElement;
+
+                    // Only close dropdown if the click target wasn't a child of this dropdown
+                    if (!$(relTarg).parents().is($dropdown)) {
+                        $dropdown.removeClass('open');
+                        $(document).off('click.dropdown.cancel');
+                    }
+                });
+            } else {
+                $(document).off('click.dropdown.cancel');
             }
         });
     });

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -74,19 +74,21 @@ $(function() {
         $('.tab-nav a[href="' + $(this).attr('href') + '"]').click();
     });
 
-    $('.dropdown-toggle').bind('click', function() {
-        $(this).closest('.dropdown').toggleClass('open');
+    $('.dropdown').each(function(){
+        var $dropdown = $(this);
 
-        // Stop event propagating so the "close all dropdowns on body clicks" code (below) doesn't immediately close the dropdown
-        return false;
-    });
+        $('.dropdown-toggle', $dropdown).on('click', function(e) {
+            e.stopPropagation();
+            $dropdown.toggleClass('open');
+        });
 
-    /* close all dropdowns on body clicks */
-    $(document).on('click', function(e) {
-        var relTarg = e.relatedTarget || e.toElement;
-        if (!$(relTarg).hasClass('dropdown-toggle')) {
-            $('.dropdown').removeClass('open');
-        }
+        $('body').on('click', function(e) {
+            var relTarg = e.relatedTarget || e.toElement;
+            // Only close dropdown if the click target wasn't a child of this dropdown
+            if (!$(relTarg).parents().is($dropdown)) {
+                $dropdown.removeClass('open');
+            }
+        });
     });
 
     /* Dropzones */


### PR DESCRIPTION
This reinstates code I removed during the initial merger of #1075  (https://github.com/torchbox/wagtail/pull/1075#discussion-diff-26763533) because I wanted to find a better solution.

Currently although the page "publish" button supports a long-running spinner, it's never visible because without the code in this PR, the dropdown in which it lives closes as the button is clicked.