### PR TITLE
Move shared URL-building logic into a get_url_parts method; implement Page.get_site

### DIFF
--- a/docs/reference/pages/model_reference.rst
+++ b/docs/reference/pages/model_reference.rst
@@ -95,6 +95,12 @@ In addition to the model fields provided, ``Page`` has many properties and metho
 
     .. autoattribute:: full_url
 
+    .. automethod:: relative_url
+
+    .. automethod:: get_site
+
+    .. automethod:: get_url_parts
+
     .. automethod:: route
 
     .. automethod:: serve

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -687,10 +687,13 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
     def get_url_parts(self):
         """
         Determine the URL for this page and return it as a tuple of
-        (site_id, site_root_url, page_url_relative_to_site_root).
+        ``(site_id, site_root_url, page_url_relative_to_site_root)``.
         Return None if the page is not routable.
 
-        Pages with custom URL routing should override this.
+        This is used internally by the ``full_url``, ``url``, ``relative_url``
+        and ``get_site`` properties and methods; pages with custom URL routing
+        should override this method in order to have those operations return
+        the custom URLs.
         """
         for (site_id, root_path, root_url) in Site.get_site_root_paths():
             if self.url_path.startswith(root_path):
@@ -754,6 +757,10 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
             return root_url + page_path
 
     def get_site(self):
+        """
+        Return the Site object that this page belongs to.
+        """
+
         url_parts = self.get_url_parts()
 
         if url_parts is None:

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -700,11 +700,13 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
     @property
     def full_url(self):
         """Return the full URL (including protocol / domain) to this page, or None if it is not routable"""
-        try:
-            site_id, root_url, page_path = self.get_url_parts()
-        except TypeError:
-            # get_url_parts returned None; page is not routable
-            return None
+        url_parts = self.get_url_parts()
+
+        if url_parts is None:
+            # page is not routable
+            return
+
+        site_id, root_url, page_path = url_parts
 
         return root_url + page_path
 
@@ -718,11 +720,13 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         same domain), and the full URL (with domain) if not.
         Return None if the page is not routable.
         """
-        try:
-            site_id, root_url, page_path = self.get_url_parts()
-        except TypeError:
-            # get_url_parts returned None; page is not routable
-            return None
+        url_parts = self.get_url_parts()
+
+        if url_parts is None:
+            # page is not routable
+            return
+
+        site_id, root_url, page_path = url_parts
 
         if len(Site.get_site_root_paths()) == 1:
             # we're only running a single site, so a local URL is sufficient
@@ -736,11 +740,13 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         a local URL if the site matches, or a fully qualified one otherwise.
         Return None if the page is not routable.
         """
-        try:
-            site_id, root_url, page_path = self.get_url_parts()
-        except TypeError:
-            # get_url_parts returned None; page is not routable
-            return None
+        url_parts = self.get_url_parts()
+
+        if url_parts is None:
+            # page is not routable
+            return
+
+        site_id, root_url, page_path = url_parts
 
         if site_id == current_site.id:
             return page_path
@@ -748,11 +754,13 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
             return root_url + page_path
 
     def get_site(self):
-        try:
-            site_id, root_url, page_path = self.get_url_parts()
-        except TypeError:
-            # get_url_parts returned None; page is not routable
-            return None
+        url_parts = self.get_url_parts()
+
+        if url_parts is None:
+            # page is not routable
+            return
+
+        site_id, root_url, page_path = url_parts
 
         return Site.objects.get(id=site_id)
 

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -136,11 +136,19 @@ class TestRouting(TestCase):
         christmas_page = Page.objects.get(url_path='/home/events/christmas/')
 
         # Basic installation only has one site configured, so page.url will return local URLs
+        self.assertEqual(
+            homepage.get_url_parts(),
+            (default_site.id, 'http://localhost', '/')
+        )
         self.assertEqual(homepage.full_url, 'http://localhost/')
         self.assertEqual(homepage.url, '/')
         self.assertEqual(homepage.relative_url(default_site), '/')
         self.assertEqual(homepage.get_site(), default_site)
 
+        self.assertEqual(
+            christmas_page.get_url_parts(),
+            (default_site.id, 'http://localhost', '/events/christmas/')
+        )
         self.assertEqual(christmas_page.full_url, 'http://localhost/events/christmas/')
         self.assertEqual(christmas_page.url, '/events/christmas/')
         self.assertEqual(christmas_page.relative_url(default_site), '/events/christmas/')
@@ -150,6 +158,7 @@ class TestRouting(TestCase):
         root = Page.objects.get(url_path='/')
         default_site = Site.objects.get(is_default_site=True)
 
+        self.assertEqual(root.get_url_parts(), None)
         self.assertEqual(root.full_url, None)
         self.assertEqual(root.url, None)
         self.assertEqual(root.relative_url(default_site), None)
@@ -165,12 +174,20 @@ class TestRouting(TestCase):
 
         # with multiple sites, page.url will return full URLs to ensure that
         # they work across sites
