### PR TITLE
Add --postgres and --elasticsearch arguments to runtests.py

### DIFF
--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -92,16 +92,19 @@ the tests against it.
 
 To test Elasticsearch, you need to have the ``elasticsearch`` package installed.
 
-Once installed, Wagtail will attempt to connect to a local instance of
-Elasticsearch (``http://localhost:9200``) and use the index ``test_wagtail``.
+Once installed, you can test Wagtail with Elasticsearch by passing the
+``--elasticsearch`` argument to ``runtests.py``::
+
+    python runtests.py --elasticsearch
+
+
+Wagtail will attempt to connect to a local instance of Elasticsearch
+(``http://localhost:9200``) and use the index ``test_wagtail``.
 
 If your Elasticsearch instance is located somewhere else, you can set the
 ``ELASTICSEARCH_URL`` environment variable to point to its location::
 
-    ELASTICSEARCH_URL=http://my-elasticsearch-instance:9200 python runtests.py
-
-If you no longer want Wagtail to test against Elasticsearch, uninstall the
-``elasticsearch`` package.
+    ELASTICSEARCH_URL=http://my-elasticsearch-instance:9200 python runtests.py --elasticsearch
 
 Compiling static assets
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -90,10 +90,8 @@ the tests against it.
 
 **Testing Elasticsearch**
 
-To test Elasticsearch, you need to have the ``elasticsearch`` package installed.
-
-Once installed, you can test Wagtail with Elasticsearch by passing the
-``--elasticsearch`` argument to ``runtests.py``::
+You can test Wagtail against Elasticsearch by passing the ``--elasticsearch``
+argument to ``runtests.py``::
 
     python runtests.py --elasticsearch
 

--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -71,16 +71,22 @@ an argument to ``runtests.py``::
 
 **Testing against PostgreSQL**
 
-By default, Wagtail tests against SQLite. If you need to test against a
-different database, set the ``DATABASE_ENGINE`` environment variable to the
-name of the Django database backend to test against::
+By default, Wagtail tests against SQLite. You can switch to using PostgreSQL by
+using the ``--postgres`` argument::
 
-    DATABASE_ENGINE=django.db.backends.postgresql_psycopg2 python runtests.py
-
-This will create a new database called ``test_wagtail`` in PostgreSQL and run
-the tests against it.
+    python runtests.py --postgres
 
 If you need to use a different user, password or host. Use the ``PGUSER``, ``PGPASSWORD`` and ``PGHOST`` environment variables.
+
+**Testing against a different database**
+
+If you need to test against a different database, set the ``DATABASE_ENGINE``
+environment variable to the name of the Django database backend to test against::
+
+    DATABASE_ENGINE=django.db.backends.mysql python runtests.py
+
+This will create a new database called ``test_wagtail`` in MySQL and run
+the tests against it.
 
 **Testing Elasticsearch**
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ mock>=1.0.0
 python-dateutil>=2.2
 pytz>=2014.7
 Pillow>=2.7.0
+elasticsearch>=1.0.0
 
 # For coverage and PEP8 linting
 coverage>=3.7.0

--- a/runtests.py
+++ b/runtests.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
+
 import sys
 import os
 import shutil
 import warnings
 
 from django.core.management import execute_from_command_line
-
-from wagtail.tests.settings import STATIC_ROOT, MEDIA_ROOT
 
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'wagtail.tests.settings'
@@ -17,10 +16,17 @@ def runtests():
     warnings.simplefilter('default', DeprecationWarning)
     warnings.simplefilter('default', PendingDeprecationWarning)
 
-    argv = sys.argv[:1] + ['test'] + sys.argv[1:]
+    args = sys.argv[1:]
+
+    if '--postgres' in args:
+        os.environ['DATABASE_ENGINE'] = 'django.db.backends.postgresql_psycopg2'
+        args.remove('--postgres')
+
+    argv = sys.argv[:1] + ['test'] + args
     try:
         execute_from_command_line(argv)
     finally:
+        from wagtail.tests.settings import STATIC_ROOT, MEDIA_ROOT
         shutil.rmtree(STATIC_ROOT, ignore_errors=True)
         shutil.rmtree(MEDIA_ROOT, ignore_errors=True)
 

--- a/runtests.py
+++ b/runtests.py
@@ -22,6 +22,10 @@ def runtests():
         os.environ['DATABASE_ENGINE'] = 'django.db.backends.postgresql_psycopg2'
         args.remove('--postgres')
 
+    if '--elasticsearch' in args:
+        os.environ.setdefault('ELASTICSEARCH_URL', 'http://localhost:9200')
+        args.remove('--elasticsearch')
+
     argv = sys.argv[:1] + ['test'] + args
     try:
         execute_from_command_line(argv)

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ ignore = E501,E128,E261,E302,E303,E124,E126
 exclude = wagtail/project_template/*
 
 [testenv]
-commands=coverage run runtests.py
+commands=coverage run runtests.py --elasticsearch
 
 basepython =
     py27: python2.7

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -157,23 +157,14 @@ WAGTAILSEARCH_BACKENDS = {
 
 AUTH_USER_MODEL = 'customuser.CustomUser'
 
-try:
-    # Only add Elasticsearch backend if the elasticsearch-py library is installed
-    import elasticsearch  # noqa
-
-    # Import succeeded, add an Elasticsearch backend
+if 'ELASTICSEARCH_URL' in os.environ:
     WAGTAILSEARCH_BACKENDS['elasticsearch'] = {
         'BACKEND': 'wagtail.wagtailsearch.backends.elasticsearch',
+        'URLS': [os.environ['ELASTICSEARCH_URL']],
         'TIMEOUT': 10,
         'max_retries': 1,
         'AUTO_UPDATE': False,
     }
-
-    if 'ELASTICSEARCH_URL' in os.environ:
-        WAGTAILSEARCH_BACKENDS['elasticsearch']['URLS'] = [os.environ['ELASTICSEARCH_URL']]
-
-except ImportError:
-    pass
 
 
 WAGTAIL_SITE_NAME = "Test Site"


### PR DESCRIPTION
This makes testing a little easier.

For example, to run tests without scrapping the DB, you currently have to run:

```
DATABASE_BACKEND=django.db.backends.postgresql_psycopg2 python runtests.py --keepdb
```

This PR shortens this to:

```
python runtests.py --postgres --keepdb
```


Also, we no longer automatically run ES tests if elasticsearch-py is installed. Meaning that this library can now be installed by all developers and most ES tests can be run