### PR TITLE
Add Python < 3.3 support for frontendcache invalidator

### DIFF
--- a/wagtail/contrib/wagtailfrontendcache/backends.py
+++ b/wagtail/contrib/wagtailfrontendcache/backends.py
@@ -11,6 +11,11 @@ from wagtail.wagtailcore import __version__
 logger = logging.getLogger('wagtail.frontendcache')
 
 
+class PurgeRequest(Request):
+
+    def get_method(self):
+        return 'PURGE'
+
 class BaseBackend(object):
     def purge(self, url):
         raise NotImplementedError
@@ -30,7 +35,7 @@ class HTTPBackend(BaseBackend):
         if url_parsed.port:
             host += (':' + str(url_parsed.port))
 
-        request = Request(
+        request = PurgeRequest(
             url=urlunparse([
                 self.cache_scheme,
                 self.cache_netloc,
@@ -42,8 +47,7 @@ class HTTPBackend(BaseBackend):
             headers={
                 'Host': host,
                 'User-Agent': 'Wagtail-frontendcache/' + __version__
-            },
-            method='PURGE'
+            }
         )
 
         try:


### PR DESCRIPTION
The previous implementation was using a Python > 3.3 specific
implementation of urllib.request.Request which can accept a `method`
keyword argument in its constructor to specify what HTTP method to use
when executing the request. This is not available in earlier versions of
the class.

This commit fixes that incompatibility by instead subclassing Request
and overriding its `get_method` method.

Fixes #1924 