### PR TITLE
PEP8 cleanups

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ usedevelop = True
 envlist = py{27,33,34,35}-dj{17,18}-{sqlite,postgres,mysql}, flake8
 
 [flake8]
-ignore = E501,E128,E303,E124,E126
+ignore = E501,E128,E303,E126
 exclude = wagtail/project_template/*
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ usedevelop = True
 envlist = py{27,33,34,35}-dj{17,18}-{sqlite,postgres,mysql}, flake8
 
 [flake8]
-ignore = E501,E128,E303,E126
+ignore = E501,E128,E303
 exclude = wagtail/project_template/*
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ usedevelop = True
 envlist = py{27,33,34,35}-dj{17,18}-{sqlite,postgres,mysql}, flake8
 
 [flake8]
-ignore = E501,E128,E302,E303,E124,E126
+ignore = E501,E128,E303,E124,E126
 exclude = wagtail/project_template/*
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ usedevelop = True
 envlist = py{27,33,34,35}-dj{17,18}-{sqlite,postgres,mysql}, flake8
 
 [flake8]
-ignore = E501,E128,E303
+ignore = E501,E303
 exclude = wagtail/project_template/*
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ usedevelop = True
 envlist = py{27,33,34,35}-dj{17,18}-{sqlite,postgres,mysql}, flake8
 
 [flake8]
-ignore = E501,E128,E261,E302,E303,E124,E126
+ignore = E501,E128,E302,E303,E124,E126
 exclude = wagtail/project_template/*
 
 [testenv]

--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -59,6 +59,7 @@ COMMANDS = {
     'start': create_project,
 }
 
+
 def main():
     # Parse options
     parser = OptionParser(usage="Usage: %prog start project_name [directory]")

--- a/wagtail/contrib/wagtailfrontendcache/backends.py
+++ b/wagtail/contrib/wagtailfrontendcache/backends.py
@@ -12,9 +12,9 @@ logger = logging.getLogger('wagtail.frontendcache')
 
 
 class PurgeRequest(Request):
-
     def get_method(self):
         return 'PURGE'
+
 
 class BaseBackend(object):
     def purge(self, url):

--- a/wagtail/contrib/wagtailsearchpromotions/tests.py
+++ b/wagtail/contrib/wagtailsearchpromotions/tests.py
@@ -205,7 +205,7 @@ class TestSearchPromotionsEditView(TestCase, WagtailTestUtils):
             'editors_picks-0-DELETE': '',
             'editors_picks-0-ORDER': 0,
             'editors_picks-0-page': 1,
-            'editors_picks-0-description': "Description has changed", # Change
+            'editors_picks-0-description': "Description has changed",  # Change
             'editors_picks-1-id': self.search_pick_2.id,
             'editors_picks-1-DELETE': '',
             'editors_picks-1-ORDER': 1,
@@ -233,12 +233,12 @@ class TestSearchPromotionsEditView(TestCase, WagtailTestUtils):
             'editors_picks-MAX_NUM_FORMS': 1000,
             'editors_picks-0-id': self.search_pick.id,
             'editors_picks-0-DELETE': '',
-            'editors_picks-0-ORDER': 1, # Change
+            'editors_picks-0-ORDER': 1,  # Change
             'editors_picks-0-page': 1,
             'editors_picks-0-description': "Root page",
             'editors_picks-1-id': self.search_pick_2.id,
             'editors_picks-1-DELETE': '',
-            'editors_picks-1-ORDER': 0, # Change
+            'editors_picks-1-ORDER': 0,  # Change
             'editors_picks-1-page': 2,
             'editors_picks-1-description': "Homepage",
         }
@@ -295,7 +295,7 @@ class TestSearchPromotionsEditView(TestCase, WagtailTestUtils):
             'editors_picks-0-DELETE': 1,
             'editors_picks-0-ORDER': 0,
             'editors_picks-0-page': 1,
-            'editors_picks-0-description': "Description has changed", # Change
+            'editors_picks-0-description': "Description has changed",  # Change
             'editors_picks-1-id': self.search_pick_2.id,
             'editors_picks-1-DELETE': 1,
             'editors_picks-1-ORDER': 1,

--- a/wagtail/contrib/wagtailsearchpromotions/wagtail_hooks.py
+++ b/wagtail/contrib/wagtailsearchpromotions/wagtail_hooks.py
@@ -33,4 +33,4 @@ def register_search_picks_menu_item():
 @hooks.register('register_permissions')
 def register_permissions():
     return Permission.objects.filter(content_type__app_label='wagtailsearchpromotions',
-        codename__in=['add_searchpromotion', 'change_searchpromotion', 'delete_searchpromotion'])
+                                     codename__in=['add_searchpromotion', 'change_searchpromotion', 'delete_searchpromotion'])

--- a/wagtail/contrib/wagtailsitemaps/tests.py
+++ b/wagtail/contrib/wagtailsitemaps/tests.py
@@ -44,8 +44,8 @@ class TestSitemapGenerator(TestCase):
         sitemap = Sitemap(self.site)
         urls = [url['location'] for url in sitemap.get_urls()]
 
-        self.assertIn('http://localhost/', urls) # Homepage
-        self.assertIn('http://localhost/hello-world/', urls) # Child page
+        self.assertIn('http://localhost/', urls)  # Homepage
+        self.assertIn('http://localhost/hello-world/', urls)  # Child page
 
     def test_get_urls_uses_specific(self):
         # Add an event page which has an extra url in the sitemap
@@ -58,8 +58,8 @@ class TestSitemapGenerator(TestCase):
         sitemap = Sitemap(self.site)
         urls = [url['location'] for url in sitemap.get_urls()]
 
-        self.assertIn('http://localhost/events/', urls) # Main view
-        self.assertIn('http://localhost/events/past/', urls) # Sub view
+        self.assertIn('http://localhost/events/', urls)  # Main view
+        self.assertIn('http://localhost/events/past/', urls)  # Sub view
 
     def test_render(self):
         sitemap = Sitemap(self.site)
@@ -102,7 +102,7 @@ class TestSitemapView(TestCase):
         second_response = self.client.get('/sitemap.xml')
 
         self.assertEqual(second_response.status_code, 200)
-        self.assertTemplateNotUsed(second_response, 'wagtailsitemaps/sitemap.xml') # Sitemap should not be re rendered
+        self.assertTemplateNotUsed(second_response, 'wagtailsitemaps/sitemap.xml')  # Sitemap should not be re rendered
 
         # Check that the content is the same
         self.assertEqual(first_response.content, second_response.content)

--- a/wagtail/tests/demosite/models.py
+++ b/wagtail/tests/demosite/models.py
@@ -156,8 +156,10 @@ class HomePage(Page):
 class HomePageCarouselItem(Orderable, AbstractCarouselItem):
     page = ParentalKey('HomePage', related_name='carousel_items')
 
+
 class HomePageRelatedLink(Orderable, AbstractRelatedLink):
     page = ParentalKey('HomePage', related_name='related_links')
+
 
 HomePage.content_panels = Page.content_panels + [
     FieldPanel('body', classname="full"),
@@ -194,11 +196,14 @@ class StandardPage(Page):
         index.SearchField('body'),
     )
 
+
 class StandardPageCarouselItem(Orderable, AbstractCarouselItem):
     page = ParentalKey('StandardPage', related_name='carousel_items')
 
+
 class StandardPageRelatedLink(Orderable, AbstractRelatedLink):
     page = ParentalKey('StandardPage', related_name='related_links')
+
 
 StandardPage.content_panels = Page.content_panels + [
     FieldPanel('intro', classname="full"),
@@ -206,6 +211,7 @@ StandardPage.content_panels = Page.content_panels + [
     FieldPanel('body', classname="full"),
     InlinePanel('related_links', label="Related links"),
 ]
+
 
 StandardPage.promote_panels = [
     MultiFieldPanel(Page.promote_panels, "Common page configuration"),
@@ -234,13 +240,16 @@ class StandardIndexPage(Page):
         index.SearchField('intro'),
     )
 
+
 class StandardIndexPageRelatedLink(Orderable, AbstractRelatedLink):
     page = ParentalKey('StandardIndexPage', related_name='related_links')
+
 
 StandardIndexPage.content_panels = Page.content_panels + [
     FieldPanel('intro', classname="full"),
     InlinePanel('related_links', label="Related links"),
 ]
+
 
 StandardIndexPage.promote_panels = [
     MultiFieldPanel(Page.promote_panels, "Common page configuration"),
@@ -280,14 +289,18 @@ class BlogEntryPage(Page):
         # Find closest ancestor which is a blog index
         return BlogIndexPage.ancestor_of(self).last()
 
+
 class BlogEntryPageCarouselItem(Orderable, AbstractCarouselItem):
     page = ParentalKey('BlogEntryPage', related_name='carousel_items')
+
 
 class BlogEntryPageRelatedLink(Orderable, AbstractRelatedLink):
     page = ParentalKey('BlogEntryPage', related_name='related_links')
 
+
 class BlogEntryPageTag(TaggedItemBase):
     content_object = ParentalKey('BlogEntryPage', related_name='tagged_items')
+
 
 BlogEntryPage.content_panels = Page.content_panels + [
     FieldPanel('date'),
@@ -295,6 +308,7 @@ BlogEntryPage.content_panels = Page.content_panels + [
     InlinePanel('carousel_items', label="Carousel items"),
     InlinePanel('related_links', label="Related links"),
 ]
+
 
 BlogEntryPage.promote_panels = [
     MultiFieldPanel(Page.promote_panels, "Common page configuration"),
@@ -341,8 +355,10 @@ class BlogIndexPage(Page):
         context['entries'] = entries
         return context
 
+
 class BlogIndexPageRelatedLink(Orderable, AbstractRelatedLink):
     page = ParentalKey('BlogIndexPage', related_name='related_links')
+
 
 BlogIndexPage.content_panels = Page.content_panels + [
     FieldPanel('intro', classname="full"),
@@ -407,11 +423,14 @@ class EventPage(Page):
         # Find closest ancestor which is an event index
         return EventIndexPage.objects.ancester_of(self).last()
 
+
 class EventPageCarouselItem(Orderable, AbstractCarouselItem):
     page = ParentalKey('EventPage', related_name='carousel_items')
 
+
 class EventPageRelatedLink(Orderable, AbstractRelatedLink):
     page = ParentalKey('EventPage', related_name='related_links')
+
 
 class EventPageSpeaker(Orderable, AbstractLinkFields):
     page = ParentalKey('EventPage', related_name='speakers')
@@ -453,6 +472,7 @@ EventPage.content_panels = Page.content_panels + [
     InlinePanel('related_links', label="Related links"),
 ]
 
+
 EventPage.promote_panels = [
     MultiFieldPanel(Page.promote_panels, "Common page configuration"),
     ImageChooserPanel('feed_image'),
@@ -485,8 +505,10 @@ class EventIndexPage(Page):
 
         return events
 
+
 class EventIndexPageRelatedLink(Orderable, AbstractRelatedLink):
     page = ParentalKey('EventIndexPage', related_name='related_links')
+
 
 EventIndexPage.content_panels = Page.content_panels + [
     FieldPanel('intro', classname="full"),
@@ -534,8 +556,10 @@ class PersonPage(Page, ContactFieldsMixin):
         index.SearchField('biography'),
     )
 
+
 class PersonPageRelatedLink(Orderable, AbstractRelatedLink):
     page = ParentalKey('PersonPage', related_name='related_links')
+
 
 PersonPage.content_panels = Page.content_panels + [
     FieldPanel('first_name'),
@@ -546,6 +570,7 @@ PersonPage.content_panels = Page.content_panels + [
     MultiFieldPanel(ContactFieldsMixin.panels, "Contact"),
     InlinePanel('related_links', label="Related links"),
 ]
+
 
 PersonPage.promote_panels = [
     MultiFieldPanel(Page.promote_panels, "Common page configuration"),
@@ -575,10 +600,12 @@ class ContactPage(Page, ContactFieldsMixin):
         index.SearchField('body'),
     )
 
+
 ContactPage.content_panels = Page.content_panels + [
     FieldPanel('body', classname="full"),
     MultiFieldPanel(ContactFieldsMixin.panels, "Contact"),
 ]
+
 
 ContactPage.promote_panels = [
     MultiFieldPanel(Page.promote_panels, "Common page configuration"),

--- a/wagtail/tests/snippets/models.py
+++ b/wagtail/tests/snippets/models.py
@@ -35,6 +35,7 @@ class RegisterFunction(models.Model):
     pass
 register_snippet(RegisterFunction)
 
+
 @register_snippet
 class RegisterDecorator(models.Model):
     pass

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -420,12 +420,14 @@ TaggedPage.content_panels = [
     FieldPanel('tags'),
 ]
 
+
 class SingletonPage(Page):
     @classmethod
     def can_create_at(cls, parent):
         # You can only create one of these!
         return super(SingletonPage, cls).can_create_at(parent) \
             and not cls.objects.exists()
+
 
 class PageChooserModel(models.Model):
     page = models.ForeignKey('wagtailcore.Page', help_text='help text')

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -35,6 +35,7 @@ class KittensMenuItem(MenuItem):
     def is_shown(self, request):
         return not request.GET.get('hide-kittens', False)
 
+
 @hooks.register('register_admin_menu_item')
 def register_kittens_menu_item():
     return KittensMenuItem('Kittens!', 'http://www.tomroyal.com/teaandkittens/', classnames='icon icon-kitten', attrs={'data-fluffy': 'yes'}, order=10000)

--- a/wagtail/utils/pagination.py
+++ b/wagtail/utils/pagination.py
@@ -3,6 +3,7 @@ from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 
 DEFAULT_PAGE_KEY = 'p'
 
+
 def paginate(request, items, page_key=DEFAULT_PAGE_KEY, per_page=20):
     page = request.GET.get(page_key, 1)
 

--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -8,6 +8,7 @@ from django.utils.translation import ungettext, ugettext_lazy
 from wagtail.wagtailadmin.widgets import AdminPageChooser
 from wagtail.wagtailcore.models import Page
 
+
 class URLOrAbsolutePathValidator(validators.URLValidator):
     @staticmethod
     def is_absolute_path(value):
@@ -18,6 +19,7 @@ class URLOrAbsolutePathValidator(validators.URLValidator):
             return None
         else:
             return super(URLOrAbsolutePathValidator, self).__call__(value)
+
 
 class URLOrAbsolutePathField(forms.URLField):
     widget = TextInput

--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -74,7 +74,6 @@ class LoginForm(AuthenticationForm):
         self.fields['username'].widget.attrs['placeholder'] = ugettext_lazy("Enter your %s") % self.username_field.verbose_name
 
 
-
 class PasswordResetForm(PasswordResetForm):
     email = forms.EmailField(label=ugettext_lazy("Enter your email address to reset your password"), max_length=254)
 

--- a/wagtail/wagtailadmin/site_summary.py
+++ b/wagtail/wagtailadmin/site_summary.py
@@ -25,6 +25,7 @@ class PagesSummaryItem(SummaryItem):
             'total_pages': Page.objects.count() - 1,  # subtract 1 because the root node is not a real page
         }
 
+
 @hooks.register('construct_homepage_summary_items')
 def add_pages_summary_item(request, items):
     items.append(PagesSummaryItem(request))

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -18,6 +18,7 @@ register = template.Library()
 
 register.filter('intcomma', intcomma)
 
+
 @register.inclusion_tag('wagtailadmin/shared/explorer_nav.html')
 def explorer_nav():
     return {
@@ -40,6 +41,7 @@ def main_nav(context):
         'menu_html': admin_menu.render_html(request),
         'request': request,
     }
+
 
 @register.simple_tag
 def main_nav_js():
@@ -170,6 +172,7 @@ def render_with_errors(bound_field):
         return widget.render_with_errors(bound_field.html_name, bound_field.value(), attrs={'id': bound_field.auto_id}, errors=bound_field.errors)
     else:
         return bound_field.as_widget()
+
 
 @register.filter
 def has_unrendered_errors(bound_field):

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -57,7 +57,6 @@ class TestGetFormForModel(TestCase):
         event_form = EventPageForm()
         self.assertEqual(type(event_form.fields['body'].widget), RichTextArea)
 
-
     def test_get_form_for_model_with_specific_fields(self):
         EventPageForm = get_form_for_model(EventPage, fields=['date_from'], formsets=['speakers'])
         form = EventPageForm()

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -261,7 +261,7 @@ class TestFieldPanel(TestCase):
     def setUp(self):
         self.EventPageForm = get_form_for_model(EventPage, formsets=[])
         self.event = EventPage(title='Abergavenny sheepdog trials',
-            date_from=date(2014, 7, 20), date_to=date(2014, 7, 21))
+                               date_from=date(2014, 7, 20), date_to=date(2014, 7, 21))
 
         self.EndDatePanel = FieldPanel('date_to', classname='full-width').bind_to_model(EventPage)
 

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -915,7 +915,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         # Check that the moderator got an email
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, ['moderator@email.com'])
-        self.assertEqual(mail.outbox[0].subject, 'The page "Hello world!" has been submitted for moderation') # Note: should this be "I've been edited!"?
+        self.assertEqual(mail.outbox[0].subject, 'The page "Hello world!" has been submitted for moderation')  # Note: should this be "I've been edited!"?
 
     def test_page_edit_post_existing_slug(self):
         # This tests the existing slug checking on page edit
@@ -1073,7 +1073,7 @@ class TestPageEditReordering(TestCase, WagtailTestUtils):
 
     def test_reorder_with_validation_error(self):
         post_data = {
-            'title': "", # Validation error
+            'title': "",  # Validation error
             'slug': 'event-page',
 
             'date_from': '01/01/2014',

--- a/wagtail/wagtailadmin/urls/__init__.py
+++ b/wagtail/wagtailadmin/urls/__init__.py
@@ -46,7 +46,8 @@ for fn in hooks.get_hooks('register_admin_urls'):
 
 
 # Add "wagtailadmin.access_admin" permission check
-urlpatterns = decorate_urlpatterns(urlpatterns,
+urlpatterns = decorate_urlpatterns(
+    urlpatterns,
     permission_required(
         'wagtailadmin.access_admin',
         login_url='wagtailadmin_login'
@@ -68,6 +69,7 @@ urlpatterns += [
 ]
 
 # Decorate all views with cache settings to prevent caching
-urlpatterns = decorate_urlpatterns(urlpatterns,
+urlpatterns = decorate_urlpatterns(
+    urlpatterns,
     cache_control(private=True, no_cache=True, no_store=True, max_age=0)
 )

--- a/wagtail/wagtailadmin/views/account.py
+++ b/wagtail/wagtailadmin/views/account.py
@@ -109,7 +109,8 @@ def login(request):
         return redirect('wagtailadmin_home')
     else:
         from django.contrib.auth import get_user_model
-        return auth_views.login(request,
+        return auth_views.login(
+            request,
             template_name='wagtailadmin/login.html',
             authentication_form=forms.LoginForm,
             extra_context={
@@ -126,8 +127,8 @@ def logout(request):
     # absence of sessionid as an indication that front-end pages are being viewed by a
     # non-logged-in user and are therefore cacheable, so we forcibly delete the cookie here.
     response.delete_cookie(settings.SESSION_COOKIE_NAME,
-        domain=settings.SESSION_COOKIE_DOMAIN,
-        path=settings.SESSION_COOKIE_PATH)
+                           domain=settings.SESSION_COOKIE_DOMAIN,
+                           path=settings.SESSION_COOKIE_PATH)
 
     # HACK: pretend that the session hasn't been modified, so that SessionMiddleware
     # won't override the above and write a new cookie.

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -201,7 +201,7 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
         'parent_page': parent_page,
         'edit_handler': edit_handler,
         'preview_modes': page.preview_modes,
-        'form': form, # Used in unit tests
+        'form': form,  # Used in unit tests
     })
 
 
@@ -295,7 +295,7 @@ def edit(request, page_id):
         'edit_handler': edit_handler,
         'errors_debug': errors_debug,
         'preview_modes': page.preview_modes,
-        'form': form, # Used in unit tests
+        'form': form,  # Used in unit tests
     })
 
 

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -470,6 +470,7 @@ def preview(request):
     """
     return render(request, 'wagtailadmin/pages/preview.html')
 
+
 def preview_loading(request):
     """
     This page is blank, but must be real HTML so its DOM can be written to once the preview of the page has rendered

--- a/wagtail/wagtailadmin/widgets.py
+++ b/wagtail/wagtailadmin/widgets.py
@@ -27,6 +27,7 @@ class AdminAutoHeightTextInput(WidgetWithScript, widgets.Textarea):
     def render_js_init(self, id_, name, value):
         return 'autosize($("#{0}"));'.format(id_)
 
+
 class AdminDateInput(WidgetWithScript, widgets.DateInput):
     # Set a default date format to match the one that our JS date picker expects -
     # it can still be overridden explicitly, but this way it won't be affected by

--- a/wagtail/wagtailcore/blocks/list_block.py
+++ b/wagtail/wagtailcore/blocks/list_block.py
@@ -81,7 +81,7 @@ class ListBlock(Block):
 
         list_members_html = [
             self.render_list_member(child_val, "%s-%d" % (prefix, i), i,
-                errors=error_list[i] if error_list else None)
+                                    errors=error_list[i] if error_list else None)
             for (i, child_val) in enumerate(value)
         ]
 
@@ -140,7 +140,8 @@ class ListBlock(Block):
         ]
 
     def render_basic(self, value):
-        children = format_html_join('\n', '<li>{0}</li>',
+        children = format_html_join(
+            '\n', '<li>{0}</li>',
             [(self.child_block.render(child_value),) for child_value in value]
         )
         return format_html("<ul>{0}</ul>", children)

--- a/wagtail/wagtailcore/blocks/stream_block.py
+++ b/wagtail/wagtailcore/blocks/stream_block.py
@@ -120,7 +120,7 @@ class BaseStreamBlock(Block):
 
         list_members_html = [
             self.render_list_member(child.block_type, child.value, "%s-%d" % (prefix, i), i,
-                errors=error_list[i] if error_list else None)
+                                    errors=error_list[i] if error_list else None)
             for (i, child) in enumerate(valid_children)
         ]
 
@@ -197,7 +197,8 @@ class BaseStreamBlock(Block):
         ]
 
     def render_basic(self, value):
-        return format_html_join('\n', '<div class="block-{1}">{0}</div>',
+        return format_html_join(
+            '\n', '<div class="block-{1}">{0}</div>',
             [(force_text(child), child.block_type) for child in value]
         )
 

--- a/wagtail/wagtailcore/blocks/struct_block.py
+++ b/wagtail/wagtailcore/blocks/struct_block.py
@@ -78,7 +78,7 @@ class BaseStructBlock(Block):
             (
                 name,
                 block.bind(value.get(name, block.get_default()),
-                    prefix="%s-%s" % (prefix, name), errors=error_dict.get(name))
+                           prefix="%s-%s" % (prefix, name), errors=error_dict.get(name))
             )
             for name, block in self.child_blocks.items()
         ])

--- a/wagtail/wagtailcore/blocks/utils.py
+++ b/wagtail/wagtailcore/blocks/utils.py
@@ -2,9 +2,11 @@ import re
 
 # helpers for Javascript expression formatting
 
+
 def indent(string, depth=1):
     """indent all non-empty lines of string by 'depth' 4-character tabs"""
     return re.sub(r'(^|\n)([^\n]+)', '\g<1>' + ('    ' * depth) + '\g<2>', string)
+
 
 def js_dict(d):
     """

--- a/wagtail/wagtailcore/forms.py
+++ b/wagtail/wagtailcore/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 
+
 class PasswordPageViewRestrictionForm(forms.Form):
     password = forms.CharField(label="Password", widget=forms.PasswordInput)
     return_url = forms.CharField(widget=forms.HiddenInput)

--- a/wagtail/wagtailcore/management/commands/fixtree.py
+++ b/wagtail/wagtailcore/management/commands/fixtree.py
@@ -13,7 +13,8 @@ from wagtail.wagtailcore.models import Page
 class Command(BaseCommand):
     help = "Checks for data integrity errors on the page tree, and fixes them where possible."
     base_options = (
-        make_option('--noinput', action='store_false', dest='interactive', default=True,
+        make_option(
+            '--noinput', action='store_false', dest='interactive', default=True,
             help='If provided, any fixes requiring user interaction will be skipped.'
         ),
     )

--- a/wagtail/wagtailcore/migrations/0001_squashed_0016_change_page_url_path_to_text_field.py
+++ b/wagtail/wagtailcore/migrations/0001_squashed_0016_change_page_url_path_to_text_field.py
@@ -83,7 +83,6 @@ def initial_data(apps, schema_editor):
         permission_type='edit',
     )
 
-
     # 0005 - add_page_lock_permission_to_moderators
     GroupPagePermission.objects.create(
         group=moderators_group,

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -364,7 +364,6 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
 
         field_exceptions += ['content_type']
 
-
         for field in cls._meta.fields:
             if isinstance(field, models.ForeignKey) and field.name not in field_exceptions:
                 if field.rel.on_delete == models.CASCADE:

--- a/wagtail/wagtailcore/rich_text.py
+++ b/wagtail/wagtailcore/rich_text.py
@@ -17,6 +17,7 @@ from wagtail.wagtailcore import hooks
 # elsewhere in the database and is liable to change - from real HTML representation
 # to DB representation and back again.
 
+
 class PageLinkHandler(object):
     """
     PageLinkHandler will be invoked whenever we encounter an <a> element in HTML content
@@ -56,6 +57,7 @@ LINK_HANDLERS = {
 has_loaded_embed_handlers = False
 has_loaded_link_handlers = False
 
+
 def get_embed_handler(embed_type):
     global EMBED_HANDLERS, has_loaded_embed_handlers
 
@@ -67,6 +69,7 @@ def get_embed_handler(embed_type):
         has_loaded_embed_handlers = True
 
     return EMBED_HANDLERS[embed_type]
+
 
 def get_link_handler(link_type):
     global LINK_HANDLERS, has_loaded_link_handlers

--- a/wagtail/wagtailcore/tests/test_page_permissions.py
+++ b/wagtail/wagtailcore/tests/test_page_permissions.py
@@ -67,7 +67,6 @@ class TestPagePermission(TestCase):
         self.assertTrue(board_meetings_perms.can_move())
         self.assertFalse(board_meetings_perms.can_move_to(christmas_page))  # cannot move because the parent_page_types rule of BusinessSubIndex forbids EventPage as a parent
 
-
     def test_publisher_page_permissions(self):
         event_moderator = get_user_model().objects.get(username='eventmoderator')
         homepage = Page.objects.get(url_path='/home/')

--- a/wagtail/wagtailcore/tests/test_page_privacy.py
+++ b/wagtail/wagtailcore/tests/test_page_privacy.py
@@ -37,7 +37,6 @@ class TestPagePrivacy(TestCase):
         response = self.client.get('/secret-plans/')
         self.assertEqual(response.templates[0].name, 'tests/simple_page.html')
 
-
     def test_view_restrictions_apply_to_subpages(self):
         underpants_page = Page.objects.get(url_path='/home/secret-plans/steal-underpants/')
         response = self.client.get('/secret-plans/steal-underpants/')

--- a/wagtail/wagtailcore/wagtail_hooks.py
+++ b/wagtail/wagtailcore/wagtail_hooks.py
@@ -2,6 +2,7 @@ from django.core.urlresolvers import reverse
 
 from wagtail.wagtailcore import hooks
 
+
 @hooks.register('before_serve_page')
 def check_view_restrictions(page, request, serve_args, serve_kwargs):
     """

--- a/wagtail/wagtailcore/wagtail_hooks.py
+++ b/wagtail/wagtailcore/wagtail_hooks.py
@@ -20,6 +20,6 @@ def check_view_restrictions(page, request, serve_args, serve_kwargs):
             if restriction.id not in passed_restrictions:
                 from wagtail.wagtailcore.forms import PasswordPageViewRestrictionForm
                 form = PasswordPageViewRestrictionForm(instance=restriction,
-                    initial={'return_url': request.get_full_path()})
+                                                       initial={'return_url': request.get_full_path()})
                 action_url = reverse('wagtailcore_authenticate_with_password', args=[restriction.id, page.id])
                 return page.serve_password_required_response(request, form, action_url)

--- a/wagtail/wagtaildocs/blocks.py
+++ b/wagtail/wagtaildocs/blocks.py
@@ -5,6 +5,7 @@ from django.utils.html import format_html
 
 from wagtail.wagtailcore.blocks import ChooserBlock
 
+
 class DocumentChooserBlock(ChooserBlock):
     @cached_property
     def target_model(self):

--- a/wagtail/wagtaildocs/wagtail_hooks.py
+++ b/wagtail/wagtaildocs/wagtail_hooks.py
@@ -37,7 +37,8 @@ def editor_js():
         'wagtaildocs/js/hallo-plugins/hallo-wagtaildoclink.js',
         'wagtaildocs/js/document-chooser.js',
     ]
-    js_includes = format_html_join('\n', '<script src="{0}{1}"></script>',
+    js_includes = format_html_join(
+        '\n', '<script src="{0}{1}"></script>',
         ((settings.STATIC_URL, filename) for filename in js_files)
     )
     return js_includes + format_html(
@@ -54,7 +55,7 @@ def editor_js():
 @hooks.register('register_permissions')
 def register_permissions():
     return Permission.objects.filter(content_type__app_label='wagtaildocs',
-        codename__in=['add_document', 'change_document'])
+                                     codename__in=['add_document', 'change_document'])
 
 
 @hooks.register('register_rich_text_link_handler')

--- a/wagtail/wagtailembeds/embeds.py
+++ b/wagtail/wagtailembeds/embeds.py
@@ -18,11 +18,14 @@ from wagtail.utils.deprecation import RemovedInWagtail14Warning
 class EmbedException(Exception):
     pass
 
+
 class EmbedNotFoundException(EmbedException):
     pass
 
+
 class EmbedlyException(EmbedException):
     pass
+
 
 class AccessDeniedEmbedlyException(EmbedlyException):
     pass

--- a/wagtail/wagtailembeds/forms.py
+++ b/wagtail/wagtailembeds/forms.py
@@ -3,6 +3,7 @@ from django.core.validators import URLValidator
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
+
 def validate_url(url):
     validator = URLValidator()
     try:

--- a/wagtail/wagtailembeds/oembed_providers.py
+++ b/wagtail/wagtailembeds/oembed_providers.py
@@ -303,6 +303,7 @@ OEMBED_ENDPOINTS = {
 # Compile endpoints into regular expression objects
 import re
 
+
 def compile_endpoints():
     endpoints = {}
     for endpoint in OEMBED_ENDPOINTS.keys():

--- a/wagtail/wagtailembeds/wagtail_hooks.py
+++ b/wagtail/wagtailembeds/wagtail_hooks.py
@@ -17,7 +17,8 @@ def register_admin_urls():
 
 @hooks.register('insert_editor_js')
 def editor_js():
-    return format_html("""
+    return format_html(
+        """
             <script src="{0}{1}"></script>
             <script>
                 window.chooserUrls.embedsChooser = '{2}';

--- a/wagtail/wagtailforms/tests.py
+++ b/wagtail/wagtailforms/tests.py
@@ -429,6 +429,7 @@ class TestDeleteFormSubmission(TestCase):
         # Check that the deletion has not happened
         self.assertEqual(FormSubmission.objects.count(), 2)
 
+
 class TestIssue798(TestCase):
     fixtures = ['test.json']
 

--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -14,6 +14,7 @@ from wagtail.wagtailforms.models import FormSubmission, get_forms_for_user
 from wagtail.wagtailforms.forms import SelectDateForm
 from wagtail.wagtailadmin import messages
 
+
 def index(request):
     form_pages = get_forms_for_user(request.user)
 
@@ -22,6 +23,7 @@ def index(request):
     return render(request, 'wagtailforms/index.html', {
         'form_pages': form_pages,
     })
+
 
 def delete_submission(request, page_id, submission_id):
     if not get_forms_for_user(request.user).filter(id=page_id).exists():
@@ -40,6 +42,7 @@ def delete_submission(request, page_id, submission_id):
         'page': page,
         'submission': submission
     })
+
 
 def list_submissions(request, page_id):
     form_page = get_object_or_404(Page, id=page_id).specific

--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -103,9 +103,9 @@ def list_submissions(request, page_id):
         })
 
     return render(request, 'wagtailforms/index_submissions.html', {
-         'form_page': form_page,
-         'select_date_form': select_date_form,
-         'submissions': submissions,
-         'data_headings': data_headings,
-         'data_rows': data_rows
+        'form_page': form_page,
+        'select_date_form': select_date_form,
+        'submissions': submissions,
+        'data_headings': data_headings,
+        'data_rows': data_rows
     })

--- a/wagtail/wagtailimages/blocks.py
+++ b/wagtail/wagtailimages/blocks.py
@@ -2,6 +2,7 @@ from django.utils.functional import cached_property
 
 from wagtail.wagtailcore.blocks import ChooserBlock
 
+
 class ImageChooserBlock(ChooserBlock):
     @cached_property
     def target_model(self):

--- a/wagtail/wagtailimages/fields.py
+++ b/wagtail/wagtailimages/fields.py
@@ -73,7 +73,7 @@ class WagtailImageField(ImageField):
             except IOError:
                 # Uploaded file is not even an image file (or corrupted)
                 raise ValidationError(self.error_messages['invalid_image_known_format'],
-                    code='invalid_image_known_format')
+                                      code='invalid_image_known_format')
 
             f.seek(file_position)
         else:

--- a/wagtail/wagtailimages/forms.py
+++ b/wagtail/wagtailimages/forms.py
@@ -17,7 +17,6 @@ def formfield_for_dbfield(db_field, **kwargs):
     return db_field.formfield(**kwargs)
 
 
-
 def get_image_form(model):
     return modelform_factory(
         model,

--- a/wagtail/wagtailimages/migrations/0004_make_focal_point_key_not_nullable.py
+++ b/wagtail/wagtailimages/migrations/0004_make_focal_point_key_not_nullable.py
@@ -31,6 +31,7 @@ def remove_duplicate_renditions(apps, schema_editor):
             ) AND focal_point_key IS NULL
         """)
 
+
 class Migration(migrations.Migration):
 
     dependencies = [

--- a/wagtail/wagtailimages/tests/test_admin_views.py
+++ b/wagtail/wagtailimages/tests/test_admin_views.py
@@ -527,7 +527,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         """
         # Send request
         response = self.client.post(reverse('wagtailimages:edit_multiple', args=(self.image.id, )), {
-            ('image-%d-title' % self.image.id): "", # Required
+            ('image-%d-title' % self.image.id): "",  # Required
             ('image-%d-tags' % self.image.id): "",
         }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
 

--- a/wagtail/wagtailimages/tests/test_models.py
+++ b/wagtail/wagtailimages/tests/test_models.py
@@ -287,7 +287,7 @@ class TestGetWillowImage(TestCase):
         # should raise a SourceImageIOError
         with self.assertRaises(SourceImageIOError):
             with bad_image.get_willow_image():
-                self.fail() # Shouldn't get here
+                self.fail()  # Shouldn't get here
 
     def test_closes_image(self):
         # This tests that willow closes images after use

--- a/wagtail/wagtailimages/tests/tests.py
+++ b/wagtail/wagtailimages/tests/tests.py
@@ -128,14 +128,16 @@ class TestFormat(TestCase):
             self.image,
             'test alt text'
         )
-        six.assertRegex(self, result,
+        six.assertRegex(
+            self, result,
             '<img data-embedtype="image" data-id="0" data-format="test name" data-alt="test alt text" class="test classnames" src="[^"]+" width="1" height="1" alt="test alt text">',
         )
 
     def test_image_to_html_no_classnames(self):
         self.format.classnames = None
         result = self.format.image_to_html(self.image, 'test alt text')
-        six.assertRegex(self, result,
+        six.assertRegex(
+            self, result,
             '<img src="[^"]+" width="1" height="1" alt="test alt text">'
         )
         self.format.classnames = 'test classnames'

--- a/wagtail/wagtailimages/wagtail_hooks.py
+++ b/wagtail/wagtailimages/wagtail_hooks.py
@@ -37,7 +37,8 @@ def editor_js():
         'wagtailimages/js/hallo-plugins/hallo-wagtailimage.js',
         'wagtailimages/js/image-chooser.js',
     ]
-    js_includes = format_html_join('\n', '<script src="{0}{1}"></script>',
+    js_includes = format_html_join(
+        '\n', '<script src="{0}{1}"></script>',
         ((settings.STATIC_URL, filename) for filename in js_files)
     )
     return js_includes + format_html(
@@ -54,7 +55,7 @@ def editor_js():
 @hooks.register('register_permissions')
 def register_permissions():
     return Permission.objects.filter(content_type__app_label='wagtailimages',
-        codename__in=['add_image', 'change_image'])
+                                     codename__in=['add_image', 'change_image'])
 
 
 @hooks.register('register_image_operations')

--- a/wagtail/wagtailredirects/wagtail_hooks.py
+++ b/wagtail/wagtailredirects/wagtail_hooks.py
@@ -33,4 +33,4 @@ def register_redirects_menu_item():
 @hooks.register('register_permissions')
 def register_permissions():
     return Permission.objects.filter(content_type__app_label='wagtailredirects',
-        codename__in=['add_redirect', 'change_redirect', 'delete_redirect'])
+                                     codename__in=['add_redirect', 'change_redirect', 'delete_redirect'])

--- a/wagtail/wagtailsearch/backends/db.py
+++ b/wagtail/wagtailsearch/backends/db.py
@@ -84,22 +84,22 @@ class DBSearch(BaseSearch):
         super(DBSearch, self).__init__(params)
 
     def reset_index(self):
-        pass # Not needed
+        pass  # Not needed
 
     def add_type(self, model):
-        pass # Not needed
+        pass  # Not needed
 
     def refresh_index(self):
-        pass # Not needed
+        pass  # Not needed
 
     def add(self, obj):
-        pass # Not needed
+        pass  # Not needed
 
     def add_bulk(self, model, obj_list):
-        return # Not needed
+        return  # Not needed
 
     def delete(self, obj):
-        pass # Not needed
+        pass  # Not needed
 
 
 SearchBackend = DBSearch

--- a/wagtail/wagtailsearch/forms.py
+++ b/wagtail/wagtailsearch/forms.py
@@ -4,7 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 
 class QueryForm(forms.Form):
     query_string = forms.CharField(label=_("Search term(s)/phrase"),
-        help_text=_("Enter the full search string to match. An "
-        "exact match is required for your Promoted Results to be "
-        "displayed, wildcards are NOT allowed."),
-        required=True)
+                                   help_text=_("Enter the full search string to match. An "
+                                               "exact match is required for your Promoted Results to be "
+                                               "displayed, wildcards are NOT allowed."),
+                                   required=True)

--- a/wagtail/wagtailsearch/management/commands/update_index.py
+++ b/wagtail/wagtailsearch/management/commands/update_index.py
@@ -58,7 +58,8 @@ class Command(BaseCommand):
         rebuilder.finish()
 
     option_list = BaseCommand.option_list + (
-        make_option('--backend',
+        make_option(
+            '--backend',
             action='store',
             dest='backend_name',
             default=None,

--- a/wagtail/wagtailsearch/queryset.py
+++ b/wagtail/wagtailsearch/queryset.py
@@ -3,10 +3,10 @@ from wagtail.wagtailsearch.backends import get_search_backend
 
 class SearchableQuerySetMixin(object):
     def search(self, query_string, fields=None,
-            operator=None, order_by_relevance=True, backend='default'):
+               operator=None, order_by_relevance=True, backend='default'):
         """
         This runs a search query on all the items in the QuerySet
         """
         search_backend = get_search_backend(backend)
         return search_backend.search(query_string, self, fields=fields,
-            operator=operator, order_by_relevance=order_by_relevance)
+                                     operator=operator, order_by_relevance=order_by_relevance)

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -491,7 +491,7 @@ class TestElasticSearchResults(TestCase):
         search.return_value = self.construct_search_response([])
         results = self.get_results()
 
-        list(results) # Performs search
+        list(results)  # Performs search
 
         search.assert_any_call(
             from_=0,
@@ -507,7 +507,7 @@ class TestElasticSearchResults(TestCase):
         search.return_value = self.construct_search_response([self.objects[0].id])
         results = self.get_results()
 
-        results[10] # Performs search
+        results[10]  # Performs search
 
         search.assert_any_call(
             from_=10,
@@ -523,7 +523,7 @@ class TestElasticSearchResults(TestCase):
         search.return_value = self.construct_search_response([])
         results = self.get_results()[1:4]
 
-        list(results) # Performs search
+        list(results)  # Performs search
 
         search.assert_any_call(
             from_=1,
@@ -539,7 +539,7 @@ class TestElasticSearchResults(TestCase):
         search.return_value = self.construct_search_response([])
         results = self.get_results()[10:][:10]
 
-        list(results) # Performs search
+        list(results)  # Performs search
 
         search.assert_any_call(
             from_=10,
@@ -556,7 +556,7 @@ class TestElasticSearchResults(TestCase):
         search.return_value = self.construct_search_response([self.objects[0].id])
         results = self.get_results()[10:]
 
-        results[10] # Performs search
+        results[10]  # Performs search
 
         search.assert_any_call(
             from_=20,
@@ -589,9 +589,9 @@ class TestElasticSearchResults(TestCase):
         self.assertEqual(len(results), 2)
 
     @mock.patch('elasticsearch.Elasticsearch.search')
-    def test_duplicate_results(self, search): # Duplicates will not be removed
+    def test_duplicate_results(self, search):  # Duplicates will not be removed
         search.return_value = self.construct_search_response([self.objects[0].id, self.objects[0].id])
-        results = list(self.get_results()) # Must cast to list so we only create one query
+        results = list(self.get_results())  # Must cast to list so we only create one query
 
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0], self.objects[0])
@@ -600,7 +600,7 @@ class TestElasticSearchResults(TestCase):
     @mock.patch('elasticsearch.Elasticsearch.search')
     def test_result_order(self, search):
         search.return_value = self.construct_search_response([self.objects[0].id, self.objects[1].id, self.objects[2].id])
-        results = list(self.get_results()) # Must cast to list so we only create one query
+        results = list(self.get_results())  # Must cast to list so we only create one query
 
         self.assertEqual(results[0], self.objects[0])
         self.assertEqual(results[1], self.objects[1])
@@ -609,7 +609,7 @@ class TestElasticSearchResults(TestCase):
     @mock.patch('elasticsearch.Elasticsearch.search')
     def test_result_order_2(self, search):
         search.return_value = self.construct_search_response([self.objects[2].id, self.objects[1].id, self.objects[0].id])
-        results = list(self.get_results()) # Must cast to list so we only create one query
+        results = list(self.get_results())  # Must cast to list so we only create one query
 
         self.assertEqual(results[0], self.objects[2])
         self.assertEqual(results[1], self.objects[1])

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -468,16 +468,16 @@ class TestElasticSearchResults(TestCase):
             '_shards': {'failed': 0, 'successful': 5, 'total': 5},
             'hits': {
                 'hits': [
-                     {
-                         '_id': 'searchtests_searchtest:' + str(result),
-                         '_index': 'wagtail',
-                         '_score': 1,
-                         '_type': 'searchtests_searchtest',
-                         'fields': {
-                             'pk': [str(result)],
-                         }
-                     }
-                     for result in results
+                    {
+                        '_id': 'searchtests_searchtest:' + str(result),
+                        '_index': 'wagtail',
+                        '_score': 1,
+                        '_type': 'searchtests_searchtest',
+                        'fields': {
+                            'pk': [str(result)],
+                        }
+                    }
+                    for result in results
                 ],
                 'max_score': 1,
                 'total': len(results)

--- a/wagtail/wagtailsearch/tests/test_frontend.py
+++ b/wagtail/wagtailsearch/tests/test_frontend.py
@@ -116,7 +116,6 @@ class TestSearchView(TestCase):
         self.assertEqual(search_results.number, 10)
 
 
-
 class TestSuggestionsView(TestCase):
     def get(self, params={}):
         return self.client.get('/search/suggest/', params)

--- a/wagtail/wagtailsearch/tests/test_queries.py
+++ b/wagtail/wagtailsearch/tests/test_queries.py
@@ -8,7 +8,6 @@ from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailsearch.utils import normalise_query_string
 
 
-
 class TestHitCounter(TestCase):
     def test_no_hits(self):
         self.assertEqual(models.Query.get("Hello").hits, 0)

--- a/wagtail/wagtailsearch/views/frontend.py
+++ b/wagtail/wagtailsearch/views/frontend.py
@@ -85,7 +85,8 @@ def search(
             return JsonResponse(search_results_json, safe=False)
         else:
             return JsonResponse([], safe=False)
-    else: # Render a template
+    else:
+        # Render a template
         if request.is_ajax() and template_ajax:
             template = template_ajax
 

--- a/wagtail/wagtailsites/wagtail_hooks.py
+++ b/wagtail/wagtailsites/wagtail_hooks.py
@@ -33,4 +33,4 @@ def register_sites_menu_item():
 @hooks.register('register_permissions')
 def register_permissions():
     return Permission.objects.filter(content_type__app_label='wagtailcore',
-        codename__in=['add_site', 'change_site', 'delete_site'])
+                                     codename__in=['add_site', 'change_site', 'delete_site'])

--- a/wagtail/wagtailsnippets/blocks.py
+++ b/wagtail/wagtailsnippets/blocks.py
@@ -5,6 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 
 from wagtail.wagtailcore.blocks import ChooserBlock
 
+
 class SnippetChooserBlock(ChooserBlock):
     def __init__(self, target_model, **kwargs):
         super(SnippetChooserBlock, self).__init__(**kwargs)

--- a/wagtail/wagtailsnippets/tests.py
+++ b/wagtail/wagtailsnippets/tests.py
@@ -281,7 +281,8 @@ class TestSnippetChooserPanel(TestCase):
 
         snippet_chooser_panel = [
             panel for panel in edit_handler.children
-            if getattr(panel, 'field_name', None) == 'advert'][0]
+            if getattr(panel, 'field_name', None) == 'advert'
+        ][0]
 
         field_html = snippet_chooser_panel.render_as_field()
         self.assertIn("Choose advert", field_html)
@@ -478,7 +479,7 @@ class TestAddOnlyPermissions(TestCase, WagtailTestUtils):
 
     def test_get_index(self):
         response = self.client.get(reverse('wagtailsnippets:list',
-            args=('tests', 'advert')))
+                                   args=('tests', 'advert')))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailsnippets/snippets/type_index.html')
 
@@ -487,13 +488,13 @@ class TestAddOnlyPermissions(TestCase, WagtailTestUtils):
 
     def test_get_add(self):
         response = self.client.get(reverse('wagtailsnippets:add',
-            args=('tests', 'advert')))
+                                   args=('tests', 'advert')))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailsnippets/snippets/create.html')
 
     def test_get_edit(self):
         response = self.client.get(reverse('wagtailsnippets:edit',
-            args=('tests', 'advert', self.test_snippet.id)))
+                                   args=('tests', 'advert', self.test_snippet.id)))
         # permission should be denied
         self.assertRedirects(response, reverse('wagtailadmin_home'))
 
@@ -518,7 +519,7 @@ class TestEditOnlyPermissions(TestCase, WagtailTestUtils):
 
     def test_get_index(self):
         response = self.client.get(reverse('wagtailsnippets:list',
-            args=('tests', 'advert')))
+                                   args=('tests', 'advert')))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailsnippets/snippets/type_index.html')
 
@@ -527,13 +528,13 @@ class TestEditOnlyPermissions(TestCase, WagtailTestUtils):
 
     def test_get_add(self):
         response = self.client.get(reverse('wagtailsnippets:add',
-            args=('tests', 'advert')))
+                                   args=('tests', 'advert')))
         # permission should be denied
         self.assertRedirects(response, reverse('wagtailadmin_home'))
 
     def test_get_edit(self):
         response = self.client.get(reverse('wagtailsnippets:edit',
-            args=('tests', 'advert', self.test_snippet.id)))
+                                   args=('tests', 'advert', self.test_snippet.id)))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailsnippets/snippets/edit.html')
 
@@ -558,7 +559,7 @@ class TestDeleteOnlyPermissions(TestCase, WagtailTestUtils):
 
     def test_get_index(self):
         response = self.client.get(reverse('wagtailsnippets:list',
-            args=('tests', 'advert')))
+                                   args=('tests', 'advert')))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailsnippets/snippets/type_index.html')
 
@@ -567,13 +568,13 @@ class TestDeleteOnlyPermissions(TestCase, WagtailTestUtils):
 
     def test_get_add(self):
         response = self.client.get(reverse('wagtailsnippets:add',
-            args=('tests', 'advert')))
+                                   args=('tests', 'advert')))
         # permission should be denied
         self.assertRedirects(response, reverse('wagtailadmin_home'))
 
     def test_get_edit(self):
         response = self.client.get(reverse('wagtailsnippets:edit',
-            args=('tests', 'advert', self.test_snippet.id)))
+                                   args=('tests', 'advert', self.test_snippet.id)))
         # permission should be denied
         self.assertRedirects(response, reverse('wagtailadmin_home'))
 

--- a/wagtail/wagtailsnippets/tests.py
+++ b/wagtail/wagtailsnippets/tests.py
@@ -122,8 +122,8 @@ class TestSnippetCreateView(TestCase, WagtailTestUtils):
 
     def post(self, post_data={}):
         return self.client.post(reverse('wagtailsnippets:add',
-                               args=('tests', 'advert')),
-                               post_data)
+                                args=('tests', 'advert')),
+                                post_data)
 
     def test_simple(self):
         response = self.get()

--- a/wagtail/wagtailsnippets/wagtail_hooks.py
+++ b/wagtail/wagtailsnippets/wagtail_hooks.py
@@ -24,6 +24,7 @@ class SnippetsMenuItem(MenuItem):
     def is_shown(self, request):
         return user_can_edit_snippets(request.user)
 
+
 @hooks.register('register_admin_menu_item')
 def register_snippets_menu_item():
     return SnippetsMenuItem(_('Snippets'), urlresolvers.reverse('wagtailsnippets:index'), classnames='icon icon-snippet', order=500)

--- a/wagtail/wagtailsnippets/wagtail_hooks.py
+++ b/wagtail/wagtailsnippets/wagtail_hooks.py
@@ -32,7 +32,8 @@ def register_snippets_menu_item():
 
 @hooks.register('insert_editor_js')
 def editor_js():
-    return format_html("""
+    return format_html(
+        """
             <script src="{0}{1}"></script>
             <script>window.chooserUrls.snippetChooser = '{2}';</script>
         """,

--- a/wagtail/wagtailusers/forms.py
+++ b/wagtail/wagtailusers/forms.py
@@ -235,7 +235,7 @@ class GroupForm(forms.ModelForm):
 
 class GroupPagePermissionForm(forms.ModelForm):
     page = forms.ModelChoiceField(queryset=Page.objects.all(),
-        widget=AdminPageChooser(show_edit_link=False, can_choose_root=True))
+                                  widget=AdminPageChooser(show_edit_link=False, can_choose_root=True))
 
     class Meta:
         model = GroupPagePermission


### PR DESCRIPTION
Cleans up the following errors:
 - ``E261`` - at least two spaces before inline comment
 - ``E302`` -  expected 2 blank lines
 - (some) ``E303`` - too many blank lines
 - ``E124`` - closing bracket does not match visual indentation
 - ``E126`` - continuation line over-indented for hanging indent
 - ``E128`` - continuation line under-indented for visual indent

Limiting the line length to 120 chars (``E501``) is quite a big one so that's been left out of this PR