### PR TITLE
Use plain models, not ContentTypes to manage snippets

### DIFF
--- a/wagtail/wagtailsnippets/blocks.py
+++ b/wagtail/wagtailsnippets/blocks.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from django.utils.functional import cached_property
-from django.contrib.contenttypes.models import ContentType
 
 from wagtail.wagtailcore.blocks import ChooserBlock
 
@@ -14,5 +13,4 @@ class SnippetChooserBlock(ChooserBlock):
     @cached_property
     def widget(self):
         from wagtail.wagtailsnippets.widgets import AdminSnippetChooser
-        content_type = ContentType.objects.get_for_model(self.target_model)
-        return AdminSnippetChooser(content_type)
+        return AdminSnippetChooser(self.target_model)

--- a/wagtail/wagtailsnippets/edit_handlers.py
+++ b/wagtail/wagtailsnippets/edit_handlers.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
+import warnings
+
 from django.template.loader import render_to_string
-from django.contrib.contenttypes.models import ContentType
 from django.utils.safestring import mark_safe
-from django.utils.encoding import force_text
 from django.core.exceptions import ImproperlyConfigured
 
+from wagtail.utils.deprecation import RemovedInWagtail15Warning
 from wagtail.wagtailadmin.edit_handlers import BaseChooserPanel
 from wagtail.wagtailcore.utils import resolve_model_string
 from .widgets import AdminSnippetChooser
@@ -15,17 +16,17 @@ class BaseSnippetChooserPanel(BaseChooserPanel):
     object_type_name = 'item'
 
     _target_model = None
-    _target_content_type = None
 
     @classmethod
     def widget_overrides(cls):
-        return {cls.field_name: AdminSnippetChooser(
-            content_type=cls.target_content_type(), snippet_type_name=cls.get_snippet_type_name())}
+        return {cls.field_name: AdminSnippetChooser(model=cls.target_model())}
 
     @classmethod
     def target_model(cls):
         if cls._target_model is None:
             if cls.snippet_type:
+                # RemovedInWagtail15Warning: The target_model is automatically
+                # detected from the relation, so snippet_type is deprecated.
                 try:
                     cls._target_model = resolve_model_string(cls.snippet_type)
                 except LookupError:
@@ -43,28 +44,22 @@ class BaseSnippetChooserPanel(BaseChooserPanel):
 
         return cls._target_model
 
-    @classmethod
-    def target_content_type(cls):
-        if cls._target_content_type is None:
-            cls._target_content_type = ContentType.objects.get_for_model(cls.target_model())
-        return cls._target_content_type
-
     def render_as_field(self):
         instance_obj = self.get_chosen_item()
         return mark_safe(render_to_string(self.field_template, {
             'field': self.bound_field,
             self.object_type_name: instance_obj,
-            'snippet_type_name': self.get_snippet_type_name(),
         }))
-
-    @classmethod
-    def get_snippet_type_name(cls):
-        return force_text(cls.target_model()._meta.verbose_name)
 
 
 class SnippetChooserPanel(object):
     def __init__(self, field_name, snippet_type=None):
         self.field_name = field_name
+        if snippet_type is not None:
+            warnings.warn(
+                'The snippet_type argument to SnippetChooserPanel is deprecated. '
+                'The related model is now automatically detected.',
+                RemovedInWagtail15Warning)
         self.snippet_type = snippet_type
 
     def bind_to_model(self, model):

--- a/wagtail/wagtailsnippets/models.py
+++ b/wagtail/wagtailsnippets/models.py
@@ -1,24 +1,10 @@
 from __future__ import unicode_literals
 
-from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 
 from wagtail.wagtailadmin.utils import get_object_usage
 
 SNIPPET_MODELS = []
-
-SNIPPET_CONTENT_TYPES = None
-
-
-def get_snippet_content_types():
-    global SNIPPET_CONTENT_TYPES
-    if SNIPPET_CONTENT_TYPES is None:
-        SNIPPET_CONTENT_TYPES = [
-            ContentType.objects.get_for_model(model)
-            for model in SNIPPET_MODELS
-        ]
-
-    return SNIPPET_CONTENT_TYPES
 
 
 def get_snippet_models():