+        self.assertEqual(
+            homepage.get_url_parts(),
+            (default_site.id, 'http://localhost', '/')
+        )
         self.assertEqual(homepage.full_url, 'http://localhost/')
         self.assertEqual(homepage.url, 'http://localhost/')
         self.assertEqual(homepage.relative_url(default_site), '/')
         self.assertEqual(homepage.relative_url(events_site), 'http://localhost/')
         self.assertEqual(homepage.get_site(), default_site)
 
+        self.assertEqual(
+            christmas_page.get_url_parts(),
+            (events_site.id, 'http://events.example.com', '/christmas/')
+        )
         self.assertEqual(christmas_page.full_url, 'http://events.example.com/christmas/')
         self.assertEqual(christmas_page.url, 'http://events.example.com/christmas/')
         self.assertEqual(christmas_page.relative_url(default_site), 'http://events.example.com/christmas/')
@@ -184,11 +201,19 @@ class TestRouting(TestCase):
         christmas_page = Page.objects.get(url_path='/home/events/christmas/')
 
         # Basic installation only has one site configured, so page.url will return local URLs
+        self.assertEqual(
+            homepage.get_url_parts(),
+            (default_site.id, 'http://localhost', '/site/')
+        )
         self.assertEqual(homepage.full_url, 'http://localhost/site/')
         self.assertEqual(homepage.url, '/site/')
         self.assertEqual(homepage.relative_url(default_site), '/site/')
         self.assertEqual(homepage.get_site(), default_site)
 
+        self.assertEqual(
+            christmas_page.get_url_parts(),
+            (default_site.id, 'http://localhost', '/site/events/christmas/')
+        )
         self.assertEqual(christmas_page.full_url, 'http://localhost/site/events/christmas/')
         self.assertEqual(christmas_page.url, '/site/events/christmas/')
         self.assertEqual(christmas_page.relative_url(default_site), '/site/events/christmas/')

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -139,10 +139,12 @@ class TestRouting(TestCase):
         self.assertEqual(homepage.full_url, 'http://localhost/')
         self.assertEqual(homepage.url, '/')
         self.assertEqual(homepage.relative_url(default_site), '/')
+        self.assertEqual(homepage.get_site(), default_site)
 
         self.assertEqual(christmas_page.full_url, 'http://localhost/events/christmas/')
         self.assertEqual(christmas_page.url, '/events/christmas/')
         self.assertEqual(christmas_page.relative_url(default_site), '/events/christmas/')
+        self.assertEqual(christmas_page.get_site(), default_site)
 
     def test_page_with_no_url(self):
         root = Page.objects.get(url_path='/')
@@ -151,6 +153,7 @@ class TestRouting(TestCase):
         self.assertEqual(root.full_url, None)
         self.assertEqual(root.url, None)
         self.assertEqual(root.relative_url(default_site), None)
+        self.assertEqual(root.get_site(), None)
 
     def test_urls_with_multiple_sites(self):
         events_page = Page.objects.get(url_path='/home/events/')
@@ -166,11 +169,13 @@ class TestRouting(TestCase):
         self.assertEqual(homepage.url, 'http://localhost/')
         self.assertEqual(homepage.relative_url(default_site), '/')
         self.assertEqual(homepage.relative_url(events_site), 'http://localhost/')
+        self.assertEqual(homepage.get_site(), default_site)
 
         self.assertEqual(christmas_page.full_url, 'http://events.example.com/christmas/')
         self.assertEqual(christmas_page.url, 'http://events.example.com/christmas/')
         self.assertEqual(christmas_page.relative_url(default_site), 'http://events.example.com/christmas/')
         self.assertEqual(christmas_page.relative_url(events_site), '/christmas/')
+        self.assertEqual(christmas_page.get_site(), events_site)
 
     @override_settings(ROOT_URLCONF='wagtail.tests.non_root_urls')
     def test_urls_with_non_root_urlconf(self):
@@ -182,10 +187,12 @@ class TestRouting(TestCase):
         self.assertEqual(homepage.full_url, 'http://localhost/site/')
         self.assertEqual(homepage.url, '/site/')
         self.assertEqual(homepage.relative_url(default_site), '/site/')
+        self.assertEqual(homepage.get_site(), default_site)
 
         self.assertEqual(christmas_page.full_url, 'http://localhost/site/events/christmas/')
         self.assertEqual(christmas_page.url, '/site/events/christmas/')
         self.assertEqual(christmas_page.relative_url(default_site), '/site/events/christmas/')
+        self.assertEqual(christmas_page.get_site(), default_site)
 
     def test_request_routing(self):
         homepage = Page.objects.get(url_path='/home/')


### PR DESCRIPTION
The `url`, `relative_url` and `full_url` methods of Page all duplicated the logic for matching a page to a site and constructing a relative page path - meaning that a page model with custom URL routing (e.g. blog posts with date-based URLs) would have to override all three of them. This PR moves the shared logic to a new `get_url_parts` method, which returns a tuple of (site_id, site_root_url, relative_page_path); subclasses now only have to override this one method.

In addition, it implements a `get_site` method as requested in #693 (which we would otherwise have to do as a fourth copy of the same logic...)

Fixes #693