### PR TITLE
Added Drone Dockerfiles to /scripts

### DIFF
--- a/scripts/drone-images/flake8/Dockerfile
+++ b/scripts/drone-images/flake8/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.4
+
+RUN pip3.4 install flake8

--- a/scripts/drone-images/jscs/Dockerfile
+++ b/scripts/drone-images/jscs/Dockerfile
@@ -1,0 +1,3 @@
+FROM node:0.12
+
+RUN npm install -g jscs

--- a/scripts/drone-images/readme.md
+++ b/scripts/drone-images/readme.md
@@ -1,0 +1,5 @@
+Wagtail CI base images
+======================
+
+This directory contains Dockerfiles for building the base images used by
+Wagtail's continuous integration server.

--- a/scripts/drone-images/scss-lint/Dockerfile
+++ b/scripts/drone-images/scss-lint/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.2
+
+ADD gen_locale.sh /gen_locale.sh
+RUN bash /gen_locale.sh
+ENV LANG=en_GB.UTF-8
+
+# Install scss-lint
+RUN gem install scss-lint

--- a/scripts/drone-images/scss-lint/gen_locale.sh
+++ b/scripts/drone-images/scss-lint/gen_locale.sh
@@ -1,0 +1,7 @@
+apt-get update \
+    && apt-get install -y locales \
+    && rm -rf /var/lib/apt/lists/* \
+
+echo "en_GB.UTF-8 UTF-8" >> /etc/locale.gen
+
+locale-gen


### PR DESCRIPTION
This adds the Dockerfiles that build the base images used by the Drone server. I think it's useful having them here for reference.