### PR TITLE
Add hook to allow adding buttons to page listing 

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -85,7 +85,7 @@ linters:
         enabled: false
 
     SelectorFormat:
-        convention: hyphenated_lowercase
+        convention: hyphenated_BEM
         ignored_names:
             - js_class
         ignored_types:

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -218,6 +218,69 @@ Hooks for building new areas of the admin interface (alongside pages, images, do
   Return a queryset of Permission objects to be shown in the Groups administration area.
 
 
+Customising page listing buttons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+``register_page_listing_buttons``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  The 'register_page_listing_buttons' hook allows plugin developers to add buttons to the actions list on the page listing in the admin. This is useful when adding custom actions to the listing, such as translations or a complex workflow.
+
+  This example will add a simple button to the listing:
+
+  .. code-block:: python
+
+    from wagtail.wagtailadmin import widgets as wagtailadmin_widgets
+
+    @hooks.register('register_page_listing_buttons')
+    def page_listing_buttons(page, page_perms, is_parent=False):
+        yield wagtailadmin_widgets.PageListingButton(
+            'A page listing button',
+            '/goes/to/a/url/',
+            priority=10
+        )
+
+  The ``priority`` argument controls the order the buttons are displayed in. Buttons are ordered from low to high priority, so a button with ``priority=10`` will be displayed before a button with ``priority=20``.
+
+
+Buttons with dropdown lists
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  The admin widgets also provide ``ButtonWithDropdownFromHook``, which allows you to define a custom hook for generating a dropdown menu that gets attached to your button.
+
+  Creating a button with a dropdown menu involves two steps. Firstly, you add your button to the ``register_page_listing_buttons`` hook, just like the example above.
+  Secondly, you register a new hook that yields the contents of the dropdown menu.
+
+  This example shows how Wagtail's default admin dropdown is implemented. You can also see how to register buttons conditionally, in this case by evaluating the ``page_perms``:
+
+  .. code-block:: python
+
+    @hooks.register('register_page_listing_buttons')
+    def page_custom_listing_buttons(page, page_perms, is_parent=False):
+        yield wagtailadmin_widgets.ButtonWithDropdownFromHook(
+            'More actions',
+            hook_name='my_button_dropdown_hook',
+            page=page,
+            page_perms=page_perms,
+            is_parent=is_parent,
+            priority=50
+        )
+
+    @hooks.register('my_button_dropdown_hook')
+    def page_custom_listing_more_buttons(page, page_perms, is_parent=False):
+        if page_perms.can_move():
+            yield Button('Move', reverse('wagtailadmin_pages:move', args=[page.id]), priority=10)
+        if page_perms.can_delete():
+            yield Button('Delete', reverse('wagtailadmin_pages:delete', args=[page.id]), priority=30)
+        if page_perms.can_unpublish():
+            yield Button('Unpublish', reverse('wagtailadmin_pages:unpublish', args=[page.id]), priority=40)
+
+
+
+  The template for the dropdown button can be customised by overriding ``wagtailadmin/pages/listing/_button_with_dropdown.html``. The JavaScript that runs the dropdowns makes use of custom data attributes, so you should leave ``data-dropdown`` and ``data-dropdown-toggle`` in the markup if you customise it.
+
+
 Editor interface
 ----------------
 

--- a/wagtail/contrib/wagtailstyleguide/static_src/wagtailstyleguide/scss/styleguide.scss
+++ b/wagtail/contrib/wagtailstyleguide/static_src/wagtailstyleguide/scss/styleguide.scss
@@ -94,7 +94,7 @@ section {
 }
 
 .icons {
-    :before, 
+    :before,
     :after {
         font-size: 2em;
     }
@@ -113,9 +113,9 @@ section {
         position: relative;
     }
 
-    .icon-spinner:after {
-        position: absolute;
-    }
+    // .spinner .icon-spinner:after {
+    //     position: absolute;
+    // }
 }
 
 .timepicker {

--- a/wagtail/contrib/wagtailstyleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/wagtailstyleguide/templates/wagtailstyleguide/base.html
@@ -405,6 +405,93 @@
                     <button>button for comparison of height</button>
                 </div>
             </div>
+
+            <div class="row">
+                <br />
+
+                <p>
+                    Inline dropdown components, primarily used in the listing.
+                </p>
+
+                <div class="c-dropdown u-para t-default" data-dropdown="">
+                    <a class="c-dropdown__button  u-btn-current">
+                        More
+                        <div data-dropdown-toggle="" class="o-icon  c-dropdown__toggle  [ icon icon-arrow-down ]"></div>
+                    </a>
+                    <div class="t-dark">
+                        <ul role="menu" class="c-dropdown__menu  u-toggle  u-arrow u-arrow--tl u-background">
+                            <li class="c-dropdown__item ">
+                                <a href="/admin/pages/2/move/" class="u-link is-live ">
+                                    Move
+                                </a>
+                            </li>
+                            <li class="c-dropdown__item ">
+                                <a href="/admin/pages/2/copy/" class="u-link is-live ">
+                                    Copy
+                                </a>
+                            </li>
+                            <li class="c-dropdown__item ">
+                                <a href="/admin/pages/2/delete/" class="u-link is-live ">
+                                    Delete
+                                </a>
+                            </li>
+                            <li class="c-dropdown__item ">
+                                <a href="/admin/pages/2/unpublish/" class="u-link is-live ">
+                                    Unpublish
+                                </a>
+                            </li>
+                            <li>
+                                <hr class="c-dropdown__divider">
+                            </li>
+                            <li class="c-dropdown__item">
+                                <a href="#" class="u-link is-live">
+                                    <span title="Live" class="c-indicator c-dropdown__indicator"></span>
+                                    Live
+                                </a>
+                            </li>
+                            <li class="c-dropdown__item">
+                                <a href="#" class="u-link is-draft">
+                                    <span title="Draft" class="c-indicator c-dropdown__indicator"></span>
+                                    Draft
+                                </a>
+                            </li>
+                            <li class="c-dropdown__item">
+                                <a href="#" class="u-link is-live+draft">
+                                    <span title="Live + Draft" class="c-indicator c-dropdown__indicator"></span>
+                                    Live + Draft
+                                </a>
+                            </li>
+                            <li class="c-dropdown__item">
+                                <a href="#" class="u-link is-absent">
+                                    <span title="Absent" class="c-indicator c-dropdown__indicator"></span>
+                                    Absent
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+
+            <p>These can also have an inverted  theme:</p>
+            <header class="nice-padding">
+                <div class="c-dropdown  t-inverted" data-dropdown="">
+                    <a class="c-dropdown__button  u-btn-current">
+                        More
+                        <div data-dropdown-toggle="" class="o-icon  c-dropdown__toggle  [ icon icon-arrow-down ]"></div>
+                    </a>
+                    <div class="t-dark">
+                        <ul role="menu" class="c-dropdown__menu  u-toggle  u-arrow u-arrow--tl u-background">
+                            <li class="c-dropdown__item ">
+                                <a href="/admin/pages/2/move/" class="u-link is-live ">
+                                    Move
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </header>
+
+
         </section>
 
         <section id="header">

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_mixins.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_mixins.scss
@@ -18,16 +18,15 @@
 }
 
 @mixin unlist() {
-    &,
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-left: 0;
+    list-style-type: none;
+    font-style: normal;
+
     li {
         list-style-type: none;
         font-style: normal;
-    }
-
-    & {
-        margin-top: 0;
-        margin-bottom: 0;
-        padding-left: 0;
     }
 }
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_mixins.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_mixins.scss
@@ -19,14 +19,12 @@
 
 @mixin unlist() {
     &,
-    ul,
     li {
         list-style-type: none;
         font-style: normal;
     }
 
-    &,
-    ul {
+    & {
         margin-top: 0;
         margin-bottom: 0;
         padding-left: 0;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
@@ -65,6 +65,12 @@ $color-link-hover: $color-teal-dark;
 $color-text-base: $color-grey-2;
 $color-text-input: $color-grey-1;
 
+// Color states
+$color-state-live: #59b524;
+$color-state-draft: #808080;
+$color-state-absent: #ff8f11;
+$color-state-live-draft: #43b1b0;
+
 // Fonts
 $font-sans: Open Sans, Arial, sans-serif;
 $font-serif: Roboto Slab, Georgia, serif;
@@ -72,3 +78,6 @@ $font-serif: Roboto Slab, Georgia, serif;
 // misc sizing
 $thumbnail-width: 130px;
 $menu-width: 180px;
+
+
+

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_dropdowns.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_dropdowns.scss
@@ -227,3 +227,196 @@
 .dropdown ul {
     @include transition(opacity 0.2s linear);
 }
+
+
+// =============================================================================
+// Listing view smaller dropdowns
+// =============================================================================
+
+.c-dropdown {
+
+}
+
+.o-icon {
+    display: inline-block;
+    vertical-align: middle;
+    line-height: 1;
+    margin-top: -.25rem;
+}
+
+.c-dropdown__button {
+    display: inline-block;
+    box-sizing: border-box;
+    padding-left: 0.5rem;
+    padding-right: 0.25rem;
+    // Make this the same as the other buttons
+    line-height: 1.85;
+    border: solid 1px transparent;
+    border-radius: 2px;
+    font-size: 11px;
+    cursor: pointer;
+    -webkit-font-smoothing: subpixel-antialiased;
+    user-select: none;
+    -webkit-user-select: none;
+}
+
+.c-dropdown__toggle {
+    display: inline-block;
+}
+
+.c-dropdown__menu.c-dropdown__menu {
+    margin-top: .75rem;
+    padding: .75rem 1rem;
+    min-width: 8rem;
+    text-transform: none;
+    position: absolute;
+    z-index: 1;
+    animation: dropdownIn .1s ease-out backwards;
+    list-style: none;
+}
+
+.c-dropdown__item {
+    margin-bottom: .375rem;
+
+    &:hover {
+        .c-dropdown__indicator {
+            opacity: .6;
+        }
+    }
+}
+
+
+
+.c-dropdown__item:last-child {
+    margin-bottom: 0;
+}
+
+.c-dropdown__divider {
+    border-color: #555;
+    border-style: dotted;
+    margin-top: 12px;
+    margin-bottom: 12px;
+}
+
+// =============================================================================
+//  Arrows
+// =============================================================================
+
+.u-arrow:before {
+    content: '';
+    border: solid .35rem transparent;
+    display: block;
+    position: absolute;
+}
+
+.u-arrow--tl:before {
+    bottom: 100%;
+    left: 1rem;
+}
+
+// =============================================================================
+//  Default dropdown theme
+// =============================================================================
+
+.t-default {
+
+}
+
+.t-default .u-btn-current {
+    border-color: rgba(0, 0, 0, 0.15);
+    color: #43b1b0;
+}
+
+.t-default .u-btn-current:hover {
+    background: #43b1b0;
+    color: #fff;
+    border-color: #43b1b0;
+}
+
+.t-default .u-btn-current:active {
+    background: #333;
+    color: #fff;
+    border-color: #333;
+}
+
+.t-inverted .u-btn-current {
+    border-color: rgba(0, 0, 0, 0.25);
+    color: #fff;
+}
+
+.t-inverted .u-btn-current:hover {
+    background-color: $color-teal-darker;
+    border-color: $color-teal-darker;
+}
+
+.t-inverted .u-btn-current:active {
+    border-color: rgba(0, 0, 0, 0.25);
+    background: #333;
+    color: #fff;
+}
+
+
+// =============================================================================
+// Dark theme
+// =============================================================================
+
+.t-dark .u-link {
+    color: #fff;
+}
+
+.t-dark .u-link:hover {
+    color: #aaa;
+}
+
+.t-dark .u-background {
+    background: #333;
+}
+
+.t-dark .u-arrow:before {
+    border-bottom-color: #333;
+}
+
+@keyframes dropdownIn {
+    0% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
+}
+
+// =============================================================================
+// Light theme
+// =============================================================================
+
+.t-light .u-link {
+    color: #333;
+}
+
+.t-light .u-link:hover {
+    color: #aaa;
+}
+
+.t-light .u-background {
+    background: #fff;
+    border-color: #ccc;
+}
+
+.t-light .u-arrow:before {
+    border-bottom-color: #fff;
+}
+
+// =============================================================================
+// States
+// =============================================================================
+
+.u-toggle {
+    display: none;
+}
+
+.is-open .u-toggle {
+    display: block;
+}
+
+
+

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_dropdowns.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_dropdowns.scss
@@ -233,9 +233,8 @@
 // Listing view smaller dropdowns
 // =============================================================================
 
-.c-dropdown {
-
-}
+// .c-dropdown {
+// }
 
 .o-icon {
     display: inline-block;
@@ -318,9 +317,9 @@
 //  Default dropdown theme
 // =============================================================================
 
-.t-default {
+// .t-default {
 
-}
+// }
 
 .t-default .u-btn-current {
     border-color: rgba(0, 0, 0, 0.15);
@@ -380,6 +379,7 @@
     0% {
         opacity: 0;
     }
+
     100% {
         opacity: 1;
     }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -472,11 +472,11 @@ button {
 }
 
 
- .button-small {
-        padding: 0 0.8em;
-        height: 2em;
-        font-size: 0.85em;
-    }
+.button-small {
+    padding: 0 0.8em;
+    height: 2em;
+    font-size: 0.85em;
+}
 
     .button-secondary {
         color: $color-button;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -217,35 +217,10 @@ button {
     -webkit-font-smoothing: auto;
     -moz-appearance: none;
 
-    &.button-small {
-        padding: 0 0.8em;
-        height: 2em;
-        font-size: 0.85em;
+    &:hover {
+        color: $color-teal;
     }
 
-    &.button-secondary {
-        color: $color-button;
-        background-color: transparent;
-    }
-
-    // Buttons which are only an icon
-    &.icon.text-replace {
-        font-size: 0; // unavoidable duplication of setting in icons.scss
-        width: 1.8rem;
-        height: 1.8rem;
-
-        &:before {
-            line-height: 1.7em;
-        }
-    }
-
-    &.button-neutral {
-        color: $color-grey-2;
-
-        &:hover {
-            color: $color-teal;
-        }
-    }
 
     &.yes {
         background-color: $color-button-yes;
@@ -348,6 +323,7 @@ button {
         }
     }
 
+
     + input[type=submit],
     + input[type=reset],
     + input[type=button],
@@ -448,7 +424,7 @@ button {
         border: 0;
     }
 
-    @media screen and (min-width: $breakpoint-mobile){
+    @media screen and (min-width: $breakpoint-mobile) {
         font-size: 0.95em;
         padding: 0 1.4em;
         height: 3em;
@@ -484,8 +460,8 @@ button {
         }
 
         &.button-small.bicolor {
-            line-height: 2.2em;
-            padding-left: 3.2em;
+            // line-height: 2.2em;
+            padding-left: 3em;
 
             &:before {
                 width: 1.8em;
@@ -494,6 +470,116 @@ button {
         }
     }
 }
+
+
+ .button-small {
+        padding: 0 0.8em;
+        height: 2em;
+        font-size: 0.85em;
+    }
+
+    .button-secondary {
+        color: $color-button;
+        background-color: transparent;
+    }
+
+    // Buttons which are only an icon
+    .button.icon.text-replace {
+        font-size: 0; // unavoidable duplication of setting in icons.scss
+        width: 1.8rem;
+        height: 1.8rem;
+
+        &:before {
+            line-height: 1.7em;
+        }
+    }
+
+    .button-neutral {
+        color: $color-grey-2;
+
+        &:hover {
+            color: $color-teal;
+        }
+    }
+
+    .yes {
+        background-color: $color-button-yes;
+        border: 1px solid $color-button-yes;
+
+        &.button-secondary {
+            border: 1px solid $color-button-yes;
+            color: $color-button-yes;
+            background-color: transparent;
+        }
+
+        &:hover {
+            color: $color-white;
+            border-color: transparent;
+            background-color: $color-button-yes-hover;
+        }
+
+        &.button-nobg:hover {
+            color: $color-button-yes;
+            background-color: transparent;
+        }
+    }
+
+    .no,
+    .serious {
+        background-color: $color-button-no;
+        border: 1px solid $color-button-no;
+
+        &.button-secondary {
+            border: 1px solid $color-button-no;
+            color: $color-button-no;
+            background-color: transparent;
+        }
+
+        &:hover {
+            color: $color-white;
+            border-color: transparent;
+            background-color: $color-button-no-hover;
+        }
+
+        &.button-nobg:hover {
+            color: $color-button-no;
+            background-color: transparent;
+        }
+    }
+
+    .button-nobg {
+        border: 0;
+        background-color: transparent;
+    }
+
+    .bicolor {
+        border: 0;
+        padding-left: 3.5em;
+
+        &:before {
+            font-size: 1rem;
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 2em;
+            line-height: 1.85em;
+            height: 100%;
+            text-align: center;
+            background-color: rgba(0, 0, 0, 0.2);
+            display: block;
+        }
+    }
+
+    .button-small.bicolor {
+        padding-left: 3.5em;
+
+        &:before {
+            width: 2em;
+            font-size: 0.8rem;
+            line-height: 1.65em;
+        }
+    }
+
 
 a.button {
     line-height: 2.4em;
@@ -1064,7 +1150,7 @@ input[type=reset],
 input[type=button],
 .button,
 button {
-    @include transition(background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease);
+    // @include transition(background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease);
 }
 
 .help {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_icons.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_icons.scss
@@ -62,6 +62,30 @@
     font-size: 1.1rem;
 }
 
+.icon-view:before {
+    content: '4';
+}
+
+.icon-no-view:before {
+    content: '^';
+}
+
+.icon-collapse-down:before {
+    content: '5';
+}
+
+.icon-collapse-up:before {
+    content: '6';
+}
+
+.icon-date:before {
+    content: '7';
+}
+
+.icon-time:before {
+    content: '8';
+}
+
 
 .icon-spinner:after,
 .icon-spinner:before {
@@ -104,4 +128,11 @@
     100% {
         transform: rotate(360deg);
     }
+}
+
+
+
+.icon-spinner:after {
+    display: inline-block;
+    line-height: 1;
 }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_indicator.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_indicator.scss
@@ -24,10 +24,6 @@ $c-indicator-margin: .25rem;
 // States
 // =============================================================================
 
-$color-state-live: #59b524;
-$color-state-draft: #808080;
-$color-state-absent: #ff8f11;
-$color-state-live-draft: #43b1b0;
 
 .is-absent .c-indicator {
     background: $color-state-absent;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_indicator.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_indicator.scss
@@ -1,0 +1,66 @@
+// =============================================================================
+// Indicator light
+// =============================================================================
+
+
+.o-icon-text {
+
+}
+
+// =============================================================================
+// Indicator light
+// =============================================================================
+$c-indicator-size: .625em;
+$c-indicator-margin: .25rem;
+
+.c-indicator {
+    display: inline-block;
+    border-radius: 50rem;
+    width: $c-indicator-size;
+    height: $c-indicator-size;
+    margin-top: -.125rem;
+    margin-right: $c-indicator-margin;
+    font-size: 1rem;
+    vertical-align: middle;
+}
+
+// =============================================================================
+// States
+// =============================================================================
+
+$color-state-live: #59B524;
+$color-state-draft: grey;
+$color-state-absent: #FF8F11;
+$color-state-live-draft: #43B1B0;
+
+.is-absent .c-indicator {
+    background: $color-state-absent;
+}
+
+.is-live .c-indicator {
+    background: $color-state-live;
+}
+
+.is-draft .c-indicator {
+    background: $color-state-draft;
+}
+
+// This is hipster. But it works.
+.is-live\+draft .c-indicator {
+    background: $color-state-draft;
+    position: relative;
+
+    &:before {
+        content: '';
+        width: $c-indicator-size/2;
+        height: $c-indicator-size;
+        position: absolute;
+        top: 0;
+        left: 0;
+        border-bottom-left-radius: 50rem;
+        border-top-left-radius: 50rem;
+        background: $color-state-live;
+        transform: rotate(45deg);
+        transform-origin: 100% 50%;
+    }
+}

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_indicator.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_indicator.scss
@@ -3,10 +3,6 @@
 // =============================================================================
 
 
-.o-icon-text {
-
-}
-
 // =============================================================================
 // Indicator light
 // =============================================================================
@@ -28,10 +24,10 @@ $c-indicator-margin: .25rem;
 // States
 // =============================================================================
 
-$color-state-live: #59B524;
-$color-state-draft: grey;
-$color-state-absent: #FF8F11;
-$color-state-live-draft: #43B1B0;
+$color-state-live: #59b524;
+$color-state-draft: #808080;
+$color-state-absent: #ff8f11;
+$color-state-live-draft: #43b1b0;
 
 .is-absent .c-indicator {
     background: $color-state-absent;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_listing.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_listing.scss
@@ -10,7 +10,9 @@ ul.listing {
     font-size: 0.95em;
 
     ul {
-        @include unlist();
+        list-style-type: none;
+        padding-left: 0;
+        // @include unlist();
     }
 
     > li {
@@ -203,11 +205,12 @@ ul.listing {
             text-decoration: none;
         }
 
-        li {
+        > li {
             float: left;
             padding: 0 0.5em 0 0;
             margin: 0 0 0.5em;
-            line-height: 1em;
+
+            // line-height: 1em;
         }
     }
 
@@ -366,8 +369,21 @@ ul.listing {
                 border-color: $color-teal-darker;
             }
 
+            &:active {
+                color: $color-white;
+                background: #333;
+                border-color: #333;
+            }
+
             &.bicolor {
                 background: $color-teal-darker;
+                border: solid 1px darken($color-teal-darker, 10%);
+
+                &:active {
+                    color: $color-white;
+                    background: #484848;
+                    border-color: #333;
+                }
             }
         }
     }
@@ -586,6 +602,8 @@ table.listing {
             visibility: visible;
         }
 
+
+
         td:hover .actions {
             visibility: visible;
         }
@@ -628,6 +646,15 @@ table.listing {
         }
     }
 }
+
+
+// State
+.listing__item--active {
+    > .actions {
+        visibility: visible;
+    }
+}
+
 
 // Transitions
 .listing {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_typography.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_typography.scss
@@ -41,7 +41,7 @@ p {
 }
 
 a {
-    @include transition(color 0.2s ease, background-color 0.2s ease);
+    // @include transition(color 0.2s ease, background-color 0.2s ease);
     outline: none;
     color: $color-link;
     text-decoration: none;
@@ -157,3 +157,7 @@ dd {
             content: '!';
         }
     }
+
+.u-para {
+    margin-bottom: 1rem;
+}

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -16,6 +16,7 @@
 @import 'wagtailadmin/scss/components/progressbar';
 @import 'wagtailadmin/scss/components/datetimepicker';
 @import 'wagtailadmin/scss/components/main-nav';
+@import 'wagtailadmin/scss/components/indicator';
 
 @import 'wagtailadmin/scss/fonts';
 
@@ -117,7 +118,7 @@ body {
 }
 
 footer {
-    @include transition(all 0.2s ease);
+    // @include transition(all 0.2s ease);
     @include transition(bottom 0.5s ease 1s);
     @include row();
     border-radius: 3px 3px 0 0;
@@ -491,10 +492,10 @@ footer,
 .nav-toggle,
 footer,
 .logo {
-    @include transition(all 0.2s ease);
+    // @include transition(all 0.2s ease);
 }
 
-.nav-main a,
-a {
-    @include transition(color 0.2s ease, background-color 0.2s ease);
-}
+// .nav-main a,
+// a {
+    // @include transition(color 0.2s ease, background-color 0.2s ease);
+// }

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
@@ -1,0 +1,16 @@
+<div {{ self.attrs }} class="c-dropdown  {% if is_parent %}t-inverted{% else %}t-default{% endif %}" data-dropdown>
+    <a href="#" class="c-dropdown__button  u-btn-current">
+        {{ label }}
+        <div data-dropdown-toggle class="o-icon  c-dropdown__toggle  [ icon icon-arrow-down ]"></div>
+    </a>
+    <div class="t-dark">
+        <ul role="menu" class="c-dropdown__menu  u-toggle  u-arrow u-arrow--tl u-background">
+        {% for button in buttons %}
+            <li class="c-dropdown__item ">
+                <a href="{{ button.url }}" class="u-link is-live {{ button.classes|join:' ' }}">
+                    {{ button.label }}
+                </a>
+            </li>
+        {% endfor %}
+    </div>
+</div>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_buttons.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_buttons.html
@@ -1,0 +1,3 @@
+{% for button in buttons %}
+    <li>{{ button|safe }}</li>
+{% endfor %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list.html
@@ -37,7 +37,7 @@
                 <td></td>
             </tr>
         {% endif %}
-    
+
         {% block post_parent_page_headers %}
         {% endblock %}
     </thead>
@@ -49,7 +49,7 @@
                     {% if show_ordering_column %}
                         <td class="ord">{% if orderable and ordering == "ord" %}<div class="handle icon icon-grip text-replace">{% trans 'Drag' %}</div>{% endif %}</td>
                     {% endif %}
-                    <td class="title" valign="top">
+                    <td class="title" valign="top" data-listing-page-title>
                         {% block page_title %}
                         {% endblock %}
                     </td>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -3,7 +3,7 @@
 {# The title field for a page in the page listing, when in 'explore' mode #}
 
 <h2>
-    {% if page_perms.can_edit and 'edit' not in hide_actions|default:'' %}
+    {% if page_perms.can_edit %}
         <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.title }}</a>
     {% else %}
         {{ page.title }}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 {# The title field for a page in the page listing, when in 'explore' mode #}
 
@@ -14,28 +14,5 @@
 </h2>
 
 <ul class="actions">
-    {% if page_perms.can_edit and 'edit' not in hide_actions|default:'' %}
-        <li><a href="{% url 'wagtailadmin_pages:edit' page.id %}" class="button button-small button-secondary" title="{% trans 'Edit this page' %}">{% trans 'Edit' %}</a></li>
-    {% endif %}
-    {% if page.has_unpublished_changes and 'view_draft' not in hide_actions|default:'' %}
-        <li><a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" class="button button-small button-secondary" target="_blank">{% trans 'Draft' %}</a></li>
-    {% endif %}
-    {% if page.live and 'view_live' not in hide_actions|default:'' %}
-        <li><a {% if page.url %}href="{{ page.url }}"{% endif %} class="button button-small button-secondary {% if not page.url %}disabled{% endif %}" target="_blank" {% if not page.url %}title="{% trans 'This page is published but does not exist within a configured Site, so cannot be viewed.' %}"{% endif %}>{% trans 'Live' %}</a></li>
-    {% endif %}
-    {% if page_perms.can_move and 'move' not in hide_actions|default:'' %}
-        <li><a href="{% url 'wagtailadmin_pages:move' page.id %}" class="button button-small button-secondary">{% trans 'Move' %}</a></li>
-    {% endif %}
-    {% if parent_page_perms.can_add_subpage and 'copy' not in hide_actions|default:'' %}
-        <li><a href="{% url 'wagtailadmin_pages:copy' page.id %}" class="button button-small button-secondary">{% trans 'Copy' %}</a></li>
-    {% endif %}
-    {% if page_perms.can_delete and 'delete' not in hide_actions|default:'' %}
-        <li><a href="{% url 'wagtailadmin_pages:delete' page.id %}" class="button button-small button-secondary">{% trans 'Delete' %}</a></li>
-    {% endif %}
-    {% if page_perms.can_unpublish and 'unpublish' not in hide_actions|default:'' %}
-        <li><a href="{% url 'wagtailadmin_pages:unpublish' page.id %}" class="button button-small button-secondary">{% trans 'Unpublish' %}</a></li>
-    {% endif %}
-    {% if page_perms.can_add_subpage and 'add_subpage' not in hide_actions|default:'' %}
-        <li><a href="{% url 'wagtailadmin_pages:add_subpage' page.id %}" class="button button-small button-secondary">{% trans 'Add child page' %}</a></li>
-    {% endif %}
+    {% page_listing_buttons page page_perms %}
 </ul>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_parent_page_title_explore.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_parent_page_title_explore.html
@@ -16,26 +16,5 @@
 {% include "wagtailadmin/pages/_privacy_switch.html" with page=parent_page %}
 
 <ul class="actions">
-    {% if parent_page_perms.can_edit and 'edit' not in hide_actions|default:'' %}
-        <li><a href="{% url 'wagtailadmin_pages:edit' parent_page.id %}" class="button button-small button-secondary">{% trans 'Edit' %}</a></li>
-    {% endif %}
-    {% if parent_page.has_unpublished_changes and 'view_draft' not in hide_actions|default:'' %}
-        <li><a href="{% url 'wagtailadmin_pages:view_draft' parent_page.id %}" class="button button-small button-secondary" target="_blank">{% trans 'Draft' %}</a></li>
-    {% endif %}
-
-    {% if parent_page.live and not parent_page.is_root and 'view_live' not in hide_actions|default:'' %}
-        <li><a {% if parent_page.url %}href="{{ parent_page.url }}"{% endif %} class="button button-small button-secondary {% if not parent_page.url %}disabled{% endif %}" target="_blank" {% if not parent_page.url %}title="{% trans 'This page is published but does not exist within a configured Site, so cannot be viewed.' %}"{% endif %}>{% trans 'Live' %}</a></li>
-    {% endif %}
-    {% if parent_page_perms.can_move and 'move' not in hide_actions|default:'' %}
-        <li><a href="{% url 'wagtailadmin_pages:move' parent_page.id %}" class="button button-small button-secondary">{% trans 'Move' %}</a></li>
-    {% endif %}
-    {% if parent_page_perms.can_delete and 'delete' not in hide_actions|default:'' %}
-        <li><a href="{% url 'wagtailadmin_pages:delete' parent_page.id %}" class="button button-small button-secondary">{% trans 'Delete' %}</a></li>
-    {% endif %}
-    {% if parent_page_perms.can_unpublish and 'unpublish' not in hide_actions|default:'' %}
-        <li><a href="{% url 'wagtailadmin_pages:unpublish' parent_page.id %}" class="button button-small button-secondary">{% trans 'Unpublish' %}</a></li>
-    {% endif %}
-    {% if parent_page_perms.can_add_subpage and 'add_subpage' not in hide_actions|default:'' %}
-        <li><a href="{% url 'wagtailadmin_pages:add_subpage' parent_page.id %}" class="button button-small bicolor icon white icon-plus">{% trans 'Add child page' %}</a></li>
-    {% endif %}
+    {% page_listing_buttons parent_page parent_page_perms is_parent=True %}
 </ul>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_parent_page_title_explore.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_parent_page_title_explore.html
@@ -4,7 +4,7 @@
 {# The title field for a parent page when the listing is in 'explore' mode #}
 
 <h2>
-    {% if parent_page_perms.can_edit and 'edit' not in hide_actions|default:'' %}
+    {% if parent_page_perms.can_edit %}
         <a href="{% url 'wagtailadmin_pages:edit' parent_page.id %}">{{ parent_page.title }}</a>
     {% else %}
         {{ parent_page.title }}

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import itertools
+
 from django.conf import settings
 from django import template
 from django.contrib.humanize.templatetags.humanize import intcomma
@@ -281,3 +283,14 @@ def paginate(context, page, base_url='', page_key=DEFAULT_PAGE_KEY,
         'page_key': page_key,
         'paginator': page.paginator,
     }
+
+
+@register.inclusion_tag("wagtailadmin/pages/listing/_buttons.html",
+                        takes_context=True)
+def page_listing_buttons(context, page, page_perms, is_parent=False):
+    button_hooks = hooks.get_hooks('register_page_listing_buttons')
+    buttons = sorted(itertools.chain.from_iterable(
+        hook(page, page_perms, is_parent)
+        for hook in button_hooks))
+    print(buttons)
+    return {'page': page, 'buttons': buttons}

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -292,5 +292,4 @@ def page_listing_buttons(context, page, page_perms, is_parent=False):
     buttons = sorted(itertools.chain.from_iterable(
         hook(page, page_perms, is_parent)
         for hook in button_hooks))
-    print(buttons)
     return {'page': page, 'buttons': buttons}

--- a/wagtail/wagtailadmin/tests/test_buttons_hooks.py
+++ b/wagtail/wagtailadmin/tests/test_buttons_hooks.py
@@ -1,0 +1,83 @@
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+from wagtail.tests.utils import WagtailTestUtils
+from wagtail.wagtailadmin import widgets as wagtailadmin_widgets
+from wagtail.wagtailcore import hooks
+from wagtail.wagtailcore.models import Page
+
+
+class TestButtonsHooks(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.root_page = Page.objects.get(id=2)
+        self.login()
+
+    def test_register_page_listing_buttons(self):
+        @hooks.register('register_page_listing_buttons')
+        def page_listing_buttons(page, page_perms, is_parent=False):
+            yield wagtailadmin_widgets.PageListingButton(
+                'Another useless page listing button',
+                '/custom-url',
+                priority=10
+            )
+
+        response = self.client.get(
+            reverse('wagtailadmin_explore', args=(self.root_page.id, ))
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/pages/listing/_button_with_dropdown.html')
+        self.assertTemplateUsed(response, 'wagtailadmin/pages/listing/_buttons.html')
+
+        self.assertContains(response, 'Another useless page listing button')
+
+    def test_register_page_listing_more_buttons(self):
+        @hooks.register('register_page_listing_more_buttons')
+        def page_listing_more_buttons(page, page_perms, is_parent=False):
+            yield wagtailadmin_widgets.Button(
+                'Another useless button in default "More" dropdown',
+                '/custom-url',
+                priority=10
+            )
+
+        response = self.client.get(
+            reverse('wagtailadmin_explore', args=(self.root_page.id, ))
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/pages/listing/_button_with_dropdown.html')
+        self.assertTemplateUsed(response, 'wagtailadmin/pages/listing/_buttons.html')
+
+        self.assertContains(response, 'Another useless button in default &quot;More&quot; dropdown')
+
+    def test_custom_button_with_dropdown(self):
+        @hooks.register('register_page_listing_buttons')
+        def page_custom_listing_buttons(page, page_perms, is_parent=False):
+            yield wagtailadmin_widgets.ButtonWithDropdownFromHook(
+                'One more more button',
+                hook_name='register_page_listing_one_more_more_buttons',
+                page=page,
+                page_perms=page_perms,
+                is_parent=is_parent,
+                attrs={'target': '_blank'},
+                priority=50
+            )
+
+        @hooks.register('register_page_listing_one_more_more_buttons')
+        def page_custom_listing_more_buttons(page, page_perms, is_parent=False):
+            yield wagtailadmin_widgets.Button(
+                'Another useless dropdown button in "One more more button" dropdown',
+                '/custom-url',
+                priority=10
+            )
+
+        response = self.client.get(
+            reverse('wagtailadmin_explore', args=(self.root_page.id, ))
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/pages/listing/_button_with_dropdown.html')
+        self.assertTemplateUsed(response, 'wagtailadmin/pages/listing/_buttons.html')
+
+        self.assertContains(response, 'One more more button')
+        self.assertContains(response, 'Another useless dropdown button in &quot;One more more button&quot; dropdown')

--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -1,5 +1,5 @@
-from django.core import urlresolvers
 from django.contrib.auth.models import Permission
+from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.staticfiles.templatetags.staticfiles import static
 
@@ -7,6 +7,7 @@ from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.permissions import collection_permission_policy
 from wagtail.wagtailadmin.menu import MenuItem, SubmenuMenuItem, settings_menu
 from wagtail.wagtailadmin.search import SearchArea
+from wagtail.wagtailadmin.widgets import Button, PageListingButton
 
 
 class ExplorerMenuItem(MenuItem):
@@ -17,10 +18,10 @@ class ExplorerMenuItem(MenuItem):
 @hooks.register('register_admin_menu_item')
 def register_explorer_menu_item():
     return ExplorerMenuItem(
-        _('Explorer'), urlresolvers.reverse('wagtailadmin_explore_root'),
+        _('Explorer'), reverse('wagtailadmin_explore_root'),
         name='explorer',
         classnames='icon icon-folder-open-inverse dl-trigger',
-        attrs={'data-explorer-menu-url': urlresolvers.reverse('wagtailadmin_explorer_nav')},
+        attrs={'data-explorer-menu-url': reverse('wagtailadmin_explorer_nav')},
         order=100)
 
 
@@ -38,7 +39,7 @@ def register_permissions():
 @hooks.register('register_admin_search_area')
 def register_pages_search_area():
     return SearchArea(
-        _('Pages'), urlresolvers.reverse('wagtailadmin_pages:search'),
+        _('Pages'), reverse('wagtailadmin_pages:search'),
         name='pages',
         classnames='icon icon-folder-open-inverse',
         order=100)
@@ -50,7 +51,32 @@ class CollectionsMenuItem(MenuItem):
             request.user, ['add', 'change', 'delete']
         )
 
-
 @hooks.register('register_settings_menu_item')
 def register_collections_menu_item():
-    return CollectionsMenuItem(_('Collections'), urlresolvers.reverse('wagtailadmin_collections:index'), classnames='icon icon-folder-open-1', order=700)
+    return CollectionsMenuItem(_('Collections'), reverse('wagtailadmin_collections:index'), classnames='icon icon-folder-open-1', order=700)
+
+
+@hooks.register('register_page_listing_buttons')
+def page_listing_buttons(page, page_perms, is_parent=False):
+    if page_perms.can_edit():
+        yield PageListingButton(_('Edit'), reverse('wagtailadmin_pages:edit', args=[page.id]),
+                                attrs={'title': _('Edit this page')}, priority=10)
+    if page.has_unpublished_changes:
+        yield PageListingButton(_('Draft'), reverse('wagtailadmin_pages:view_draft', args=[page.id]),
+                                attrs={'target': '_blank'}, priority=20)
+    if page.live and page.url:
+        yield PageListingButton(_('Live'), page.url, attrs={'target': "_blank"}, priority=30)
+    if page_perms.can_move():
+        yield PageListingButton(_('Move'), reverse('wagtailadmin_pages:move', args=[page.id]), priority=40)
+    if not page.is_root():
+        yield PageListingButton(_('Copy'), reverse('wagtailadmin_pages:copy', args=[page.id]), priority=50)
+    if page_perms.can_delete():
+        yield PageListingButton(_('Delete'), reverse('wagtailadmin_pages:delete', args=[page.id]), priority=60)
+    if page_perms.can_unpublish():
+        yield PageListingButton(_('Unpublish'), reverse('wagtailadmin_pages:unpublish', args=[page.id]), priority=70)
+    if page_perms.can_add_subpage():
+        if is_parent:
+            yield Button(_('Add child page'), reverse('wagtailadmin_pages:add_subpage', args=[page.id]),
+                         classes={'button', 'button-small', 'bicolor', 'icon', 'white', 'icon-plus'}, priority=80)
+        else:
+            yield PageListingButton(_('Add child page'), reverse('wagtailadmin_pages:add_subpage', args=[page.id]), priority=80)

--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -7,7 +7,7 @@ from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.permissions import collection_permission_policy
 from wagtail.wagtailadmin.menu import MenuItem, SubmenuMenuItem, settings_menu
 from wagtail.wagtailadmin.search import SearchArea
-from wagtail.wagtailadmin.widgets import Button, PageListingButton
+from wagtail.wagtailadmin.widgets import Button, PageListingButton, ButtonWithDropdownFromHook
 
 
 class ExplorerMenuItem(MenuItem):
@@ -51,6 +51,7 @@ class CollectionsMenuItem(MenuItem):
             request.user, ['add', 'change', 'delete']
         )
 
+
 @hooks.register('register_settings_menu_item')
 def register_collections_menu_item():
     return CollectionsMenuItem(_('Collections'), reverse('wagtailadmin_collections:index'), classnames='icon icon-folder-open-1', order=700)
@@ -66,17 +67,29 @@ def page_listing_buttons(page, page_perms, is_parent=False):
                                 attrs={'target': '_blank'}, priority=20)
     if page.live and page.url:
         yield PageListingButton(_('Live'), page.url, attrs={'target': "_blank"}, priority=30)
-    if page_perms.can_move():
-        yield PageListingButton(_('Move'), reverse('wagtailadmin_pages:move', args=[page.id]), priority=40)
-    if not page.is_root():
-        yield PageListingButton(_('Copy'), reverse('wagtailadmin_pages:copy', args=[page.id]), priority=50)
-    if page_perms.can_delete():
-        yield PageListingButton(_('Delete'), reverse('wagtailadmin_pages:delete', args=[page.id]), priority=60)
-    if page_perms.can_unpublish():
-        yield PageListingButton(_('Unpublish'), reverse('wagtailadmin_pages:unpublish', args=[page.id]), priority=70)
     if page_perms.can_add_subpage():
         if is_parent:
             yield Button(_('Add child page'), reverse('wagtailadmin_pages:add_subpage', args=[page.id]),
-                         classes={'button', 'button-small', 'bicolor', 'icon', 'white', 'icon-plus'}, priority=80)
+                         classes={'button', 'button-small', 'bicolor', 'icon', 'white', 'icon-plus'}, priority=40)
         else:
-            yield PageListingButton(_('Add child page'), reverse('wagtailadmin_pages:add_subpage', args=[page.id]), priority=80)
+            yield PageListingButton(_('Add child page'), reverse('wagtailadmin_pages:add_subpage', args=[page.id]), priority=40)
+
+    yield ButtonWithDropdownFromHook(
+        _('More'),
+        hook_name='register_page_listing_more_buttons',
+        page=page,
+        page_perms=page_perms,
+        is_parent=is_parent,
+        attrs={'target': '_blank'}, priority=50)
+
+
+@hooks.register('register_page_listing_more_buttons')
+def page_listing_more_buttons(page, page_perms, is_parent=False):
+    if page_perms.can_move():
+        yield Button(_('Move'), reverse('wagtailadmin_pages:move', args=[page.id]), priority=10)
+    if not page.is_root():
+        yield Button(_('Copy'), reverse('wagtailadmin_pages:copy', args=[page.id]), priority=20)
+    if page_perms.can_delete():
+        yield Button(_('Delete'), reverse('wagtailadmin_pages:delete', args=[page.id]), priority=30)
+    if page_perms.can_unpublish():
+        yield Button(_('Unpublish'), reverse('wagtailadmin_pages:unpublish', args=[page.id]), priority=40)

--- a/wagtail/wagtailadmin/widgets.py
+++ b/wagtail/wagtailadmin/widgets.py
@@ -1,19 +1,22 @@
 from __future__ import absolute_import, unicode_literals
 
 import json
+from functools import total_ordering
 
-from django.utils.formats import get_format
+from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 from django.forms import widgets
-from django.contrib.contenttypes.models import ContentType
-from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.forms.utils import flatatt
 from django.template.loader import render_to_string
+from django.utils.encoding import python_2_unicode_compatible
+from django.utils.formats import get_format
+from django.utils.functional import cached_property
+from django.utils.html import format_html
+from django.utils.translation import ugettext_lazy as _
+from taggit.forms import TagWidget
 
 from wagtail.utils.widgets import WidgetWithScript
 from wagtail.wagtailcore.models import Page
-
-from taggit.forms import TagWidget
 
 
 class AdminAutoHeightTextInput(WidgetWithScript, widgets.Textarea):
@@ -186,3 +189,45 @@ class AdminPageChooser(AdminChooser):
             parent=json.dumps(parent.id if parent else None),
             can_choose_root=('true' if self.can_choose_root else 'false')
         )
+
+
+@python_2_unicode_compatible
+@total_ordering
+class Button(object):
+    def __init__(self, label, url, classes=set(), attrs={}, priority=1000):
+        self.label = label
+        self.url = url
+        self.classes = classes
+        self.attrs = attrs.copy()
+        self.priority = priority
+
+    def render(self):
+        attrs = {'href': self.url, 'class': ' '.join(sorted(self.classes))}
+        attrs.update(self.attrs)
+        return format_html('<a{}>{}</a>', flatatt(attrs), self.label)
+
+    def __str__(self):
+        return self.render()
+
+    def __repr__(self):
+        return '<Button: {}>'.format(self.label)
+
+    def __lt__(self, other):
+        if not isinstance(other, Button):
+            return NotImplemented
+        return (self.priority, self.label) < (other.priority, other.label)
+
+    def __eq__(self, other):
+        if not isinstance(other, Button):
+            return NotImplemented
+        return (self.label == other.label and
+                self.url == other.url and
+                self.classes == other.classes and
+                self.attrs == other.attrs and
+                self.priority == other.priority)
+
+
+class PageListingButton(Button):
+    def __init__(self, label, url, classes=set(), **kwargs):
+        classes = {'button', 'button-small', 'button-secondary'} | set(classes)
+        super(PageListingButton, self).__init__(label, url, classes=classes, **kwargs)


### PR DESCRIPTION
The 'register_page_listing_buttons' hook allows plugin developers to add buttons to the actions list on the page listing in the admin.

This will come in useful when adding the revision rollback feature in the future, as the rollback plugin can add a button to the page listing.

Does this concept sound like a good plan to you? Documentation and tests will be coming shortly.