### PR TITLE
Deprecate admin permissions helper; move to Page model

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -17,6 +17,7 @@ from django.core.handlers.wsgi import WSGIRequest
 from django.core.handlers.base import BaseHandler
 from django.core.urlresolvers import reverse
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.conf import settings
 from django.template.response import TemplateResponse
@@ -1069,6 +1070,28 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
     def get_view_restrictions(self):
         """Return a query set of all page view restrictions that apply to this page"""
         return PageViewRestriction.objects.filter(page__in=self.get_ancestors(inclusive=True))
+
+    def get_users_with_permission(self, permission_type, include_superusers=True):
+        """
+        May be overriden by a derived page class in order to add additional
+        permissions to an individual page, outside of a group.
+
+        Args:
+            permission_type: str of permission type
+            include_superusers: bool indicating whether or not all superusers should be included
+
+        Returns:
+            QuerySet of users with "permission_type" permission.
+        """
+        # Find GroupPagePermission records of the given type that apply to this page or an ancestor
+        ancestors_and_self = list(self.get_ancestors()) + [self]
+        perm = GroupPagePermission.objects.filter(permission_type=permission_type, page__in=ancestors_and_self)
+        q = Q(groups__page_permissions=perm)
+
+        if include_superusers:
+            q |= Q(is_superuser=True)
+
+        return get_user_model().objects.filter(is_active=True).filter(q)
 
     password_required_template = getattr(settings, 'PASSWORD_REQUIRED_TEMPLATE', 'wagtailcore/password_required.html')
 


### PR DESCRIPTION
Basically, migrating `wagtail.wagtailadmin.utils.users_with_page_permission` to `wagtail.wagtailcore.models.PageBase. get_users_with_permission`. Doing so makes it possible to override the default behaviour on `Page` subclasses.

Before merging, some discussion will be required on how this should be made consistent with `Page.permissions_for_user` - it seems the admin helper used some simplifying assumptions. Though it would be far slower, it seems that in order to get all users with an appropriate permission, we must fetch all users and test their permissions with `permissions_for_user`. Something like

```python
def get_users_with_permission(self, permission, include_superusers=True):
    return [
        upp.user for upp in filter(
            lambda upp: permission in upp.permissions,
            self.permissions_for_user(user) for user in get_user_model().objects.all()
        )
    ]
```

In order to retain the `include_superusers` behaviour, the `PagePermissionsTester` would require some refactoring.

Something else to consider is the deprecation warning. If you're happy to deprecate the old helper, I don't know what the policy on which 'version' should be used for the warning (1.5?). The original helper wasn't used anywhere in the Wagtail code outside of the `utils.py` file, 