### PR TITLE
Issue with multiple word tags in Images and Documents views.

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -21,6 +21,20 @@ function escapeHtml(text) {
     });
 }
 
+function initTagField(id, autocompleteUrl) {
+    $('#' + id).tagit({
+        autocomplete: {source: autocompleteUrl},
+        preprocessTag: function(val) {
+            // Double quote a tag if it contains a space
+            // and if it isn't already quoted.
+            if (val && val[0] != '"' && val.indexOf(' ') > -1) {
+                return '"' + val + '"';
+            }
+            return val;
+        }
+    });
+}
+
 $(function() {
     // Add class to the body from which transitions may be hung so they don't appear to transition as the page loads
     $('body').addClass('ready');
@@ -183,3 +197,4 @@ $(function() {
         }, 10);
     });
 });
+

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -30,6 +30,7 @@ function initTagField(id, autocompleteUrl) {
             if (val && val[0] != '"' && val.indexOf(' ') > -1) {
                 return '"' + val + '"';
             }
+
             return val;
         }
     });

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -130,21 +130,6 @@ function initDateTimeChooser(id) {
     }
 }
 
-function initTagField(id, autocompleteUrl) {
-    $('#' + id).tagit({
-        autocomplete: {source: autocompleteUrl},
-        preprocessTag: function(val) {
-            // Double quote a tag if it contains a space
-            // and if it isn't already quoted.
-            if (val && val[0] != '"' && val.indexOf(' ') > -1) {
-                return '"' + val + '"';
-            }
-
-            return val;
-        }
-    });
-}
-
 function InlinePanel(opts) {
     var self = {};
 

--- a/wagtail/wagtaildocs/forms.py
+++ b/wagtail/wagtaildocs/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 
+from wagtail.wagtailadmin import widgets
 from wagtail.wagtaildocs.models import Document
 
 
@@ -10,5 +11,6 @@ class DocumentForm(forms.ModelForm):
         model = Document
         fields = ('title', 'file', 'tags')
         widgets = {
-            'file': forms.FileInput()
+            'file': forms.FileInput(),
+            'tags': widgets.AdminTagWidget,
         }

--- a/wagtail/wagtailimages/forms.py
+++ b/wagtail/wagtailimages/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.forms.models import modelform_factory
 from django.utils.translation import ugettext as _
 
+from wagtail.wagtailadmin import widgets
 from wagtail.wagtailimages.formats import get_image_formats
 from wagtail.wagtailimages.fields import WagtailImageField
 
@@ -16,6 +17,7 @@ def formfield_for_dbfield(db_field, **kwargs):
     return db_field.formfield(**kwargs)
 
 
+
 def get_image_form(model):
     return modelform_factory(
         model,
@@ -25,6 +27,7 @@ def get_image_form(model):
         # so that when editing, we don't get the 'currently: ...' banner which is
         # a bit pointless here
         widgets={
+            'tags': widgets.AdminTagWidget,
             'file': forms.FileInput(),
             'focal_point_x': forms.HiddenInput(attrs={'class': 'focal_point_x'}),
             'focal_point_y': forms.HiddenInput(attrs={'class': 'focal_point_y'}),


### PR DESCRIPTION
When you use tagging feature for Images and Documents you can't save a model with only a single tag containing multiple words in it.
It will create separate tags.

Steps to reproduce:
 1. Start editing a document in Wagtail admin. 
2. Ensure tags field is empty.
 3. Start typing a single tag with a double quote and enter multiple words, then close it with double quote. 4. Save the document.
 5. Edit the document again—you will see multiple tags instead a one with multiple words.

The problem is that tag fields are not preprocessed by this function:
https://github.com/torchbox/wagtail/blob/master/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js#L133
