### PR TITLE
Workaround issue where the image listing view goes blank if one image failed to render

### DIFF
--- a/wagtail/wagtailimages/templates/wagtailimages/images/results.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/results.html
@@ -19,7 +19,7 @@
         {% for image in images %}
             <li>
                 <a class="image-choice" href="{% url 'wagtailimages:edit' image.id %}">
-                    <div class="image">{% image image max-165x165 class="show-transparency" %}</div>
+                    {% include "wagtailimages/images/results_image.html" %}
                     <h3>{{ image.title|ellipsistrim:60 }}</h3>
                 </a>
             </li>

--- a/wagtail/wagtailimages/templates/wagtailimages/images/results_image.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/results_image.html
@@ -1,3 +1,18 @@
+{% comment %}
+ Separated out of results.html to prevent invalid images from crashing the entire
+ images listing. (issue #1805)
+
+ If an error is raised inside a template include, the error is caught by the
+ calling {% include %} tag and the contents blanked out.
+
+ This behaviour caused a confusing error on the images listing view where it
+ would go blank if one of the images was invalid.
+
+ Separating the image rendering code into this file allows us to limit Django's
+ crash/blanking behaviour to a single image so the listing can still be used when
+ the issue occurs.
+{% endcomment %}
+
 {% load wagtailimages_tags wagtailadmin_tags %}
 {% load i18n %}
 

--- a/wagtail/wagtailimages/templates/wagtailimages/images/results_image.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/results_image.html
@@ -1,0 +1,4 @@
+{% load wagtailimages_tags wagtailadmin_tags %}
+{% load i18n %}
+
+<div class="image">{% image image max-165x165 class="show-transparency" %}</div>

--- a/wagtail/wagtailimages/templates/wagtailimages/images/results_image.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/results_image.html
@@ -13,7 +13,6 @@
  the issue occurs.
 {% endcomment %}
 
-{% load wagtailimages_tags wagtailadmin_tags %}
-{% load i18n %}
+{% load wagtailimages_tags %}
 
 <div class="image">{% image image max-165x165 class="show-transparency" %}</div>


### PR DESCRIPTION
This replaces #2025. I've added a comment to the new template explaining its purpose

Fixes #1805 