### PR TITLE
Use SiteManager for Sites, add tests

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -62,6 +62,8 @@ class Site(models.Model):
     root_page = models.ForeignKey('Page', verbose_name=_('Root page'), related_name='sites_rooted_here')
     is_default_site = models.BooleanField(verbose_name=_('Is default site'), default=False, help_text=_("If true, this site will handle requests for all other hostnames that do not have a site entry of their own"))
 
+    objects = SiteManager()
+
     class Meta:
         unique_together = ('hostname', 'port')
         verbose_name = _('site')
@@ -146,6 +148,7 @@ class Site(models.Model):
             cache.set('wagtail_site_root_paths', result, 3600)
 
         return result
+
 
 # Clear the wagtail_site_root_paths from the cache whenever Site records are updated
 @receiver(post_save, sender=Site)

--- a/wagtail/wagtailcore/tests/test_sites.py
+++ b/wagtail/wagtailcore/tests/test_sites.py
@@ -1,0 +1,62 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from wagtail.wagtailcore.models import Site, Page
+
+
+class TestSiteNaturalKey(TestCase):
+    def test_natural_key(self):
+        site = Site(hostname='example.com', port=8080)
+        self.assertEqual(site.natural_key(), ('example.com', 8080))
+
+    def test_get_by_natural_key(self):
+        site = Site.objects.create(hostname='example.com', port=8080, root_page=Page.objects.get(pk=2))
+        self.assertEqual(Site.objects.get_by_natural_key('example.com', 8080),
+                         site)
+
+
+class TestSiteUrl(TestCase):
+    def test_root_url_http(self):
+        site = Site(hostname='example.com', port=80)
+        self.assertEqual(site.root_url, 'http://example.com')
+
+    def test_root_url_https(self):
+        site = Site(hostname='example.com', port=443)
+        self.assertEqual(site.root_url, 'https://example.com')
+
+    def test_root_url_custom_port(self):
+        site = Site(hostname='example.com', port=8000)
+        self.assertEqual(site.root_url, 'http://example.com:8000')
+
+
+class TestDefaultSite(TestCase):
+    def test_create_default_site(self):
+        Site.objects.all().delete()
+        Site.objects.create(hostname='test.com', is_default_site=True,
+                            root_page=Page.objects.get(pk=2))
+        self.assertTrue(Site.objects.filter(is_default_site=True).exists())
+
+    def test_change_default_site(self):
+        default = Site.objects.get(is_default_site=True)
+        default.is_default_site = False
+        default.save()
+
+        Site.objects.create(hostname='test.com', is_default_site=True,
+                            root_page=Page.objects.get(pk=2))
+        self.assertTrue(Site.objects.filter(is_default_site=True).exists())
+
+    def test_there_can_only_be_one(self):
+        site = Site(hostname='test.com', is_default_site=True,
+                    root_page=Page.objects.get(pk=2))
+        with self.assertRaises(ValidationError):
+            site.clean_fields()
+
+    def test_oops_there_is_more_than_one(self):
+        Site.objects.create(hostname='example.com', is_default_site=True,
+                            root_page=Page.objects.get(pk=2))
+
+        site = Site(hostname='test.com', is_default_site=True,
+                    root_page=Page.objects.get(pk=2))
+        with self.assertRaises(Site.MultipleObjectsReturned):
+            # If there already are multiple default sites, you're in trouble
+            site.clean_fields()


### PR DESCRIPTION
The SiteManager class was not used on the Site model, or anywhere else.

This was not caught by the tests, because nothing tested the relevan attributes on the Site model, nor were they used in the code base. Tests have been added now.