### PR TITLE
[WIP] Rename search "backends" to "indices"

### DIFF
--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -186,7 +186,7 @@ class BaseSearchResults(object):
         return repr(data)
 
 
-class BaseSearch(object):
+class BaseSearchIndex(object):
     query_class = None
     results_class = None
 
@@ -252,3 +252,7 @@ class BaseSearch(object):
             queryset, query_string, fields=fields, operator=operator, order_by_relevance=order_by_relevance
         )
         return self.results_class(self, search_query)
+
+
+# Backwards compatibility
+BaseSearch = BaseSearchIndex  # noqa

--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -187,8 +187,8 @@ class BaseSearchResults(object):
 
 
 class BaseSearch(object):
-    search_query_class = None
-    search_results_class = None
+    query_class = None
+    results_class = None
 
     def __init__(self, params):
         pass
@@ -248,7 +248,7 @@ class BaseSearch(object):
                 raise ValueError("operator must be either 'or' or 'and'")
 
         # Search
-        search_query = self.search_query_class(
+        search_query = self.query_class(
             queryset, query_string, fields=fields, operator=operator, order_by_relevance=order_by_relevance
         )
-        return self.search_results_class(self, search_query)
+        return self.results_class(self, search_query)

--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -103,8 +103,8 @@ class BaseSearchQuery(object):
 
 
 class BaseSearchResults(object):
-    def __init__(self, backend, query, prefetch_related=None):
-        self.backend = backend
+    def __init__(self, index, query, prefetch_related=None):
+        self.index = index
         self.query = query
         self.prefetch_related = prefetch_related
         self.start = 0
@@ -127,7 +127,7 @@ class BaseSearchResults(object):
 
     def _clone(self):
         klass = self.__class__
-        new = klass(self.backend, self.query, prefetch_related=self.prefetch_related)
+        new = klass(self.index, self.query, prefetch_related=self.prefetch_related)
         new.start = self.start
         new.stop = self.stop
         return new

--- a/wagtail/wagtailsearch/backends/db.py
+++ b/wagtail/wagtailsearch/backends/db.py
@@ -77,8 +77,8 @@ class DBSearchResults(BaseSearchResults):
 
 
 class DBSearch(BaseSearch):
-    search_query_class = DBSearchQuery
-    search_results_class = DBSearchResults
+    query_class = DBSearchQuery
+    results_class = DBSearchResults
 
     def __init__(self, params):
         super(DBSearch, self).__init__(params)

--- a/wagtail/wagtailsearch/backends/db.py
+++ b/wagtail/wagtailsearch/backends/db.py
@@ -1,6 +1,6 @@
 from django.db import models
 
-from wagtail.wagtailsearch.backends.base import BaseSearch, BaseSearchQuery, BaseSearchResults
+from wagtail.wagtailsearch.backends.base import BaseSearchIndex, BaseSearchQuery, BaseSearchResults
 
 
 class DBSearchQuery(BaseSearchQuery):
@@ -76,12 +76,12 @@ class DBSearchResults(BaseSearchResults):
         return self.get_queryset().count()
 
 
-class DBSearch(BaseSearch):
+class DBSearchIndex(BaseSearchIndex):
     query_class = DBSearchQuery
     results_class = DBSearchResults
 
     def __init__(self, params):
-        super(DBSearch, self).__init__(params)
+        super(DBSearchIndex, self).__init__(params)
 
     def reset_index(self):
         pass  # Not needed
@@ -102,4 +102,7 @@ class DBSearch(BaseSearch):
         pass  # Not needed
 
 
-SearchBackend = DBSearch
+SearchBackend = DBSearchIndex
+
+# Backwards compatibility
+DBSearch = DBSearchIndex  # noqa

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -12,7 +12,7 @@ from elasticsearch.helpers import bulk
 from django.db import models
 from django.utils.crypto import get_random_string
 
-from wagtail.wagtailsearch.backends.base import BaseSearch, BaseSearchQuery, BaseSearchResults
+from wagtail.wagtailsearch.backends.base import BaseSearchIndex, BaseSearchQuery, BaseSearchResults
 from wagtail.wagtailsearch.index import SearchField, FilterField, RelatedFields, class_is_indexed
 from wagtail.utils.deprecation import RemovedInWagtail14Warning
 
@@ -558,7 +558,7 @@ class ElasticSearchAtomicIndexRebuilder(ElasticSearchIndexRebuilder):
                     pass
 
 
-class ElasticSearch(BaseSearch):
+class ElasticSearchIndex(BaseSearchIndex):
     query_class = ElasticSearchQuery
     results_class = ElasticSearchResults
     mapping_class = ElasticSearchMapping
@@ -610,7 +610,7 @@ class ElasticSearch(BaseSearch):
     }
 
     def __init__(self, params):
-        super(ElasticSearch, self).__init__(params)
+        super(ElasticSearchIndex, self).__init__(params)
 
         # Get settings
         self.hosts = params.pop('HOSTS', None)
@@ -726,4 +726,7 @@ class ElasticSearch(BaseSearch):
             pass  # Document doesn't exist, ignore this exception
 
 
-SearchBackend = ElasticSearch
+SearchBackend = ElasticSearchIndex
+
+# Backwards compatibility
+ElasticSearch = ElasticSearchIndex  # noqa

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -600,8 +600,8 @@ class ElasticSearchAtomicIndexRebuilder(ElasticSearchIndexRebuilder):
 
 
 class ElasticSearch(BaseSearch):