@@ -35,8 +21,5 @@ def register_snippet(model):
 
 
 def get_snippet_usage_url(self):
-    content_type = ContentType.objects.get_for_model(self)
-    return reverse('wagtailsnippets:usage',
-                   args=(content_type.app_label,
-                         content_type.model,
-                         self.id,))
+    return reverse('wagtailsnippets:usage', args=(
+        self._meta.app_label, self._meta.model_name, self.id))

--- a/wagtail/wagtailsnippets/permissions.py
+++ b/wagtail/wagtailsnippets/permissions.py
@@ -1,5 +1,4 @@
 from django.contrib.auth import get_permission_codename
-from django.contrib.contenttypes.models import ContentType
 
 from wagtail.wagtailsnippets.models import get_snippet_models
 
@@ -8,13 +7,8 @@ def get_permission_name(action, model):
     return "%s.%s" % (model._meta.app_label, get_permission_codename(action, model._meta))
 
 
-def user_can_edit_snippet_type(user, model_or_content_type):
+def user_can_edit_snippet_type(user, model):
     """ true if user has 'add', 'change' or 'delete' permission on this model """
-    if isinstance(model_or_content_type, ContentType):
-        model = model_or_content_type.model_class()
-    else:
-        model = model_or_content_type
-
     for action in ('add', 'change', 'delete'):
         if user.has_perm(get_permission_name(action, model)):
             return True

