### PR TITLE
Bump browserify to 3.46.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "browserify-shim": {},
   "devDependencies": {
-    "browserify": "~3.36.0",
+    "browserify": "~3.46.1",
     "browserify-shim": "~3.4.1",
     "gulp": "~3.8.11",
     "gulp-autoprefixer": "~1.0.1",


### PR DESCRIPTION
3.36.0 depends (indirectly, via derequire 0.6.0) on esprima-six, which has disappeared from npm causing Wagtail's overall `npm install` step to fail. https://github.com/substack/node-browserify/pull/710