### PR TITLE
Make "Hello" part of notification emails use user's username if we don't know their real name

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/notifications/base_notification.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/notifications/base_notification.html
@@ -1,4 +1,4 @@
 {% load i18n %}{% block subject %}{% endblock %}
-{% block greeting %}{% trans "Hello" %} {{ user.get_short_name }},{% endblock %}
+{% block greeting %}{% trans "Hello" %} {{ user.get_short_name|default:user.get_username }},{% endblock %}
 {% block notification %}{% endblock %}
 {% trans "Edit your notification preferences here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_account_notification_preferences' %}


### PR DESCRIPTION
Fixes #2037