### PR TITLE
Replacing removeStyling() function with paste event interceptor to facilitate HTML contend editable functions

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -34,8 +34,8 @@ function makeRichTextEditable(id) {
     */
     }).bind('paste', function(event, data) {
         event.preventDefault();
-        var text = event.originalEvent.clipboardData.getData("text/plain");
-        document.execCommand("insertHTML", false, text);
+        var text = event.originalEvent.clipboardData.getData('text/plain');
+        document.execCommand('insertHTML', false, text);
     /* Animate the fields open when you click into them. */
     }).bind('halloactivated', function(event, data) {
         $(event.target).addClass('expanded', 200, function(e) {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -20,18 +20,6 @@ function makeRichTextEditable(id) {
     richText.insertBefore(input);
     input.hide();
 
-    var removeStylingPending = false;
-    function removeStyling() {
-        /* Strip the 'style' attribute from spans that have no other attributes.
-        (we don't remove the span entirely as that messes with the cursor position,
-        and spans will be removed anyway by our whitelisting)
-        */
-        $('span[style]', richText).filter(function() {
-            return this.attributes.length === 1;
-        }).removeAttr('style');
-        removeStylingPending = false;
-    }
-
     var closestObj = input.closest('.object');
 
     richText.hallo({
@@ -40,12 +28,14 @@ function makeRichTextEditable(id) {
         plugins: halloPlugins
     }).bind('hallomodified', function(event, data) {
         input.val(data.content);
-        if (!removeStylingPending) {
-            setTimeout(removeStyling, 100);
-            removeStylingPending = true;
-        }
+    /* Intercept the paste command in RichText areas and convert the data
+       to plaintext, this prevents people being surprised when they
+       copy/paste from word and the special styling vanishes on submission
+    */
     }).bind('paste', function(event, data) {
-        setTimeout(removeStyling, 1);
+        event.preventDefault();
+        var text = event.originalEvent.clipboardData.getData("text/plain");
+        document.execCommand("insertHTML", false, text);
     /* Animate the fields open when you click into them. */
     }).bind('halloactivated', function(event, data) {
         $(event.target).addClass('expanded', 200, function(e) {


### PR DESCRIPTION
The removeStyling() function strips out all `style=...` attributes on any <span> elements within a RichText area so that when content is pasted in from Word or elsewhere, the extraneous styling is removed immediately, rather than coming as a surprise to the user when it gets stripped out during the submission process.

However this also prevents the use of the HTML5 content editable functions such as backColor and hiliteColor however, which are browser-specific implementations and generally work by inserting a `background-color: yellow` <span> element around the text.

I propose that instead of stripping the styling out on paste, the paste command is intercepted and converted into plaintext, before being pasted into the RichText box- this also has the benefit of not leaving any rogue <span> elements behind after the styling has been stripped. The code in the pull request works in firefox/chrome, yet to be tested in IE but this stack answer may have a solution to that in the comments: http://stackoverflow.com/a/12028136/2547709