### PR TITLE
Decouple 'popular tags' filtering on image chooser from search

### DIFF
--- a/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.html
@@ -22,7 +22,7 @@
                     <li class="taglist">
                         <h3>{% trans 'Popular tags' %}</h3>
                         {% for tag in popular_tags %}
-                            <a class="suggested-tag tag" href="{% url 'wagtailimages:index' %}?q={{ tag.name|urlencode }}">{{ tag.name }}</a>
+                            <a class="suggested-tag tag" href="{% url 'wagtailimages:index' %}?tag={{ tag.name|urlencode }}">{{ tag.name }}</a>
                         {% endfor %}
                     </li>
                 {% endif %}

--- a/wagtail/wagtailimages/tests/test_admin_views.py
+++ b/wagtail/wagtailimages/tests/test_admin_views.py
@@ -299,6 +299,24 @@ class TestImageChooserView(TestCase, WagtailTestUtils):
             response = self.get({'p': page})
             self.assertEqual(response.status_code, 200)
 
+    def test_filter_by_tag(self):
+        for i in range(0, 10):
+            image = Image.objects.create(
+                title="Test image %d is even better than the last one" % i,
+                file=get_test_image_file(),
+            )
+            if i % 2 == 0:
+                image.tags.add('even')
+
+        response = self.get({'tag': "even"})
+        self.assertEqual(response.status_code, 200)
+
+        # Results should include images tagged 'even'
+        self.assertContains(response, "Test image 2 is even better")
+
+        # Results should not include images that just have 'even' in the title
+        self.assertNotContains(response, "Test image 3 is even better")
+
 
 class TestImageChooserChosenView(TestCase, WagtailTestUtils):
     def setUp(self):

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -42,16 +42,24 @@ def chooser(request):
     else:
         uploadform = None
 
+    images = Image.objects.order_by('-created_at')
+
     q = None
-    if 'q' in request.GET or 'p' in request.GET:
+    if 'q' in request.GET or 'p' in request.GET or 'tag' in request.GET:
+        # this request is triggered from search, pagination or 'popular tags';
+        # we will just render the results.html fragment
+
+        tag_name = request.GET.get('tag')
+        if tag_name:
+            images = images.filter(tags__name=tag_name)
+
         searchform = SearchForm(request.GET)
         if searchform.is_valid():
             q = searchform.cleaned_data['q']
 
-            images = Image.objects.search(q)
+            images = images.search(q)
             is_searching = True
         else:
-            images = Image.objects.order_by('-created_at')
             is_searching = False
 
         # Pagination
@@ -66,7 +74,6 @@ def chooser(request):
     else:
         searchform = SearchForm()
 
-        images = Image.objects.order_by('-created_at')
         paginator, images = paginate(request, images, per_page=12)
 
     return render_modal_workflow(request, 'wagtailimages/chooser/chooser.html', 'wagtailimages/chooser/chooser.js', {

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -49,10 +49,6 @@ def chooser(request):
         # this request is triggered from search, pagination or 'popular tags';
         # we will just render the results.html fragment
 
-        tag_name = request.GET.get('tag')
-        if tag_name:
-            images = images.filter(tags__name=tag_name)
-
         searchform = SearchForm(request.GET)
         if searchform.is_valid():
             q = searchform.cleaned_data['q']
@@ -61,6 +57,10 @@ def chooser(request):
             is_searching = True
         else:
             is_searching = False
+
+            tag_name = request.GET.get('tag')
+            if tag_name:
+                images = images.filter(tags__name=tag_name)
 
         # Pagination
         paginator, images = paginate(request, images, per_page=12)


### PR DESCRIPTION
Workaround for https://github.com/torchbox/wagtail/issues/278#issuecomment-157817200.

Searching by tag only works under Elasticsearch, so clicking on 'popular tags' is broken
in the default install. As a workaround, add a new 'tag' parameter to the chooser view
that allows us to filter on tags using plain SQL lookup, as a separate operation to search.