### PR TITLE
Remove the evil pixel border

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/main-nav.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/main-nav.scss
@@ -320,7 +320,6 @@ body.explorer-open {
         left:$menu-width;
         overflow:auto;
         max-height:100%;
-        border-right:1px solid rgba(0,0,0,0.1);
 
         h2,ul{
             float:right;


### PR DESCRIPTION
Don't know if it is intentional, but this pixel border on submenu just makes me crazy :)

![evilpixel](https://cloud.githubusercontent.com/assets/14926363/10945390/81aa41e2-831d-11e5-84e5-1ea68aad7e9d.jpg)
  