### PR TITLE
Advertise python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ matrix:
      python: 3.5
    - env: TOXENV=py35-dj18-mysql
      python: 3.5
-  allow_failures:
-    - python: 3.5
 
 # Services
 services:

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Wagtail is sponsored by `Torchbox <https://torchbox.com/>`_. If you need help im
 
 Compatibility
 ~~~~~~~~~~~~~
-Wagtail supports Django 1.7.1+ on Python 2.7, 3.3 and 3.4. Supported database backends are PostgreSQL, MySQL and SQLite.
+Wagtail supports Django 1.7.1+ on Python 2.7, 3.3, 3.4 and 3.5. Supported database backends are PostgreSQL, MySQL and SQLite.
 
 Contributing
 ~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Framework :: Django',
         'Topic :: Internet :: WWW/HTTP :: Site Management',
     ],


### PR DESCRIPTION
Django 1.8.6 adds official support for Python 3.5 into Django and Wagtail's run fine on Python 3.5 for months (despite Django not "officially" supporting it).

This PR adds Python 3.5 support into setup.py/readme.md