### PR TITLE
1615 lock should prevent unpublishing

### DIFF
--- a/wagtail/tests/testapp/fixtures/test.json
+++ b/wagtail/tests/testapp/fixtures/test.json
@@ -23,7 +23,7 @@
     "model": "wagtailcore.page",
     "fields": {
         "title": "Welcome to the Wagtail test site!",
-        "numchild": 5,
+        "numchild": 6,
         "show_in_menus": false,
         "live": true,
         "depth": 2,
@@ -33,7 +33,6 @@
         "slug": "home"
     }
 },
-
 {
     "pk": 3,
     "model": "wagtailcore.page",
@@ -379,7 +378,22 @@
         "cost": "free"
     }
 },
-
+{
+    "pk": 14,
+    "model": "wagtailcore.page",
+    "fields": {
+        "title": "My locked page",
+        "numchild": 0,
+        "show_in_menus": true,
+        "live": true,
+        "depth": 3,
+        "content_type": ["wagtailcore", "page"],
+        "path": "000100010006",
+        "url_path": "/home/my-locked-page/",
+        "slug": "my-locked-page",
+        "locked": true
+    }
+},
 {
     "pk": 1,
     "model": "wagtailcore.site",

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1352,6 +1352,8 @@ class PagePermissionTester(object):
             return False
         if (not self.page.live) or self.page_is_root:
             return False
+        if self.page.locked:
+            return False
 
         return self.user.is_superuser or ('publish' in self.permissions)
 

--- a/wagtail/wagtailcore/tests/test_page_permissions.py
+++ b/wagtail/wagtailcore/tests/test_page_permissions.py
@@ -303,10 +303,13 @@ class TestPagePermission(TestCase):
     def test_lock_page_for_superuser(self):
         user = get_user_model().objects.get(username='superuser')
         christmas_page = EventPage.objects.get(url_path='/home/events/christmas/')
+        locked_page = Page.objects.get(url_path='/home/my-locked-page/')
 
         perms = UserPagePermissionsProxy(user).for_page(christmas_page)
+        locked_perms = UserPagePermissionsProxy(user).for_page(locked_page)
 
         self.assertTrue(perms.can_lock())
+        self.assertFalse(locked_perms.can_unpublish()) # locked pages can't be unpublished
 
     def test_lock_page_for_moderator(self):
         user = get_user_model().objects.get(username='eventmoderator')

--- a/wagtail/wagtailcore/tests/test_page_permissions.py
+++ b/wagtail/wagtailcore/tests/test_page_permissions.py
@@ -309,7 +309,7 @@ class TestPagePermission(TestCase):
         locked_perms = UserPagePermissionsProxy(user).for_page(locked_page)
 
         self.assertTrue(perms.can_lock())
-        self.assertFalse(locked_perms.can_unpublish()) # locked pages can't be unpublished
+        self.assertFalse(locked_perms.can_unpublish())  # locked pages can't be unpublished
 
     def test_lock_page_for_moderator(self):
         user = get_user_model().objects.get(username='eventmoderator')


### PR DESCRIPTION
Fix for bug #1615 (Locking a page makes it possible to unpublish a page without a method to undo). By denying permission at the level of the `can_unpublish` function, the interface takes care of hiding the unpublish option as appropriate.