--- a/wagtail/wagtailsnippets/static_src/wagtailsnippets/js/snippet-chooser.js
+++ b/wagtail/wagtailsnippets/static_src/wagtailsnippets/js/snippet-chooser.js
@@ -1,4 +1,4 @@
-function createSnippetChooser(id, contentType) {
+function createSnippetChooser(id, modelString) {
     var chooserElement = $('#' + id + '-chooser');
     var docTitle = chooserElement.find('.title');
     var input = $('#' + id);
@@ -6,7 +6,7 @@ function createSnippetChooser(id, contentType) {
 
     $('.action-choose', chooserElement).click(function() {
         ModalWorkflow({
-            url: window.chooserUrls.snippetChooser + contentType + '/',
+            url: window.chooserUrls.snippetChooser + modelString + '/',
             responses: {
                 snippetChosen: function(snippetData) {
                     input.val(snippetData.id);

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/chooser/choose.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/chooser/choose.html
@@ -1,11 +1,11 @@
 {% load i18n %}
 {% trans "Choose" as choose_str %}
-{% include "wagtailadmin/shared/header.html" with title=choose_str subtitle=snippet_type_name icon="snippet" %}
+{% include "wagtailadmin/shared/header.html" with title=choose_str subtitle=model_opts.verbose_name icon="snippet" %}
 
 <div class="nice-padding">
     {# Need to keep the form in the HTML, even if the snippet is not searchable #}
     {# This is to allow pagination links to be generated from the form action URL #}
-    <form class="snippet-search search-bar" action="{% url 'wagtailsnippets:choose' content_type.app_label content_type.model %}" method="GET">
+    <form class="snippet-search search-bar" action="{% url 'wagtailsnippets:choose' model_opts.app_label model_opts.model_name %}" method="GET">
         {% if is_searchable %}
             <ul class="fields">
                 {% for field in search_form %}

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/chooser/results.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/chooser/results.html
@@ -17,7 +17,7 @@
     {% if is_searching %}
          <p>{% blocktrans %}Sorry, no snippets match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
     {% else %}
-        {% url 'wagtailsnippets:add' content_type.app_label content_type.model as wagtailsnippets_create_snippet_url %}
-        <p>{% blocktrans %}You haven't created any {{ snippet_type_name }} snippets. Why not <a href="{{ wagtailsnippets_create_snippet_url }}" target="_blank">create one now{% endblocktrans %}</p>
+        {% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name as wagtailsnippets_create_snippet_url %}
+        <p>{% blocktrans with snippet_type_name=model_opts.verbose_name %}You haven't created any {{ snippet_type_name }} snippets. Why not <a href="{{ wagtailsnippets_create_snippet_url }}" target="_blank">create one now{% endblocktrans %}</p>
     {% endif %}
 {% endif %}

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/confirm_delete.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/confirm_delete.html
@@ -1,13 +1,13 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans %}Delete {{ snippet_type_name}} - {{ instance }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans with snippet_type_name=model_opts.verbose_name %}Delete {{ snippet_type_name }} - {{ instance }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Delete" as delete_str %}
     {% include "wagtailadmin/shared/header.html" with title=delete_str subtitle=instance icon="snippet" %}
 
     <div class="nice-padding">
-        <p>{% blocktrans %}Are you sure you want to delete this {{ snippet_type_name }}?{% endblocktrans %}</p>
-        <form action="{% url 'wagtailsnippets:delete' content_type.app_label content_type.model instance.id %}" method="POST">
+        <p>{% blocktrans with snippet_type_name=model_opts.verbose_name %}Are you sure you want to delete this {{ snippet_type_name }}?{% endblocktrans %}</p>
+        <form action="{% url 'wagtailsnippets:delete' model_opts.app_label model_opts.model_name instance.id %}" method="POST">
             {% csrf_token %}
             <input type="submit" value="{% trans 'Yes, delete' %}" class="serious" />
         </form>

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/create.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/create.html
@@ -1,14 +1,14 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans %}New  {{ snippet_type_name}}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans with snippet_type_name=model_opts.verbose_name %}New  {{ snippet_type_name }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "New" as new_str %}
-    {% include "wagtailadmin/shared/header.html" with title=new_str subtitle=snippet_type_name icon="snippet" %}
+    {% include "wagtailadmin/shared/header.html" with title=new_str subtitle=model_opts.verbose_name icon="snippet" %}
 
-    <form action="{% url 'wagtailsnippets:add' content_type.app_label content_type.model %}" method="POST">
+    <form action="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}" method="POST">
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
-        
+
         <footer>
             <ul>
                 <li class="actions">
@@ -19,7 +19,7 @@
             </ul>
         </footer>
     </form>
-   
+
 {% endblock %}
 
 {% block extra_css %}

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
@@ -1,11 +1,11 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans %}Editing {{ snippet_type_name}} - {{ instance }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans with snippet_type_name=model_opts.verbose_name %}Editing {{ snippet_type_name }} - {{ instance }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Editing" as editing_str %}
     {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=instance icon="snippet" usage_object=instance %}
 
-    <form action="{% url 'wagtailsnippets:edit' content_type.app_label content_type.model instance.id %}" method="POST">
+    <form action="{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name instance.id %}" method="POST">
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
 
@@ -16,7 +16,7 @@
                         <input type="submit" value="{% trans 'Save' %}" class="button" />
                         <div class="dropdown-toggle icon icon-arrow-up"></div>
                         <ul role="menu">
-                            <li><a href="{% url 'wagtailsnippets:delete' content_type.app_label content_type.model instance.id %}" class="shortcut">{% trans "Delete" %}</a></li>
+                            <li><a href="{% url 'wagtailsnippets:delete' model_opts.app_label model_opts.model_name instance.id %}" class="shortcut">{% trans "Delete" %}</a></li>
                         </ul>
                     </div>
                 </li>

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/index.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/index.html
@@ -7,12 +7,12 @@
 
     <div class="nice-padding">
         <ul class="listing">
-            {% for name, content_type in snippet_types %}
+            {% for model_opts in snippet_model_opts %}
                 <li>
                     <div class="row row-flush title">
                         <h2>
-                            <a href="{% url 'wagtailsnippets:list' content_type.app_label content_type.model %}" class="col6">
-                                {{ name|capfirst }}
+                            <a href="{% url 'wagtailsnippets:list' model_opts.app_label model_opts.model_name %}" class="col6">
+                                {{ model_opts.verbose_name_plural|capfirst }}
                             </a>
                         </h2>
                     </div>

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/list.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/list.html
@@ -13,9 +13,9 @@
             <tr>
                 <td class="title">
                     {% if choosing %}
-                        <h2><a class="snippet-choice" href="{% url 'wagtailsnippets:chosen' content_type.app_label content_type.model snippet.id %}">{{ snippet }}</a></h2>
+                        <h2><a class="snippet-choice" href="{% url 'wagtailsnippets:chosen' model_opts.app_label model_opts.model_name snippet.id %}">{{ snippet }}</a></h2>
                     {% else %}
-                        <h2><a href="{% url 'wagtailsnippets:edit' content_type.app_label content_type.model snippet.id %}">{{ snippet }}</a></h2>
+                        <h2><a href="{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name snippet.id %}">{{ snippet }}</a></h2>
                     {% endif %}
                 </td>
             </tr>

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/results.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/results.html
@@ -12,13 +12,13 @@
 
     {% include "wagtailsnippets/snippets/list.html" %}
 
-    {% url 'wagtailsnippets:list' content_type.app_label content_type.model as wagtailsnippets_list_url %}
+    {% url 'wagtailsnippets:list' model_opts.app_label model_opts.model_name as wagtailsnippets_list_url %}
     {% include "wagtailadmin/shared/pagination_nav.html" with items=items is_searching=is_searching linkurl=wagtailsnippets_list_url %}
 {% else %}
     {% if is_searching %}
          <p>{% blocktrans %}Sorry, no snippets match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
     {% else %}
-        {% url 'wagtailsnippets:add' content_type.app_label content_type.model as wagtailsnippets_create_url %}
-        <p class="no-results-message">{% blocktrans %}No {{ snippet_type_name_plural }} have been created. Why not <a href="{{ wagtailsnippets_create_url }}">add one</a>?{% endblocktrans %}</p>
+        {% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name as wagtailsnippets_create_url %}
+        <p class="no-results-message">{% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural %}No {{ snippet_type_name_plural }} have been created. Why not <a href="{{ wagtailsnippets_create_url }}">add one</a>?{% endblocktrans %}</p>
     {% endif %}
 {% endif %}

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/type_index.html
@@ -1,12 +1,12 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with snippet_type_name_plural=snippet_type_name_plural|capfirst %}Snippets {{ snippet_type_name_plural }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets {{ snippet_type_name_plural }}{% endblocktrans %}{% endblock %}
 
 {% block extra_js %}
     <script>
         {{ block.super }}
         window.headerSearch = {
-            url: "{% url 'wagtailsnippets:list' content_type.app_label content_type.model %}",
+            url: "{% url 'wagtailsnippets:list' model_opts.app_label model_opts.model_name %}",
             termInput: "#id_q",
             targetOutput: "#snippet-results"
         }
@@ -18,10 +18,10 @@
     <header class="nice-padding">
         <div class="row row-flush">
             <div class="left col9">
-                <h1 class="icon icon-snippet">{% blocktrans with snippet_type_name_plural=snippet_type_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}</h1>
+                <h1 class="icon icon-snippet">{% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}</h1>
 
                 {% if is_searchable %}
-                    <form class="col search-form" action="{% url 'wagtailsnippets:list' content_type.app_label content_type.model %}" method="get">
+                    <form class="col search-form" action="{% url 'wagtailsnippets:list' model_opts.app_label model_opts.model_name %}" method="get">
                         <ul class="fields">
                             {% for field in search_form %}
                                 {% include "wagtailadmin/shared/field_as_li.html" with field=field field_classes="field-small iconfield" input_classes="icon-search" %}
@@ -33,7 +33,7 @@
             </div>
             <div class="right col3">
                 {% if can_add_snippet %}
-                    <a href="{% url 'wagtailsnippets:add' content_type.app_label content_type.model %}" class="button bicolor icon icon-plus">{% blocktrans %}Add {{ snippet_type_name }}{% endblocktrans %}</a>
+                    <a href="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}" class="button bicolor icon icon-plus">{% blocktrans with snippet_type_name=model_opts.verbose_name %}Add {{ snippet_type_name }}{% endblocktrans %}</a>
                     {# TODO: figure out a way of saying "Add a/an [foo]" #}
                 {% endif %}
             </div>

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/usage.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/usage.html
@@ -31,7 +31,7 @@
                             {% endif %}
                         </td>
                         <td>
-                            {{ page.content_type.model_class.get_verbose_name }}
+                            {{ page.specific_class.get_verbose_name }}
                         </td>
                         <td>
                             {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/widgets/snippet_chooser.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/widgets/snippet_chooser.html
@@ -6,4 +6,4 @@
     <span class="title">{{ item }}</span>
 {% endblock %}
 
-{% block edit_chosen_item_url %}{% if item %}{% url 'wagtailsnippets:edit' widget.target_content_type.app_label widget.target_content_type.model item.id %}{% endif %}{% endblock %}
+{% block edit_chosen_item_url %}{% if item %}{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name item.id %}{% endif %}{% endblock %}

--- a/wagtail/wagtailsnippets/tests.py
+++ b/wagtail/wagtailsnippets/tests.py
@@ -250,7 +250,7 @@ class TestSnippetDelete(TestCase, WagtailTestUtils):
         self.assertEqual(Advert.objects.filter(text='test_advert').count(), 0)
 
 
-class TestSnippetChooserPanel(TestCase):
+class TestSnippetChooserPanel(TestCase, WagtailTestUtils):
     fixtures = ['test.json']
 
     def setUp(self):
@@ -296,41 +296,49 @@ class TestSnippetChooserPanel(TestCase):
         self.assertIn('createSnippetChooser("id_advert", "tests/advert");',
                       self.snippet_chooser_panel.render_as_field())
 
-    def test_target_content_type_from_string(self):
-        result = SnippetChooserPanel(
-            'advert',
-            'tests.advert'
-        ).bind_to_model(SnippetChooserModel).target_content_type()
-        self.assertEqual(result.name, 'advert')
+    def test_target_model_from_string(self):
+        # RemovedInWagtail15Warning: snippet_type argument
+        with self.ignore_deprecation_warnings():
+            result = SnippetChooserPanel(
+                'advert',
+                'tests.advert'
+            ).bind_to_model(SnippetChooserModel).target_model()
+            self.assertIs(result, Advert)
 
-    def test_target_content_type_from_model(self):
-        result = SnippetChooserPanel(
-            'advert',
-            Advert
-        ).bind_to_model(SnippetChooserModel).target_content_type()
-        self.assertEqual(result.name, 'advert')
+    def test_target_model_from_model(self):
+        # RemovedInWagtail15Warning: snippet_type argument
+        with self.ignore_deprecation_warnings():
+            result = SnippetChooserPanel(
+                'advert',
+                Advert
+            ).bind_to_model(SnippetChooserModel).target_model()
+            self.assertIs(result, Advert)
 
-    def test_target_content_type_autodetected(self):
+    def test_target_model_autodetected(self):
         result = SnippetChooserPanel(
             'advert'
-        ).bind_to_model(SnippetChooserModel).target_content_type()
-        self.assertEqual(result.name, 'advert')
+        ).bind_to_model(SnippetChooserModel).target_model()
+        self.assertEqual(result, Advert)
 
-    def test_target_content_type_malformed_type(self):
-        result = SnippetChooserPanel(
-            'advert',
-            'snowman'
-        ).bind_to_model(SnippetChooserModel)
-        self.assertRaises(ImproperlyConfigured,
-                          result.target_content_type)
+    def test_target_model_malformed_type(self):
+        # RemovedInWagtail15Warning: snippet_type argument
+        with self.ignore_deprecation_warnings():
+            result = SnippetChooserPanel(
+                'advert',
+                'snowman'
+            ).bind_to_model(SnippetChooserModel)
+            self.assertRaises(ImproperlyConfigured,
+                              result.target_model)
 
-    def test_target_content_type_nonexistent_type(self):
-        result = SnippetChooserPanel(
-            'advert',
-            'snowman.lorry'
-        ).bind_to_model(SnippetChooserModel)
-        self.assertRaises(ImproperlyConfigured,
-                          result.target_content_type)
+    def test_target_model_nonexistent_type(self):
+        # RemovedInWagtail15Warning: snippet_type argument
+        with self.ignore_deprecation_warnings():
+            result = SnippetChooserPanel(
+                'advert',
+                'snowman.lorry'
+            ).bind_to_model(SnippetChooserModel)
+            self.assertRaises(ImproperlyConfigured,
+                              result.target_model)
 
 
 class TestSnippetRegistering(TestCase):

--- a/wagtail/wagtailsnippets/views/snippets.py
+++ b/wagtail/wagtailsnippets/views/snippets.py
@@ -1,50 +1,38 @@
-from django.http import Http404
-from django.shortcuts import get_object_or_404, render, redirect
-from django.utils.encoding import force_text
-from django.utils.text import capfirst
-from django.contrib.contenttypes.models import ContentType
-from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
+from django.apps import apps
+from django.http import Http404
+from django.shortcuts import get_object_or_404, redirect, render
+from django.utils.text import capfirst
+from django.utils.translation import ugettext as _
 
 from wagtail.utils.pagination import paginate
-from wagtail.wagtailadmin.edit_handlers import ObjectList, extract_panel_definitions_from_model_class
-from wagtail.wagtailadmin.utils import permission_denied
-
-from wagtail.wagtailsnippets.models import get_snippet_content_types
-from wagtail.wagtailsnippets.permissions import get_permission_name, user_can_edit_snippet_type
 from wagtail.wagtailadmin import messages
+from wagtail.wagtailadmin.edit_handlers import (
+    ObjectList, extract_panel_definitions_from_model_class)
 from wagtail.wagtailadmin.forms import SearchForm
-from wagtail.wagtailsearch.index import class_is_indexed
+from wagtail.wagtailadmin.utils import permission_denied
 from wagtail.wagtailsearch.backends import get_search_backend
+from wagtail.wagtailsearch.index import class_is_indexed
+from wagtail.wagtailsnippets.models import get_snippet_models
+from wagtail.wagtailsnippets.permissions import (
+    get_permission_name, user_can_edit_snippet_type)
 
 
 # == Helper functions ==
-
-
-def get_snippet_type_name(content_type):
-    """ e.g. given the 'advert' content type, return ('Advert', 'Adverts') """
-    # why oh why is this so convoluted?
-    opts = content_type.model_class()._meta
-    return (
-        force_text(opts.verbose_name),
-        force_text(opts.verbose_name_plural)
-    )
-
-
-def get_content_type_from_url_params(app_name, model_name):
+def get_snippet_model_from_url_params(app_name, model_name):
     """
-    retrieve a content type from an app_name / model_name combo.
-    Throw Http404 if not a valid snippet type
+    Retrieve a model from an app_label / model_name combo.
+    Raise Http404 if the model is not a valid snippet type.
     """
     try:
-        content_type = ContentType.objects.get_by_natural_key(app_name, model_name)
-    except ContentType.DoesNotExist:
+        model = apps.get_model(app_name, model_name)
+    except LookupError:
         raise Http404
-    if content_type not in get_snippet_content_types():
+    if model not in get_snippet_models():
         # don't allow people to hack the URL to edit content types that aren't registered as snippets
         raise Http404
 
-    return content_type
+    return model
 
 
 SNIPPET_EDIT_HANDLERS = {}
@@ -64,22 +52,16 @@ def get_snippet_edit_handler(model):
 
 
 def index(request):
-    snippet_types = [
-        (
-            get_snippet_type_name(content_type)[1],
-            content_type
-        )
-        for content_type in get_snippet_content_types()
-        if user_can_edit_snippet_type(request.user, content_type)
-    ]
+    snippet_model_opts = [
+        model._meta for model in get_snippet_models()
+        if user_can_edit_snippet_type(request.user, model)]
     return render(request, 'wagtailsnippets/snippets/index.html', {
-        'snippet_types': sorted(snippet_types, key=lambda x: x[0].lower()),
-    })
+        'snippet_model_opts': sorted(
+            snippet_model_opts, key=lambda x: x.verbose_name.lower())})
 
 
-def list(request, content_type_app_name, content_type_model_name):
-    content_type = get_content_type_from_url_params(content_type_app_name, content_type_model_name)
-    model = content_type.model_class()
+def list(request, app_label, model_name):
+    model = get_snippet_model_from_url_params(app_label, model_name)
 
     permissions = [
         get_permission_name(action, model)
@@ -87,8 +69,6 @@ def list(request, content_type_app_name, content_type_model_name):
     ]
     if not any([request.user.has_perm(perm) for perm in permissions]):
         return permission_denied(request)
-
-    snippet_type_name, snippet_type_name_plural = get_snippet_type_name(content_type)
 
     items = model.objects.all()
 
@@ -98,7 +78,7 @@ def list(request, content_type_app_name, content_type_model_name):
     search_query = None
     if is_searchable and 'q' in request.GET:
         search_form = SearchForm(request.GET, placeholder=_("Search %(snippet_type_name)s") % {
-            'snippet_type_name': snippet_type_name_plural
+            'snippet_type_name': model._meta.verbose_name_plural
         })
 
         if search_form.is_valid():
@@ -110,7 +90,7 @@ def list(request, content_type_app_name, content_type_model_name):
 
     else:
         search_form = SearchForm(placeholder=_("Search %(snippet_type_name)s") % {
-            'snippet_type_name': snippet_type_name_plural
+            'snippet_type_name': model._meta.verbose_name_plural
         })
 
     paginator, paginated_items = paginate(request, items)
@@ -122,9 +102,7 @@ def list(request, content_type_app_name, content_type_model_name):
         template = 'wagtailsnippets/snippets/type_index.html'
 
     return render(request, template, {
-        'content_type': content_type,
-        'snippet_type_name': snippet_type_name,
-        'snippet_type_name_plural': snippet_type_name_plural,
+        'model_opts': model._meta,
         'items': paginated_items,
         'can_add_snippet': request.user.has_perm(get_permission_name('add', model)),
         'is_searchable': is_searchable,
@@ -134,15 +112,12 @@ def list(request, content_type_app_name, content_type_model_name):
     })
 
 
-def create(request, content_type_app_name, content_type_model_name):
-    content_type = get_content_type_from_url_params(content_type_app_name, content_type_model_name)
-    model = content_type.model_class()
+def create(request, app_label, model_name):
+    model = get_snippet_model_from_url_params(app_label, model_name)
 
     permission = get_permission_name('add', model)
     if not request.user.has_perm(permission):
         return permission_denied(request)
-
-    snippet_type_name = get_snippet_type_name(content_type)[0]
 
     instance = model()
     edit_handler_class = get_snippet_edit_handler(model)
@@ -157,16 +132,16 @@ def create(request, content_type_app_name, content_type_model_name):
             messages.success(
                 request,
                 _("{snippet_type} '{instance}' created.").format(
-                    snippet_type=capfirst(get_snippet_type_name(content_type)[0]),
+                    snippet_type=capfirst(model._meta.verbose_name),
                     instance=instance
                 ),
                 buttons=[
                     messages.button(reverse(
-                        'wagtailsnippets:edit', args=(content_type_app_name, content_type_model_name, instance.id)
+                        'wagtailsnippets:edit', args=(app_label, model_name, instance.id)
                     ), _('Edit'))
                 ]
             )
-            return redirect('wagtailsnippets:list', content_type.app_label, content_type.model)
+            return redirect('wagtailsnippets:list', app_label, model_name)
         else:
             messages.error(request, _("The snippet could not be created due to errors."))
             edit_handler = edit_handler_class(instance=instance, form=form)
@@ -175,21 +150,17 @@ def create(request, content_type_app_name, content_type_model_name):
         edit_handler = edit_handler_class(instance=instance, form=form)
 
     return render(request, 'wagtailsnippets/snippets/create.html', {
-        'content_type': content_type,
-        'snippet_type_name': snippet_type_name,
+        'model_opts': model._meta,
         'edit_handler': edit_handler,
     })
 
 
-def edit(request, content_type_app_name, content_type_model_name, id):
-    content_type = get_content_type_from_url_params(content_type_app_name, content_type_model_name)
-    model = content_type.model_class()
+def edit(request, app_label, model_name, id):
+    model = get_snippet_model_from_url_params(app_label, model_name)
 
     permission = get_permission_name('change', model)
     if not request.user.has_perm(permission):
         return permission_denied(request)
-
-    snippet_type_name = get_snippet_type_name(content_type)[0]
 
     instance = get_object_or_404(model, id=id)
     edit_handler_class = get_snippet_edit_handler(model)
@@ -204,17 +175,16 @@ def edit(request, content_type_app_name, content_type_model_name, id):
             messages.success(
                 request,
                 _("{snippet_type} '{instance}' updated.").format(
-                    snippet_type=capfirst(snippet_type_name),
+                    snippet_type=capfirst(model._meta.verbose_name_plural),
                     instance=instance
                 ),
                 buttons=[
                     messages.button(reverse(
-                        'wagtailsnippets:edit',
-                        args=(content_type_app_name, content_type_model_name, instance.id)
+                        'wagtailsnippets:edit', args=(app_label, model_name, instance.id)
                     ), _('Edit'))
                 ]
             )
-            return redirect('wagtailsnippets:list', content_type.app_label, content_type.model)
+            return redirect('wagtailsnippets:list', app_label, model_name)
         else:
             messages.error(request, _("The snippet could not be saved due to errors."))
             edit_handler = edit_handler_class(instance=instance, form=form)
@@ -223,22 +193,18 @@ def edit(request, content_type_app_name, content_type_model_name, id):
         edit_handler = edit_handler_class(instance=instance, form=form)
 
     return render(request, 'wagtailsnippets/snippets/edit.html', {
-        'content_type': content_type,
-        'snippet_type_name': snippet_type_name,
+        'model_opts': model._meta,
         'instance': instance,
         'edit_handler': edit_handler
     })
 
 
-def delete(request, content_type_app_name, content_type_model_name, id):
-    content_type = get_content_type_from_url_params(content_type_app_name, content_type_model_name)
-    model = content_type.model_class()
+def delete(request, app_label, model_name, id):
+    model = get_snippet_model_from_url_params(app_label, model_name)
 
     permission = get_permission_name('delete', model)
     if not request.user.has_perm(permission):
         return permission_denied(request)
-
-    snippet_type_name = get_snippet_type_name(content_type)[0]
 
     instance = get_object_or_404(model, id=id)
 
@@ -247,22 +213,20 @@ def delete(request, content_type_app_name, content_type_model_name, id):
         messages.success(
             request,
             _("{snippet_type} '{instance}' deleted.").format(
-                snippet_type=capfirst(snippet_type_name),
+                snippet_type=capfirst(model._meta.verbose_name_plural),
                 instance=instance
             )
         )
-        return redirect('wagtailsnippets:list', content_type.app_label, content_type.model)
+        return redirect('wagtailsnippets:list', app_label, model_name)
 
     return render(request, 'wagtailsnippets/snippets/confirm_delete.html', {
-        'content_type': content_type,
-        'snippet_type_name': snippet_type_name,
+        'model_opts': model._meta,
         'instance': instance,
     })
 
 
-def usage(request, content_type_app_name, content_type_model_name, id):
-    content_type = get_content_type_from_url_params(content_type_app_name, content_type_model_name)
-    model = content_type.model_class()
+def usage(request, app_label, model_name, id):
+    model = get_snippet_model_from_url_params(app_label, model_name)
     instance = get_object_or_404(model, id=id)
 
     paginator, used_by = paginate(request, instance.get_usage())

--- a/wagtail/wagtailsnippets/wagtail_hooks.py
+++ b/wagtail/wagtailsnippets/wagtail_hooks.py
@@ -1,16 +1,16 @@
 from django.conf import settings
 from django.conf.urls import include, url
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from django.core import urlresolvers
 from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
-from django.contrib.auth.models import Permission
 
-from wagtail.wagtailcore import hooks
 from wagtail.wagtailadmin.menu import MenuItem
-
+from wagtail.wagtailcore import hooks
 from wagtail.wagtailsnippets import urls
+from wagtail.wagtailsnippets.models import get_snippet_models
 from wagtail.wagtailsnippets.permissions import user_can_edit_snippets
-from wagtail.wagtailsnippets.models import get_snippet_content_types
 
 
 @hooks.register('register_admin_urls')
@@ -50,6 +50,5 @@ def editor_js():
 
 @hooks.register('register_permissions')
 def register_permissions():
-    snippet_content_types = get_snippet_content_types()
-    snippet_permissions = Permission.objects.filter(content_type__in=snippet_content_types)
-    return snippet_permissions
+    content_types = ContentType.objects.get_for_models(*get_snippet_models()).values()
+    return Permission.objects.filter(content_type__in=content_types)


### PR DESCRIPTION
Using ContentTypes was unnecessary, and obfuscated the code. Removing
them and using plain models makes the code easier to understand.

The `snippet_type` argument to the SnippetChooserPanel has been
deprecated as part of this. It was already unnecessary, with the snippet
type being detected from the model field.

This is in the same spirit as #1950.