### PR TITLE
Include non-creatable pages in get_page_models

### DIFF
--- a/docs/reference/pages/queryset_reference.rst
+++ b/docs/reference/pages/queryset_reference.rst
@@ -202,6 +202,24 @@ Reference
 
     .. automethod:: not_type
 
+    .. automethod:: exact_type
+
+        Example:
+
+        .. code-block:: python
+
+            # Find all pages that are of the exact type EventPage
+            event_pages = Page.objects.exact_type(EventPage)
+
+    .. automethod:: not_exact_type
+
+        Example:
+
+        .. code-block:: python
+
+            # Find all pages that are not of the exact type EventPage (but may be a subclass)
+            non_event_pages = Page.objects.not_exact_type(EventPage)
+
     .. automethod:: unpublish
 
         Example:

--- a/wagtail/tests/testapp/migrations/0016_mtibasepage_verbose_name.py
+++ b/wagtail/tests/testapp/migrations/0016_mtibasepage_verbose_name.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tests', '0015_genericsnippetpage'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='mtibasepage',
+            options={'verbose_name': 'MTI Base page'},
+        ),
+    ]

--- a/wagtail/tests/testapp/migrations/0017_businessnowherepage.py
+++ b/wagtail/tests/testapp/migrations/0017_businessnowherepage.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0020_add_index_on_page_first_published_at'),
+        ('tests', '0016_mtibasepage_verbose_name'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='BusinessNowherePage',
+            fields=[
+                ('page_ptr', models.OneToOneField(serialize=False, auto_created=True, to='wagtailcore.Page', primary_key=True, parent_link=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('wagtailcore.page',),
+        ),
+    ]

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -462,6 +462,9 @@ class StreamPage(Page):
 class MTIBasePage(Page):
     is_creatable = False
 
+    class Meta:
+        verbose_name = "MTI Base page"
+
 
 class MTIChildPage(MTIBasePage):
     # Should be creatable by default, no need to set anything

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -359,8 +359,8 @@ register_snippet(Advert)
 
 
 class StandardIndex(Page):
-    """ Index for the site, not allowed to be placed anywhere """
-    parent_page_types = []
+    """ Index for the site """
+    pass
 
 
 # A custom panel setup where all Promote fields are placed in the Content tab instead;
@@ -401,6 +401,11 @@ class BusinessChild(Page):
     """ Can only be placed under Business indexes, no children allowed """
     subpage_types = []
     parent_page_types = ['tests.BusinessIndex', BusinessSubIndex]
+
+
+class BusinessNowherePage(Page):
+    """ Not allowed to be placed anywhere """
+    parent_page_types = []
 
 
 class TaggedPageTag(TaggedItemBase):

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -202,6 +202,12 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtailadmin_pages:add_subpage', args=(self.root_page.id, )))
         self.assertEqual(response.status_code, 200)
 
+        self.assertContains(response, "Simple Page")
+        # List of available page types should not contain pages with is_creatable = False
+        self.assertNotContains(response, "MTI Base Page")
+        # List of available page types should not contain abstract pages
+        self.assertNotContains(response, "Abstract Page")
+
     def test_add_subpage_bad_permissions(self):
         # Remove privileges from user
         self.user.is_superuser = False

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -67,8 +67,7 @@ def add_subpage(request, parent_page_id):
 
     page_types = [
         (model.get_verbose_name(), model._meta.app_label, model._meta.model_name)
-        for model in parent_page.allowed_subpage_models()
-        if model.is_creatable
+        for model in parent_page.creatable_subpage_models()
     ]
     # sort by lower-cased version of verbose name
     page_types.sort(key=lambda page_type: page_type[0].lower())
@@ -128,7 +127,7 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
         raise Http404
 
     # page must be in the list of allowed subpage types for this parent ID
-    if page_class not in parent_page.allowed_subpage_models():
+    if page_class not in parent_page.creatable_subpage_models():
         raise PermissionDenied
 
     page = page_class(owner=request.user)

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -68,6 +68,7 @@ def add_subpage(request, parent_page_id):
     page_types = [
         (model.get_verbose_name(), model._meta.app_label, model._meta.model_name)
         for model in parent_page.allowed_subpage_models()
+        if model.is_creatable
     ]
     # sort by lower-cased version of verbose name
     page_types.sort(key=lambda page_type: page_type[0].lower())

--- a/wagtail/wagtailcore/management/commands/replace_text.py
+++ b/wagtail/wagtailcore/management/commands/replace_text.py
@@ -32,7 +32,10 @@ class Command(BaseCommand):
 
             child_relation_names = [rel.get_accessor_name() for rel in get_all_child_relations(page_class)]
 
-            for page in page_class.objects.all():
+            # Find all pages of this exact type; exclude subclasses, as they will
+            # appear in the get_page_models() list in their own right, and this
+            # ensures that replacement happens only once
+            for page in page_class.objects.exact_type(page_class):
                 replace_in_model(page, from_text, to_text)
                 for child_rel in child_relation_names:
                     for child in getattr(page, child_rel).all():

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -721,11 +721,6 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         Returns the list of page types that this page type can be a parent of,
         as a list of model classes
         """
-        # Special case the 'Page' class, such as the Root page or Home page -
-        # otherwise you can not add initial pages when setting up a site
-        if cls == Page:
-            return get_page_models()
-
         return [
             subpage_model for subpage_model in cls.clean_subpage_models()
             if cls in subpage_model.clean_parent_page_models()

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -740,6 +740,17 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         return get_content_type_list(cls.allowed_subpage_models())
 
     @classmethod
+    def creatable_subpage_models(cls):
+        """
+        Returns the list of page types that may be created under this page type,
+        as a list of model classes
+        """
+        return [
+            page_model for page_model in cls.allowed_subpage_models()
+            if page_model.is_creatable
+        ]
+
+    @classmethod
     def get_verbose_name(cls):
         """
             Returns the human-readable "verbose name" of this page model e.g "Blog page".

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -226,7 +226,7 @@ class PageBase(models.base.ModelBase):
         if 'is_creatable' not in dct:
             cls.is_creatable = not cls._meta.abstract
 
-        if cls.is_creatable:
+        if not cls._meta.abstract:
             # register this type in the list of page content types
             PAGE_MODEL_CLASSES.append(cls)
 

--- a/wagtail/wagtailcore/query.py
+++ b/wagtail/wagtailcore/query.py
@@ -191,6 +191,23 @@ class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
         """
         return self.exclude(self.type_q(model))
 
+    def exact_type_q(self, klass):
+        return Q(content_type=ContentType.objects.get_for_model(klass))
+
+    def exact_type(self, model):
+        """
+        This filters the QuerySet to only contain pages that are an instance of the specified model
+        (matching the model exactly, not subclasses).
+        """
+        return self.filter(self.exact_type_q(model))
+
+    def not_exact_type(self, model):
+        """
+        This filters the QuerySet to not contain any pages which are an instance of the specified model
+        (matching the model exactly, not subclasses).
+        """
+        return self.exclude(self.exact_type_q(model))
+
     def public_q(self):
         from wagtail.wagtailcore.models import PageViewRestriction
 

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -16,7 +16,7 @@ from wagtail.tests.testapp.models import (
     BusinessIndex, BusinessSubIndex, BusinessChild, StandardIndex,
     MTIBasePage, MTIChildPage, AbstractPage, TaggedPage,
     BlogCategory, BlogCategoryBlogPage, Advert, ManyToManyBlogPage,
-    GenericSnippetPage)
+    GenericSnippetPage, BusinessNowherePage)
 from wagtail.tests.utils import WagtailTestUtils
 
 
@@ -765,9 +765,9 @@ class TestSubpageTypeBusinessRules(TestCase, WagtailTestUtils):
         # BusinessChild cannot be a parent of anything
         self.assertNotIn(BusinessChild, SimplePage.allowed_parent_page_models())
 
-        # StandardIndex does not allow anything as a parent
-        self.assertNotIn(SimplePage, StandardIndex.allowed_parent_page_models())
-        self.assertNotIn(StandardIndex, StandardIndex.allowed_parent_page_models())
+        # BusinessNowherePage does not allow anything as a parent
+        self.assertNotIn(SimplePage, BusinessNowherePage.allowed_parent_page_models())
+        self.assertNotIn(StandardIndex, BusinessNowherePage.allowed_parent_page_models())
 
         # BusinessSubIndex only allows BusinessIndex as a parent
         self.assertNotIn(SimplePage, BusinessSubIndex.allowed_parent_page_models())
@@ -787,9 +787,9 @@ class TestSubpageTypeBusinessRules(TestCase, WagtailTestUtils):
             # BusinessChild cannot be a parent of anything
             self.assertNotIn(ContentType.objects.get_for_model(BusinessChild), SimplePage.allowed_parent_page_types())
 
-            # StandardIndex does not allow anything as a parent
-            self.assertNotIn(ContentType.objects.get_for_model(SimplePage), StandardIndex.allowed_parent_page_types())
-            self.assertNotIn(ContentType.objects.get_for_model(StandardIndex), StandardIndex.allowed_parent_page_types())
+            # BusinessNowherePage does not allow anything as a parent
+            self.assertNotIn(ContentType.objects.get_for_model(SimplePage), BusinessNowherePage.allowed_parent_page_types())
+            self.assertNotIn(ContentType.objects.get_for_model(StandardIndex), BusinessNowherePage.allowed_parent_page_types())
 
             # BusinessSubIndex only allows BusinessIndex as a parent
             self.assertNotIn(ContentType.objects.get_for_model(SimplePage), BusinessSubIndex.allowed_parent_page_types())

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -871,7 +871,8 @@ class TestIsCreatable(TestCase):
     def test_is_creatable_false(self):
         """Page types should be able to disable their creation"""
         self.assertFalse(MTIBasePage.is_creatable)
-        self.assertNotIn(MTIBasePage, get_page_models())
+        # non-creatable pages should still appear in the get_page_models list
+        self.assertIn(MTIBasePage, get_page_models())
 
     def test_is_creatable_not_inherited(self):
         """

--- a/wagtail/wagtailcore/tests/test_page_queryset.py
+++ b/wagtail/wagtailcore/tests/test_page_queryset.py
@@ -294,6 +294,11 @@ class TestPageQuerySet(TestCase):
         event = Page.objects.get(url_path='/home/events/someone-elses-event/')
         self.assertTrue(pages.filter(id=event.id).exists())
 
+        # Check that "Saint Patrick" (an instance of SingleEventPage, a subclass of EventPage)
+        # is in the results
+        event = Page.objects.get(url_path='/home/events/saint-patrick/')
+        self.assertTrue(pages.filter(id=event.id).exists())
+
     def test_type_includes_subclasses(self):
         from wagtail.wagtailforms.models import AbstractEmailForm
         pages = Page.objects.type(AbstractEmailForm)
@@ -316,6 +321,38 @@ class TestPageQuerySet(TestCase):
         # Check that the homepage is in the results
         homepage = Page.objects.get(url_path='/home/')
         self.assertTrue(pages.filter(id=homepage.id).exists())
+
+    def test_exact_type(self):
+        pages = Page.objects.exact_type(EventPage)
+
+        # Check that all objects are EventPages (and not a subclass)
+        for page in pages:
+            self.assertEqual(type(page.specific), EventPage)
+
+        # Check that "someone elses event" is in the results
+        event = Page.objects.get(url_path='/home/events/someone-elses-event/')
+        self.assertTrue(pages.filter(id=event.id).exists())
+
+        # Check that "Saint Patrick" (an instance of SingleEventPage, a subclass of EventPage)
+        # is NOT in the results
+        event = Page.objects.get(url_path='/home/events/saint-patrick/')
+        self.assertFalse(pages.filter(id=event.id).exists())
+
+    def test_not_exact_type(self):
+        pages = Page.objects.not_exact_type(EventPage)
+
+        # Check that no objects are EventPages
+        for page in pages:
+            self.assertNotEqual(type(page.specific), EventPage)
+
+        # Check that the homepage is in the results
+        homepage = Page.objects.get(url_path='/home/')
+        self.assertTrue(pages.filter(id=homepage.id).exists())
+
+        # Check that "Saint Patrick" (an instance of SingleEventPage, a subclass of EventPage)
+        # is in the results
+        event = Page.objects.get(url_path='/home/events/saint-patrick/')
+        self.assertTrue(pages.filter(id=event.id).exists())
 
     def test_public(self):
         events_index = Page.objects.get(url_path='/home/events/')


### PR DESCRIPTION
Second part of the cleanup for #1572 as discussed in https://github.com/torchbox/wagtail/pull/1572#issuecomment-158382266. This builds on #1950, the first part of the cleanup.

We update the `PAGE_MODEL_CLASSES` list (as returned by `get_page_models`) to include non-creatable page models such as `Page` itself. (Leaving these out made sense when these types were referred to as "abstract", but now our terminology has changed to "creatable" it's logical for these to be included.) This means that we can drop the special case in `allowed_subpage_types` that allowed all pages as children of `Page`; this special case was necessary because `Page` never appeared in the default `parent_page_types` list, meaning that we wouldn't be able to create children of root without jumping through hoops.

Note that this is a change of behaviour - pages with an explicit `parent_page_types` that does not include `Page` could previously be added, and now they cannot (i.e. this fixes #725). There was some debate on https://github.com/torchbox/wagtail/issues/725#issuecomment-60009672 about whether `parent_page_types = []` should genuinely mean "cannot be added anywhere" or whether it should be special-cased as "can only be added at the top level" (so that we don't have to write the clunky-and-internals-exposing `parent_page_types = [Page]` for homepages). I've gone for the former, as it involves less "magic" (and if we decide otherwise, I reckon it's going to be cleaner to make that change on top of this one).

Besides the `allowed_subpage_types` logic, there are a couple of other places that use `get_page_models`. I've checked that these are not adversely affected by this change - in most cases, they become *more* logically correct by including `Page` (and other non-creatable types) in the list. However, this uncovered an obscure edge case (i.e. made it slightly less obscure...) in the `replace_text` management command, where the text replacement could end up happening multiple times on the same page. This is now fixed (and in the process, new methods `exact_type` and `not_exact_type` added on `PageQuerySet`).