### PR TITLE
Added 'operator' to the API

### DIFF
--- a/wagtail/contrib/wagtailapi/endpoints.py
+++ b/wagtail/contrib/wagtailapi/endpoints.py
@@ -46,6 +46,7 @@ class BaseAPIEndpoint(GenericViewSet):
         'fields',
         'order',
         'search',
+        'operator',
 
         # Used by jQuery for cache-busting. See #1671
         '_',

--- a/wagtail/contrib/wagtailapi/filters.py
+++ b/wagtail/contrib/wagtailapi/filters.py
@@ -101,9 +101,10 @@ class SearchFilter(BaseFilterBackend):
                 raise BadRequestError("filtering by tag with a search query is not supported")
 
             search_query = request.GET['search']
+            search_operator = request.GET.get('operator', None)
 
             sb = get_search_backend()
-            queryset = sb.search(search_query, queryset)
+            queryset = sb.search(search_query, queryset, operator=search_operator)
 
         return queryset
 

--- a/wagtail/contrib/wagtailapi/tests/test_pages.py
+++ b/wagtail/contrib/wagtailapi/tests/test_pages.py
@@ -532,6 +532,22 @@ class TestPageListing(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(content, {'message': "filtering by tag with a search query is not supported"})
 
+    def test_search_operator_and(self):
+        response = self.get_response(type='demosite.BlogEntryPage', search='blog again', operator='and')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+
+        self.assertEqual(set(page_id_list), set([18]))
+
+    def test_search_operator_or(self):
+        response = self.get_response(type='demosite.BlogEntryPage', search='blog again', operator='or')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+
+        self.assertEqual(set(page_id_list), set([16, 18, 19]))
+
 
 class TestPageDetail(TestCase):
     fixtures = ['demosite.json']


### PR DESCRIPTION
Enabled searching via the api to include the 'operator' key for performing searches using the elasticsearch 'and' operator.