### PR TITLE
Add docs for integrating Wagtail into existing Django projects

### DIFF
--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -47,3 +47,4 @@ There are a few optional packages which are not installed by default but are rec
 
     tutorial
     demo_site
+    integrating_into_django

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -35,6 +35,7 @@ Inside your ``mysite`` folder, we now just run the setup steps necessary for any
 
 Your site is now accessible at ``http://localhost:8000``, with the admin backend available at ``http://localhost:8000/admin/``.
 
+This will set you up with a new standalone Wagtail project. If you'd like to add Wagtail to an existing Django project instead, see :doc:`integrating_into_django`.
 
 There are a few optional packages which are not installed by default but are recommended to improve performance or add features to Wagtail, including:
 

--- a/docs/getting_started/integrating_into_django.rst
+++ b/docs/getting_started/integrating_into_django.rst
@@ -1,0 +1,97 @@
+.. _integrating_into_django:
+
+Integrating Wagtail into a Django project
+=========================================
+
+Wagtail provides the ``wagtail start`` command and project template to get you started with a new Wagtail project as quickly as possible, but it's easy to integrate Wagtail into an existing Django project too.
+
+Wagtail is currently compatible with Django 1.7 and 1.8. First, install the ``wagtail`` package from PyPI::
+
+    pip install wagtail
+
+or add the package to your existing requirements file. This will also install the **Pillow** library as a dependency, which requires libjpeg and zlib - see Pillow's `platform-specific installation instructions <http://pillow.readthedocs.org/en/latest/installation.html#external-libraries>`_.
+
+Settings
+--------
+
+In your settings file, add the following apps to ``INSTALLED_APPS``::
+
+    'wagtail.wagtailforms',
+    'wagtail.wagtailredirects',
+    'wagtail.wagtailembeds',
+    'wagtail.wagtailsites',
+    'wagtail.wagtailusers',
+    'wagtail.wagtailsnippets',
+    'wagtail.wagtaildocs',
+    'wagtail.wagtailimages',
+    'wagtail.wagtailsearch',
+    'wagtail.wagtailadmin',
+    'wagtail.wagtailcore',
+
+    'modelcluster',
+    'compressor',
+    'taggit',
+
+Add the following entries to ``MIDDLEWARE_CLASSES``::
+
+    'wagtail.wagtailcore.middleware.SiteMiddleware',
+    'wagtail.wagtailredirects.middleware.RedirectMiddleware',
+
+Add a ``STATIC_ROOT`` setting, if your project does not have one already:
+
+.. code-block:: python
+
+    STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
+Add a ``WAGTAIL_SITE_NAME`` - this will be displayed on the main dashboard of the Wagtail admin backend:
+
+.. code-block:: python
+
+    WAGTAIL_SITE_NAME = 'My Example Site'
+
+Various other settings are available to configure Wagtail's behaviour - see :doc:`/advanced_topics/settings`.
+
+URL configuration
+-----------------
+
+Now make the following additions to your ``urls.py`` file:
+
+.. code-block:: python
+
+    from wagtail.wagtailadmin import urls as wagtailadmin_urls
+    from wagtail.wagtaildocs import urls as wagtaildocs_urls
+    from wagtail.wagtailcore import urls as wagtail_urls
+
+    urlpatterns = [
+        ...
+        url(r'^cms/', include(wagtailadmin_urls)),
+        url(r'^documents/', include(wagtaildocs_urls)),
+        url(r'^pages/', include(wagtail_urls)),
+        ...
+    ]
+
+The URL paths here can be altered as necessary to fit your project's URL scheme.
+
+``wagtailadmin_urls`` provides the admin interface for Wagtail. This is separate from the Django admin interface (``django.contrib.admin``); Wagtail-only projects typically host the Wagtail admin at ``/admin/``, but if this would clash with your project's existing admin backend then an alternative path can be used, such as ``/cms/`` here.
+
+``wagtaildocs_urls`` is the location from where document files will be served. This can be omitted if you do not intend to use Wagtail's document management features.
+
+``wagtail_urls`` is the base location from where the pages of your Wagtail site will be served. In the above example, Wagtail will handle URLs under ``/pages/``, leaving the root URL and other paths to be handled as normal by your Django project. If you want Wagtail to handle the entire URL space including the root URL, this can be replaced with::
+
+    url(r'', include(wagtail_urls)),
+
+In this case, this should be placed at the end of the ``urlpatterns`` list, so that it does not override more specific URL patterns.
+
+With this configuration in place, you are ready to run ``./manage.py migrate`` to create the database tables used by Wagtail.
+
+User accounts
+-------------
+
+Superuser accounts receive automatic access to the Wagtail admin interface; use ``./manage.py createsuperuser`` if you don't already have one. Custom user models are supported, with some restrictions; Wagtail uses an extension of Django's permissions framework, so your user model must at minimum inherit from ``AbstractBaseUser`` and ``PermissionsMixin``.
+
+Start developing
+----------------
+
+You're now ready to add a new app to your Django project (via ``./manage.py startapp`` - remember to add it to ``INSTALLED_APPS``) and set up page models, as described in :doc:`/getting_started/tutorial`.
+
+Note that there's one small difference when not using the Wagtail project template: Wagtail creates an initial homepage of the basic type ``Page``, which does not include any content fields beyond the title. You'll probably want to replace this with your own ``HomePage`` class - when you do so, ensure that you set up a site record (under Settings / Sites in the Wagtail admin) to point to the new homepage.

--- a/docs/getting_started/tutorial.rst
+++ b/docs/getting_started/tutorial.rst
@@ -1,6 +1,9 @@
 Your first Wagtail site
 =======================
 
+.. note::
+   This tutorial covers setting up a brand new Wagtail project. If you'd like to add Wagtail to an existing Django project instead, see :doc:`integrating_into_django`.
+
 1. Install Wagtail and its dependencies::
 
     pip install wagtail


### PR DESCRIPTION
At Django Under The Hood, the Q+A after the Django CMS talk planted the misconception that Wagtail and Mezzanine are only suited for standalone sites, not integrating into existing Django projects. We should stamp out that notion ASAP :-)

This does slightly duplicate the Advanced Topics -> Configuring Django for Wagtail page, but that page is still written from the point of view of setting up a project from scratch - I think it's worth explicitly covering the steps for adding it to an existing project (and putting that information up-front in the Getting Started section).