-    search_query_class = ElasticSearchQuery
-    search_results_class = ElasticSearchResults
+    query_class = ElasticSearchQuery
+    results_class = ElasticSearchResults
 
     def __init__(self, params):
         super(ElasticSearch, self).__init__(params)

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -63,7 +63,7 @@ INDEX_SETTINGS = {
 
 
 class ElasticSearchMapping(object):
-    TYPE_MAP = {
+    type_map = {
         'AutoField': 'integer',
         'BinaryField': 'binary',
         'BooleanField': 'boolean',
@@ -105,7 +105,7 @@ class ElasticSearchMapping(object):
 
             return field.get_index_name(self.model), mapping
         else:
-            mapping = {'type': self.TYPE_MAP.get(field.get_type(self.model), 'string')}
+            mapping = {'type': self.type_map.get(field.get_type(self.model), 'string')}
 
             if isinstance(field, SearchField):
                 if field.boost:

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -397,7 +397,7 @@ class ElasticSearchResults(BaseSearchResults):
     def _do_search(self):
         # Params for elasticsearch query
         params = dict(
-            index=self.backend.name,
+            index=self.index.name,
             body=self._get_es_body(),
             _source=False,
             fields='pk',
@@ -409,7 +409,7 @@ class ElasticSearchResults(BaseSearchResults):
             params['size'] = self.stop - self.start
 
         # Send to Elasticsearch
-        hits = self.backend.es.search(**params)
+        hits = self.index.es.search(**params)
 
         # Get pks from results
         pks = [hit['fields']['pk'][0] for hit in hits['hits']['hits']]
@@ -427,8 +427,8 @@ class ElasticSearchResults(BaseSearchResults):
 
     def _do_count(self):
         # Get count
-        hit_count = self.backend.es.count(
-            index=self.backend.name,
+        hit_count = self.index.es.count(
+            index=self.index.name,
             body=self._get_es_body(for_count=True),
         )['count']
 

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -605,6 +605,8 @@ class ElasticSearch(BaseSearch):
     query_class = ElasticSearchQuery
     results_class = ElasticSearchResults
     mapping_class = ElasticSearchMapping
+    basic_rebuilder_class = ElasticSearchIndexRebuilder
+    atomic_rebuilder_class = ElasticSearchAtomicIndexRebuilder
 
     def __init__(self, params):
         super(ElasticSearch, self).__init__(params)
@@ -615,9 +617,9 @@ class ElasticSearch(BaseSearch):
         self.es_timeout = params.pop('TIMEOUT', 10)
 
         if params.pop('ATOMIC_REBUILD', False):
-            self.rebuilder_class = ElasticSearchAtomicIndexRebuilder
+            self.rebuilder_class = self.atomic_rebuilder_class
         else:
-            self.rebuilder_class = ElasticSearchIndexRebuilder
+            self.rebuilder_class = self.basic_rebuilder_class
 
         # If HOSTS is not set, convert URLS setting to HOSTS
         es_urls = params.pop('URLS', ['http://localhost:9200'])

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -489,6 +489,7 @@ class ElasticSearchIndexRebuilder(object):
     def __init__(self, index):
         self.es = index.es
         self.index_name = index.es_index
+        self.mapping_class = index.mapping_class
 
     def reset_index(self):
         # Delete old index
@@ -506,7 +507,7 @@ class ElasticSearchIndexRebuilder(object):
 
     def add_model(self, model):
         # Get mapping
-        mapping = ElasticSearchMapping(model)
+        mapping = self.mapping_class(model)
 
         # Put mapping
         self.es.indices.put_mapping(
@@ -518,7 +519,7 @@ class ElasticSearchIndexRebuilder(object):
             return
 
         # Get mapping
-        mapping = ElasticSearchMapping(model)
+        mapping = self.mapping_class(model)
         doc_type = mapping.get_document_type()
 
         # Create list of actions
@@ -546,6 +547,7 @@ class ElasticSearchAtomicIndexRebuilder(ElasticSearchIndexRebuilder):
         self.es = index.es
         self.alias_name = index.es_index
         self.index_name = self.alias_name + '_' + get_random_string(7).lower()
+        self.mapping_class = index.mapping_class
 
     def reset_index(self):
         # Delete old index using the alias
@@ -602,6 +604,7 @@ class ElasticSearchAtomicIndexRebuilder(ElasticSearchIndexRebuilder):
 class ElasticSearch(BaseSearch):
     query_class = ElasticSearchQuery
     results_class = ElasticSearchResults
+    mapping_class = ElasticSearchMapping
 
     def __init__(self, params):
         super(ElasticSearch, self).__init__(params)
@@ -655,7 +658,7 @@ class ElasticSearch(BaseSearch):
 
     def add_type(self, model):
         # Get mapping
-        mapping = ElasticSearchMapping(model)
+        mapping = self.mapping_class(model)
 
         # Put mapping
         self.es.indices.put_mapping(
@@ -671,7 +674,7 @@ class ElasticSearch(BaseSearch):
             return
 
         # Get mapping
-        mapping = ElasticSearchMapping(obj.__class__)
+        mapping = self.mapping_class(obj.__class__)
 
         # Add document to index
         self.es.index(
@@ -683,7 +686,7 @@ class ElasticSearch(BaseSearch):
             return
 
         # Get mapping
-        mapping = ElasticSearchMapping(model)
+        mapping = self.mapping_class(model)
         doc_type = mapping.get_document_type()
 
         # Create list of actions
@@ -707,7 +710,7 @@ class ElasticSearch(BaseSearch):
             return
 
         # Get mapping
-        mapping = ElasticSearchMapping(obj.__class__)
+        mapping = self.mapping_class(obj.__class__)
 
         # Delete document
         try:

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -486,9 +486,9 @@ class ElasticSearchResults(BaseSearchResults):
 
 
 class ElasticSearchIndexRebuilder(object):
-    def __init__(self, es, index_name):
-        self.es = es
-        self.index_name = index_name
+    def __init__(self, index):
+        self.es = index.es
+        self.index_name = index.es_index
 
     def reset_index(self):
         # Delete old index
@@ -542,10 +542,10 @@ class ElasticSearchIndexRebuilder(object):
 
 
 class ElasticSearchAtomicIndexRebuilder(ElasticSearchIndexRebuilder):
-    def __init__(self, es, alias_name):
-        self.es = es
-        self.alias_name = alias_name
-        self.index_name = alias_name + '_' + get_random_string(7).lower()
+    def __init__(self, index):
+        self.es = index.es
+        self.alias_name = index.es_index
+        self.index_name = self.alias_name + '_' + get_random_string(7).lower()
 
     def reset_index(self):
         # Delete old index using the alias
@@ -647,7 +647,7 @@ class ElasticSearch(BaseSearch):
             **params)
 
     def get_rebuilder(self):
-        return self.rebuilder_class(self.es, self.es_index)
+        return self.rebuilder_class(self)
 
     def reset_index(self):
         # Use the rebuilder to reset the index

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -442,7 +442,7 @@ class ElasticSearchResults(BaseSearchResults):
     def _do_search(self):
         # Params for elasticsearch query
         params = dict(
-            index=self.backend.es_index,
+            index=self.backend.name,
             body=self._get_es_body(),
             _source=False,
             fields='pk',
@@ -473,7 +473,7 @@ class ElasticSearchResults(BaseSearchResults):
     def _do_count(self):
         # Get count
         hit_count = self.backend.es.count(
-            index=self.backend.es_index,
+            index=self.backend.name,
             body=self._get_es_body(for_count=True),
         )['count']
 
@@ -488,7 +488,7 @@ class ElasticSearchResults(BaseSearchResults):
 class ElasticSearchIndexRebuilder(object):
     def __init__(self, index):
         self.es = index.es
-        self.index_name = index.es_index
+        self.index_name = index.name
         self.mapping_class = index.mapping_class
 
     def reset_index(self):
@@ -545,7 +545,7 @@ class ElasticSearchIndexRebuilder(object):
 class ElasticSearchAtomicIndexRebuilder(ElasticSearchIndexRebuilder):
     def __init__(self, index):
         self.es = index.es
-        self.alias_name = index.es_index
+        self.alias_name = index.name
         self.index_name = self.alias_name + '_' + get_random_string(7).lower()
         self.mapping_class = index.mapping_class
 
@@ -612,9 +612,9 @@ class ElasticSearch(BaseSearch):
         super(ElasticSearch, self).__init__(params)
 
         # Get settings
-        self.es_hosts = params.pop('HOSTS', None)
-        self.es_index = params.pop('INDEX', 'wagtail')
-        self.es_timeout = params.pop('TIMEOUT', 10)
+        self.hosts = params.pop('HOSTS', None)
+        self.name = params.pop('INDEX', 'wagtail')
+        self.timeout = params.pop('TIMEOUT', 10)
 
         if params.pop('ATOMIC_REBUILD', False):
             self.rebuilder_class = self.atomic_rebuilder_class
@@ -623,8 +623,8 @@ class ElasticSearch(BaseSearch):
 
         # If HOSTS is not set, convert URLS setting to HOSTS
         es_urls = params.pop('URLS', ['http://localhost:9200'])
-        if self.es_hosts is None:
-            self.es_hosts = []
+        if self.hosts is None:
+            self.hosts = []
 
             for url in es_urls:
                 parsed_url = urlparse(url)
@@ -636,7 +636,7 @@ class ElasticSearch(BaseSearch):
                 if parsed_url.username is not None and parsed_url.password is not None:
                     http_auth = (parsed_url.username, parsed_url.password)
 
-                self.es_hosts.append({
+                self.hosts.append({
                     'host': parsed_url.hostname,
                     'port': port,
                     'url_prefix': parsed_url.path,
@@ -647,8 +647,8 @@ class ElasticSearch(BaseSearch):
         # Get Elasticsearch interface
         # Any remaining params are passed into the Elasticsearch constructor
         self.es = Elasticsearch(
-            hosts=self.es_hosts,
-            timeout=self.es_timeout,
+            hosts=self.hosts,
+            timeout=self.timeout,
             **params)
 
     def get_rebuilder(self):
@@ -664,11 +664,11 @@ class ElasticSearch(BaseSearch):
 
         # Put mapping
         self.es.indices.put_mapping(
-            index=self.es_index, doc_type=mapping.get_document_type(), body=mapping.get_mapping()
+            index=self.name, doc_type=mapping.get_document_type(), body=mapping.get_mapping()
         )
 
     def refresh_index(self):
-        self.es.indices.refresh(self.es_index)
+        self.es.indices.refresh(self.name)
 
     def add(self, obj):
         # Make sure the object can be indexed
@@ -680,7 +680,7 @@ class ElasticSearch(BaseSearch):
 
         # Add document to index
         self.es.index(
-            self.es_index, mapping.get_document_type(), mapping.get_document(obj), id=mapping.get_document_id(obj)
+            self.name, mapping.get_document_type(), mapping.get_document(obj), id=mapping.get_document_id(obj)
         )
 
     def add_bulk(self, model, obj_list):
@@ -696,7 +696,7 @@ class ElasticSearch(BaseSearch):
         for obj in obj_list:
             # Create the action
             action = {
-                '_index': self.es_index,
+                '_index': self.name,
                 '_type': doc_type,
                 '_id': mapping.get_document_id(obj),
             }
@@ -717,7 +717,7 @@ class ElasticSearch(BaseSearch):
         # Delete document
         try:
             self.es.delete(
-                self.es_index,
+                self.name,
                 mapping.get_document_type(),
                 mapping.get_document_id(obj),
             )

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -453,7 +453,7 @@ class ElasticSearchResults(BaseSearchResults):
         if self.stop is not None:
             params['size'] = self.stop - self.start
 
-        # Send to ElasticSearch
+        # Send to Elasticsearch
         hits = self.backend.es.search(**params)
 
         # Get pks from results
@@ -467,7 +467,7 @@ class ElasticSearchResults(BaseSearchResults):
         for obj in queryset:
             results[str(obj.pk)] = obj
 
-        # Return results in order given by ElasticSearch
+        # Return results in order given by Elasticsearch
         return [results[str(pk)] for pk in pks if results[str(pk)]]
 
     def _do_count(self):
@@ -644,8 +644,8 @@ class ElasticSearch(BaseSearch):
                     'http_auth': http_auth,
                 })
 
-        # Get ElasticSearch interface
-        # Any remaining params are passed into the ElasticSearch constructor
+        # Get Elasticsearch interface
+        # Any remaining params are passed into the Elasticsearch constructor
         self.es = Elasticsearch(
             hosts=self.es_hosts,
             timeout=self.es_timeout,

--- a/wagtail/wagtailsearch/management/commands/update_index.py
+++ b/wagtail/wagtailsearch/management/commands/update_index.py
@@ -16,26 +16,26 @@ class Command(BaseCommand):
             for model in get_indexed_models()
         ]
 
-    def update_backend(self, backend_name, object_list):
+    def update_index(self, index_name, object_list):
         # Print info
-        self.stdout.write("Updating backend: " + backend_name)
+        self.stdout.write("Updating index: " + index_name)
 
-        # Get backend
-        backend = get_search_backend(backend_name)
+        # Get index
+        index = get_search_backend(index_name)
 
         # Get rebuilder
-        rebuilder = backend.get_rebuilder()
+        rebuilder = index.get_rebuilder()
 
         if not rebuilder:
-            self.stdout.write(backend_name + ": Backend doesn't support rebuild. Skipping")
+            self.stdout.write(index_name + ": Backend doesn't support rebuild. Skipping")
             return
 
         # Start rebuild
-        self.stdout.write(backend_name + ": Starting rebuild")
+        self.stdout.write(index_name + ": Starting rebuild")
         rebuilder.start()
 
         for model, queryset in object_list:
-            self.stdout.write(backend_name + ": Indexing model '%s.%s'" % (
+            self.stdout.write(index_name + ": Indexing model '%s.%s'" % (
                 model._meta.app_label,
                 model.__name__,
             ))
@@ -54,16 +54,16 @@ class Command(BaseCommand):
             self.print_newline()
 
         # Finish rebuild
-        self.stdout.write(backend_name + ": Finishing rebuild")
+        self.stdout.write(index_name + ": Finishing rebuild")
         rebuilder.finish()
 
     option_list = BaseCommand.option_list + (
         make_option(
             '--backend',
             action='store',
-            dest='backend_name',
+            dest='index_name',
             default=None,
-            help="Specify a backend to update",
+            help="Specify an index to update",
         ),
     )
 
@@ -71,20 +71,20 @@ class Command(BaseCommand):
         # Get object list
         object_list = self.get_object_list()
 
-        # Get list of backends to index
-        if options['backend_name']:
-            # index only the passed backend
-            backend_names = [options['backend_name']]
+        # Get list of indices to update
+        if options['index_name']:
+            # update only the passed index
+            index_names = [options['index_name']]
         elif hasattr(settings, 'WAGTAILSEARCH_BACKENDS'):
-            # index all backends listed in settings
-            backend_names = settings.WAGTAILSEARCH_BACKENDS.keys()
+            # update all indices listed in settings
+            index_names = settings.WAGTAILSEARCH_BACKENDS.keys()
         else:
-            # index the 'default' backend only
-            backend_names = ['default']
+            # update the 'default' index only
+            index_names = ['default']
 
-        # Update backends
-        for backend_name in backend_names:
-            self.update_backend(backend_name, object_list)
+        # Update indices
+        for index_name in index_names:
+            self.update_index(index_name, object_list)
 
     def print_newline(self):
         self.stdout.write('')

--- a/wagtail/wagtailsearch/tests/test_backends.py
+++ b/wagtail/wagtailsearch/tests/test_backends.py
@@ -10,7 +10,7 @@ from django.utils.six import StringIO
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.tests.search import models
 from wagtail.wagtailsearch.backends import get_search_backend, get_search_backends, InvalidSearchBackendError
-from wagtail.wagtailsearch.backends.db import DBSearch
+from wagtail.wagtailsearch.backends.db import DBSearchIndex
 
 
 class BackendTests(WagtailTestUtils):
@@ -159,15 +159,15 @@ class BackendTests(WagtailTestUtils):
 class TestBackendLoader(TestCase):
     def test_import_by_name(self):
         db = get_search_backend(backend='default')
-        self.assertIsInstance(db, DBSearch)
+        self.assertIsInstance(db, DBSearchIndex)
 
     def test_import_by_path(self):
         db = get_search_backend(backend='wagtail.wagtailsearch.backends.db')
-        self.assertIsInstance(db, DBSearch)
+        self.assertIsInstance(db, DBSearchIndex)
 
     def test_import_by_full_path(self):
-        db = get_search_backend(backend='wagtail.wagtailsearch.backends.db.DBSearch')
-        self.assertIsInstance(db, DBSearch)
+        db = get_search_backend(backend='wagtail.wagtailsearch.backends.db.DBSearchIndex')
+        self.assertIsInstance(db, DBSearchIndex)
 
     def test_nonexistent_backend_import(self):
         self.assertRaises(
@@ -181,7 +181,7 @@ class TestBackendLoader(TestCase):
         backends = list(get_search_backends())
 
         self.assertEqual(len(backends), 1)
-        self.assertIsInstance(backends[0], DBSearch)
+        self.assertIsInstance(backends[0], DBSearchIndex)
 
     @override_settings(
         WAGTAILSEARCH_BACKENDS={

--- a/wagtail/wagtailsearch/tests/test_backends.py
+++ b/wagtail/wagtailsearch/tests/test_backends.py
@@ -18,95 +18,95 @@ class BackendTests(WagtailTestUtils):
 
     def setUp(self):
         # Search WAGTAILSEARCH_BACKENDS for an entry that uses the given backend path
-        for backend_name, backend_conf in settings.WAGTAILSEARCH_BACKENDS.items():
-            if backend_conf['BACKEND'] == self.backend_path:
-                self.backend = get_search_backend(backend_name)
-                self.backend_name = backend_name
+        for index_name, index_conf in settings.WAGTAILSEARCH_BACKENDS.items():
+            if index_conf['BACKEND'] == self.backend_path:
+                self.index = get_search_backend(index_name)
+                self.index_name = index_name
                 break
         else:
-            # no conf entry found - skip tests for this backend
+            # no index conf entry found - skip tests for this backend
             raise unittest.SkipTest("No WAGTAILSEARCH_BACKENDS entry for the backend %s" % self.backend_path)
 
         self.load_test_data()
 
     def load_test_data(self):
         # Reset the index
-        self.backend.reset_index()
-        self.backend.add_type(models.SearchTest)
-        self.backend.add_type(models.SearchTestChild)
+        self.index.reset_index()
+        self.index.add_type(models.SearchTest)
+        self.index.add_type(models.SearchTestChild)
 
         # Create a test database
         testa = models.SearchTest()
         testa.title = "Hello World"
         testa.save()
-        self.backend.add(testa)
+        self.index.add(testa)
         self.testa = testa
 
         testb = models.SearchTest()
         testb.title = "Hello"
         testb.live = True
         testb.save()
-        self.backend.add(testb)
+        self.index.add(testb)
         self.testb = testb
 
         testc = models.SearchTestChild()
         testc.title = "Hello"
         testc.live = True
         testc.save()
-        self.backend.add(testc)
+        self.index.add(testc)
         self.testc = testc
 
         testd = models.SearchTestChild()
         testd.title = "World"
         testd.save()
-        self.backend.add(testd)
+        self.index.add(testd)
         self.testd = testd
 
         # Refresh the index
-        self.backend.refresh_index()
+        self.index.refresh_index()
 
     def test_blank_search(self):
-        results = self.backend.search("", models.SearchTest)
+        results = self.index.search("", models.SearchTest)
         self.assertEqual(set(results), set())
 
     def test_search(self):
-        results = self.backend.search("Hello", models.SearchTest)
+        results = self.index.search("Hello", models.SearchTest)
         self.assertEqual(set(results), {self.testa, self.testb, self.testc.searchtest_ptr})
 
-        results = self.backend.search("World", models.SearchTest)
+        results = self.index.search("World", models.SearchTest)
         self.assertEqual(set(results), {self.testa, self.testd.searchtest_ptr})
 
     def test_operator_or(self):
         # All records that match any term should be returned
-        results = self.backend.search("Hello world", models.SearchTest, operator='or')
+        results = self.index.search("Hello world", models.SearchTest, operator='or')
 
         self.assertEqual(set(results), {self.testa, self.testb, self.testc.searchtest_ptr, self.testd.searchtest_ptr})
 
     def test_operator_and(self):
         # Records must match all search terms to be returned
-        results = self.backend.search("Hello world", models.SearchTest, operator='and')
+        results = self.index.search("Hello world", models.SearchTest, operator='and')
 
         self.assertEqual(set(results), {self.testa})
 
     def test_callable_indexed_field(self):
-        results = self.backend.search("Callable", models.SearchTest)
+        results = self.index.search("Callable", models.SearchTest)
         self.assertEqual(set(results), {self.testa, self.testb, self.testc.searchtest_ptr, self.testd.searchtest_ptr})
 
     def test_filters(self):
-        results = self.backend.search(None, models.SearchTest, filters=dict(live=True))
+        results = self.index.search(None, models.SearchTest, filters=dict(live=True))
         self.assertEqual(set(results), {self.testb, self.testc.searchtest_ptr})
 
     def test_filters_with_in_lookup(self):
         live_page_titles = models.SearchTest.objects.filter(live=True).values_list('title', flat=True)
-        results = self.backend.search(None, models.SearchTest, filters=dict(title__in=live_page_titles))
+        results = self.index.search(None, models.SearchTest, filters=dict(title__in=live_page_titles))
         self.assertEqual(set(results), {self.testb, self.testc.searchtest_ptr})
 
     def test_single_result(self):
-        result = self.backend.search(None, models.SearchTest)[0]
+        result = self.index.search(None, models.SearchTest)[0]
         self.assertIsInstance(result, models.SearchTest)
 
     def test_sliced_results(self):
-        sliced_results = self.backend.search(None, models.SearchTest)[1:3]
+        sliced_results = self.index.search(None, models.SearchTest)[1:3]
 
         self.assertEqual(len(sliced_results), 2)
 
@@ -114,40 +114,40 @@ class BackendTests(WagtailTestUtils):
             self.assertIsInstance(result, models.SearchTest)
 
     def test_child_model(self):
-        results = self.backend.search(None, models.SearchTestChild)
+        results = self.index.search(None, models.SearchTestChild)
         self.assertEqual(set(results), {self.testc, self.testd})
 
     def test_child_model_with_id_filter(self):
-        results = self.backend.search("World", models.SearchTestChild.objects.filter(id=self.testd.id))
+        results = self.index.search("World", models.SearchTestChild.objects.filter(id=self.testd.id))
         self.assertEqual(set(results), {self.testd})
 
     def test_delete(self):
         # Delete one of the objects
-        self.backend.delete(self.testa)
+        self.index.delete(self.testa)
         self.testa.delete()
-        self.backend.refresh_index()
+        self.index.refresh_index()
 
-        results = self.backend.search(None, models.SearchTest)
+        results = self.index.search(None, models.SearchTest)
         self.assertEqual(set(results), {self.testb, self.testc.searchtest_ptr, self.testd.searchtest_ptr})
 
     def test_update_index_command(self):
         # Reset the index, this should clear out the index
-        self.backend.reset_index()
+        self.index.reset_index()
 
         # Give Elasticsearch some time to catch up...
         time.sleep(1)
 
-        results = self.backend.search(None, models.SearchTest)
+        results = self.index.search(None, models.SearchTest)
         self.assertEqual(set(results), set())
 
         # Run update_index command
         with self.ignore_deprecation_warnings():
             # ignore any DeprecationWarnings thrown by models with old-style indexed_fields definitions
             management.call_command(
-                'update_index', backend_name=self.backend_name, interactive=False, stdout=StringIO()
+                'update_index', index_name=self.index_name, interactive=False, stdout=StringIO()
             )
 
-        results = self.backend.search(None, models.SearchTest)
+        results = self.index.search(None, models.SearchTest)
         self.assertEqual(set(results), {self.testa, self.testb, self.testc.searchtest_ptr, self.testd.searchtest_ptr})
 
 
@@ -158,16 +158,16 @@ class BackendTests(WagtailTestUtils):
 )
 class TestBackendLoader(TestCase):
     def test_import_by_name(self):
-        db = get_search_backend(backend='default')
-        self.assertIsInstance(db, DBSearchIndex)
+        index = get_search_backend(backend='default')
+        self.assertIsInstance(index, DBSearchIndex)
 
     def test_import_by_path(self):
-        db = get_search_backend(backend='wagtail.wagtailsearch.backends.db')
-        self.assertIsInstance(db, DBSearchIndex)
+        index = get_search_backend(backend='wagtail.wagtailsearch.backends.db')
+        self.assertIsInstance(index, DBSearchIndex)
 
     def test_import_by_full_path(self):
-        db = get_search_backend(backend='wagtail.wagtailsearch.backends.db.DBSearchIndex')
-        self.assertIsInstance(db, DBSearchIndex)
+        index = get_search_backend(backend='wagtail.wagtailsearch.backends.db.DBSearchIndex')
+        self.assertIsInstance(index, DBSearchIndex)
 
     def test_nonexistent_backend_import(self):
         self.assertRaises(
@@ -178,31 +178,31 @@ class TestBackendLoader(TestCase):
         self.assertRaises(InvalidSearchBackendError, get_search_backend, backend="I'm not a backend!")
 
     def test_get_search_backends(self):
-        backends = list(get_search_backends())
+        indices = list(get_search_backends())
 
-        self.assertEqual(len(backends), 1)
-        self.assertIsInstance(backends[0], DBSearchIndex)
+        self.assertEqual(len(indices), 1)
+        self.assertIsInstance(indices[0], DBSearchIndex)
 
     @override_settings(
         WAGTAILSEARCH_BACKENDS={
             'default': {
                 'BACKEND': 'wagtail.wagtailsearch.backends.db'
             },
-            'another-backend': {
+            'another-index': {
                 'BACKEND': 'wagtail.wagtailsearch.backends.db'
             },
         }
     )
     def test_get_search_backends_multiple(self):
-        backends = list(get_search_backends())
+        indices = list(get_search_backends())
 
-        self.assertEqual(len(backends), 2)
+        self.assertEqual(len(indices), 2)
 
     def test_get_search_backends_with_auto_update(self):
-        backends = list(get_search_backends(with_auto_update=True))
+        indices = list(get_search_backends(with_auto_update=True))
 
         # Auto update is the default
-        self.assertEqual(len(backends), 1)
+        self.assertEqual(len(indices), 1)
 
     @override_settings(
         WAGTAILSEARCH_BACKENDS={
@@ -213,9 +213,9 @@ class TestBackendLoader(TestCase):
         }
     )
     def test_get_search_backends_with_auto_update_disabled(self):
-        backends = list(get_search_backends(with_auto_update=True))
+        indices = list(get_search_backends(with_auto_update=True))
 
-        self.assertEqual(len(backends), 0)
+        self.assertEqual(len(indices), 0)
 
     @override_settings(
         WAGTAILSEARCH_BACKENDS={
@@ -226,6 +226,6 @@ class TestBackendLoader(TestCase):
         }
     )
     def test_get_search_backends_without_auto_update_disabled(self):
-        backends = list(get_search_backends())
+        indices = list(get_search_backends())
 
-        self.assertEqual(len(backends), 1)
+        self.assertEqual(len(indices), 1)

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -13,13 +13,7 @@ from django.test import TestCase
 from django.db.models import Q
 
 from wagtail.wagtailsearch.backends import get_search_backend
-from wagtail.wagtailsearch.backends.elasticsearch import (
-    ElasticSearch,
-    ElasticSearchMapping,
-    ElasticSearchResults,
-    ElasticSearchQuery,
-    ElasticSearchAtomicIndexRebuilder,
-)
+from wagtail.wagtailsearch.backends.elasticsearch import ElasticSearch
 
 from wagtail.tests.search import models
 from .test_backends import BackendTests
@@ -239,9 +233,11 @@ class TestElasticSearchQuery(TestCase):
             json.dumps(a, sort_keys=True, default=default), json.dumps(b, sort_keys=True, default=default)
         )
 
+    query_class = ElasticSearch.query_class
+
     def test_simple(self):
         # Create a query
-        query = ElasticSearchQuery(models.SearchTest.objects.all(), "Hello")
+        query = self.query_class(models.SearchTest.objects.all(), "Hello")
 
         # Check it
         expected_result = {'filtered': {
@@ -252,7 +248,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_none_query_string(self):
         # Create a query
-        query = ElasticSearchQuery(models.SearchTest.objects.all(), None)
+        query = self.query_class(models.SearchTest.objects.all(), None)
 
         # Check it
         expected_result = {'filtered': {
@@ -263,7 +259,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_and_operator(self):
         # Create a query
-        query = ElasticSearchQuery(models.SearchTest.objects.all(), "Hello", operator='and')
+        query = self.query_class(models.SearchTest.objects.all(), "Hello", operator='and')
 
         # Check it
         expected_result = {'filtered': {
@@ -274,7 +270,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_filter(self):
         # Create a query
-        query = ElasticSearchQuery(models.SearchTest.objects.filter(title="Test"), "Hello")
+        query = self.query_class(models.SearchTest.objects.filter(title="Test"), "Hello")
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [
@@ -285,7 +281,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_and_filter(self):
         # Create a query
-        query = ElasticSearchQuery(models.SearchTest.objects.filter(title="Test", live=True), "Hello")
+        query = self.query_class(models.SearchTest.objects.filter(title="Test", live=True), "Hello")
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [
@@ -302,7 +298,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_or_filter(self):
         # Create a query
-        query = ElasticSearchQuery(models.SearchTest.objects.filter(Q(title="Test") | Q(live=True)), "Hello")
+        query = self.query_class(models.SearchTest.objects.filter(Q(title="Test") | Q(live=True)), "Hello")
 
         # Make sure field filters are sorted (as they can be in any order which may cause false positives)
         query = query.get_query()
@@ -318,7 +314,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_negated_filter(self):
         # Create a query
-        query = ElasticSearchQuery(models.SearchTest.objects.exclude(live=True), "Hello")
+        query = self.query_class(models.SearchTest.objects.exclude(live=True), "Hello")
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [
@@ -329,7 +325,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_fields(self):
         # Create a query
-        query = ElasticSearchQuery(models.SearchTest.objects.all(), "Hello", fields=['title'])
+        query = self.query_class(models.SearchTest.objects.all(), "Hello", fields=['title'])
 
         # Check it
         expected_result = {'filtered': {
@@ -340,7 +336,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_fields_with_and_operator(self):
         # Create a query
-        query = ElasticSearchQuery(models.SearchTest.objects.all(), "Hello", fields=['title'], operator='and')
+        query = self.query_class(models.SearchTest.objects.all(), "Hello", fields=['title'], operator='and')
 
         # Check it
         expected_result = {'filtered': {
@@ -351,7 +347,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_multiple_fields(self):
         # Create a query
-        query = ElasticSearchQuery(models.SearchTest.objects.all(), "Hello", fields=['title', 'content'])
+        query = self.query_class(models.SearchTest.objects.all(), "Hello", fields=['title', 'content'])
 
         # Check it
         expected_result = {'filtered': {
@@ -362,7 +358,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_multiple_fields_with_and_operator(self):
         # Create a query
-        query = ElasticSearchQuery(
+        query = self.query_class(
             models.SearchTest.objects.all(), "Hello", fields=['title', 'content'], operator='and'
         )
 
@@ -375,7 +371,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_exact_lookup(self):
         # Create a query
-        query = ElasticSearchQuery(models.SearchTest.objects.filter(title__exact="Test"), "Hello")
+        query = self.query_class(models.SearchTest.objects.filter(title__exact="Test"), "Hello")
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [
@@ -386,7 +382,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_none_lookup(self):
         # Create a query
-        query = ElasticSearchQuery(models.SearchTest.objects.filter(title=None), "Hello")
+        query = self.query_class(models.SearchTest.objects.filter(title=None), "Hello")
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [
@@ -397,7 +393,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_isnull_true_lookup(self):
         # Create a query
-        query = ElasticSearchQuery(models.SearchTest.objects.filter(title__isnull=True), "Hello")
+        query = self.query_class(models.SearchTest.objects.filter(title__isnull=True), "Hello")
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [
@@ -408,7 +404,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_isnull_false_lookup(self):
         # Create a query
-        query = ElasticSearchQuery(models.SearchTest.objects.filter(title__isnull=False), "Hello")
+        query = self.query_class(models.SearchTest.objects.filter(title__isnull=False), "Hello")
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [
@@ -419,7 +415,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_startswith_lookup(self):
         # Create a query
-        query = ElasticSearchQuery(models.SearchTest.objects.filter(title__startswith="Test"), "Hello")
+        query = self.query_class(models.SearchTest.objects.filter(title__startswith="Test"), "Hello")
 
         # Check it
         expected_result = {'filtered': {'filter': {'and': [
@@ -432,7 +428,7 @@ class TestElasticSearchQuery(TestCase):
         # This also tests conversion of python dates to strings
 
         # Create a query
-        query = ElasticSearchQuery(
+        query = self.query_class(
             models.SearchTest.objects.filter(published_date__gt=datetime.datetime(2014, 4, 29)), "Hello"
         )
 
@@ -445,7 +441,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_lt_lookup(self):
         # Create a query
-        query = ElasticSearchQuery(
+        query = self.query_class(
             models.SearchTest.objects.filter(published_date__lt=datetime.datetime(2014, 4, 29)), "Hello"
         )
 
@@ -458,7 +454,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_gte_lookup(self):
         # Create a query
-        query = ElasticSearchQuery(
+        query = self.query_class(
             models.SearchTest.objects.filter(published_date__gte=datetime.datetime(2014, 4, 29)), "Hello"
         )
 
@@ -471,7 +467,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_lte_lookup(self):
         # Create a query
-        query = ElasticSearchQuery(
+        query = self.query_class(
             models.SearchTest.objects.filter(published_date__lte=datetime.datetime(2014, 4, 29)), "Hello"
         )
 
@@ -487,7 +483,7 @@ class TestElasticSearchQuery(TestCase):
         end_date = datetime.datetime(2014, 8, 19)
 
         # Create a query
-        query = ElasticSearchQuery(
+        query = self.query_class(
             models.SearchTest.objects.filter(published_date__range=(start_date, end_date)), "Hello"
         )
 
@@ -500,7 +496,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_custom_ordering(self):
         # Create a query
-        query = ElasticSearchQuery(
+        query = self.query_class(
             models.SearchTest.objects.order_by('published_date'), "Hello", order_by_relevance=False
         )
 
@@ -510,7 +506,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_custom_ordering_reversed(self):
         # Create a query
-        query = ElasticSearchQuery(
+        query = self.query_class(
             models.SearchTest.objects.order_by('-published_date'), "Hello", order_by_relevance=False
         )
 
@@ -520,7 +516,7 @@ class TestElasticSearchQuery(TestCase):
 
     def test_custom_ordering_multiple(self):
         # Create a query
-        query = ElasticSearchQuery(
+        query = self.query_class(
             models.SearchTest.objects.order_by('published_date', 'live'), "Hello", order_by_relevance=False
         )
 
@@ -548,7 +544,7 @@ class TestElasticSearchResults(TestCase):
         query.queryset = models.SearchTest.objects.all()
         query.get_query.return_value = 'QUERY'
         query.get_sort.return_value = None
-        return ElasticSearchResults(backend, query)
+        return backend.results_class(backend, query)
 
     def construct_search_response(self, results):
         return {
@@ -716,7 +712,7 @@ class TestElasticSearchMapping(TestCase):
 
     def setUp(self):
         # Create ES mapping
-        self.es_mapping = ElasticSearchMapping(models.SearchTest)
+        self.es_mapping = ElasticSearch.mapping_class(models.SearchTest)
 
         # Create ES document
         self.obj = models.SearchTest(title="Hello")
@@ -798,7 +794,7 @@ class TestElasticSearchMappingInheritance(TestCase):
 
     def setUp(self):
         # Create ES mapping
-        self.es_mapping = ElasticSearchMapping(models.SearchTestChild)
+        self.es_mapping = ElasticSearch.mapping_class(models.SearchTestChild)
 
         # Create ES document
         self.obj = models.SearchTestChild(title="Hello", subtitle="World", page_id=1)
@@ -1008,7 +1004,7 @@ class TestRebuilder(TestCase):
         self.rebuilder.add_model(models.SearchTest)
 
         # Check the mapping went into Elasticsearch correctly
-        mapping = ElasticSearchMapping(models.SearchTest)
+        mapping = ElasticSearch.mapping_class(models.SearchTest)
         response = self.es.indices.get_mapping(self.backend.es_index, mapping.get_document_type())
 
         # Make some minor tweaks to the mapping so it matches what is in ES
@@ -1030,7 +1026,7 @@ class TestRebuilder(TestCase):
 class TestAtomicRebuilder(TestCase):
     def setUp(self):
         self.backend = get_search_backend('elasticsearch')
-        self.backend.rebuilder_class = ElasticSearchAtomicIndexRebuilder
+        self.backend.rebuilder_class = self.backend.atomic_rebuilder_class
         self.es = self.backend.es
         self.rebuilder = self.backend.get_rebuilder()
 


### PR DESCRIPTION
Depends on #1491 #2005

This pull request fixes some of the terminology used in wagtail search. Here's the new definitions:
 - "index" - A database to index documents into and run search queries against
 - "backend" - A module that provides access to indices for a particular DBMS (eg elasticsearch, postgres)

Currently, both of the above are referred to as "backend". The main thing we do here is rewrite some APIs to refer to indices instead of backends.

The following APIs will be broken (backwards compatibility for both will be provided):
 - ``WAGTAILSEARCH_BACKENDS`` will be renamed to ``WAGTAILSEARCH_INDICES``
 - The ``get_search_backend(s)`` functions will be renamed to ``get_search_ind(ex|ices)``