### PR TITLE
Email notifications use page permission helpers

### DIFF
--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -52,16 +52,30 @@ def get_object_usage(obj):
 
 def users_with_page_permission(page, permission_type, include_superusers=True):
     # Get user model
+    if not include_superusers:
+        raise NotImplementedError("This functionality is no longer supported")
+
     User = get_user_model()
 
-    # Find GroupPagePermission records of the given type that apply to this page or an ancestor
-    ancestors_and_self = list(page.get_ancestors()) + [page]
-    perm = GroupPagePermission.objects.filter(permission_type=permission_type, page__in=ancestors_and_self)
-    q = Q(groups__page_permissions=perm)
+    # Get all page permissions for all users (this is going to be slow if you
+    # have lots of users). Note that the `permissions` attribute isn't set on
+    # `PagePermissionTester` if the user is a superuser or not active, so we
+    # pre-filter out such users to avoid attribtue errors. We OR superusers
+    # back in later, and we don't care about inactive users.
+    user_page_permissions = [
+        page.permissions_for_user(user)
+        for user in User.objects.filter(is_superuser=False, is_active=True)
+    ]
+    # Now we have all the users, filter by those that have `permission_type` in
+    # their list of permissions for this page.
+    q = Q(pk__in=[
+        upp.user.pk
+        for upp in user_page_permissions
+        if permission_type in upp.permissions
+    ])
 
     # Include superusers
-    if include_superusers:
-        q |= Q(is_superuser=True)
+    q |= Q(is_superuser=True)
 
     return User.objects.filter(is_active=True).filter(q).distinct()
 


### PR DESCRIPTION
Sorry for the PR spam :)

The original implementation of this helper didn't necessarily agree with what
`page.permissions_for_user` would tell you for a given user, so this
code has been updated to fix that. The compromise is that
`include_superuser` can no longer be set to `False` and it'll be a bit
slower, but given that this helper is only used in one place, hopefully
that's not an issue.

Not sure if raising a `NotImplementedError` is the way to go, or whether
we should just strip the parameter.

Replaces #1989, related to #1384.