### PR TITLE
Add missing blocktrans to InlinePanel's add-button

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/edit_handlers/inline_panel.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/edit_handlers/inline_panel.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% load wagtailadmin_tags  %}
 
 {{ self.formset.management_form }}
@@ -23,5 +24,6 @@
 </script>
 
 <p class="add">
-    <a class="button bicolor icon icon-plus" id="id_{{ self.formset.prefix }}-ADD" value="Add">Add {{ self.heading|lower }}</a>
+    <a class="button bicolor icon icon-plus" id="id_{{ self.formset.prefix }}-ADD" value="Add">
+        {% blocktrans with heading=self.heading|lower %}Add {{ heading }}{% endblocktrans %}</a>
 </p>


### PR DESCRIPTION
Right now, one can set the label of a model to a localized string but the add button still displays the string "Add <translated label>" nonetheless. 