### PR TITLE
Handle reverse_lazy generated urls

### DIFF
--- a/wagtail/wagtailadmin/menu.py
+++ b/wagtail/wagtailadmin/menu.py
@@ -35,7 +35,7 @@ class MenuItem(with_metaclass(MediaDefiningClass)):
         return True
 
     def is_active(self, request):
-        return request.path.startswith(self.url)
+        return request.path.startswith(text_type(self.url)) # self.url may be a reverse_lazy object
 
     def render_html(self, request):
         return render_to_string(self.template, {


### PR DESCRIPTION
To allow for lazy url generation in hook registration, see https://github.com/unbit/django-uwsgi/blob/master/django_uwsgi/wagtail_hooks.py#L41 for an example