### PR TITLE
Use an dictionary for StreamField errors

### DIFF
--- a/wagtail/wagtailcore/blocks/stream_block.py
+++ b/wagtail/wagtailcore/blocks/stream_block.py
@@ -107,21 +107,20 @@ class BaseStreamBlock(Block):
         return "StreamBlock(%s)" % js_dict(opts)
 
     def render_form(self, value, prefix='', errors=None):
+        error_dict = {}
         if errors:
             if len(errors) > 1:
                 # We rely on ListBlock.clean throwing a single ValidationError with a specially crafted
                 # 'params' attribute that we can pull apart and distribute to the child blocks
                 raise TypeError('ListBlock.render_form unexpectedly received multiple errors')
-            error_list = errors.as_data()[0].params
-        else:
-            error_list = None
+            error_dict = errors.as_data()[0].params
 
         # drop any child values that are an unrecognised block type
         valid_children = [child for child in value if child.block_type in self.child_blocks]
 
         list_members_html = [
             self.render_list_member(child.block_type, child.value, "%s-%d" % (prefix, i), i,
-                                    errors=error_list[i] if error_list else None)
+                                    errors=error_dict.get(i))
             for (i, child) in enumerate(valid_children)
         ]
 
@@ -160,18 +159,16 @@ class BaseStreamBlock(Block):
 
     def clean(self, value):
         cleaned_data = []
-        errors = []
-        for child in value:  # child is a BoundBlock instance
+        errors = {}
+        for i, child in enumerate(value):  # child is a BoundBlock instance
             try:
                 cleaned_data.append(
                     (child.block.name, child.block.clean(child.value))
                 )
             except ValidationError as e:
-                errors.append(ErrorList([e]))
-            else:
-                errors.append(None)
+                errors[i] = ErrorList([e])
 
-        if any(errors):
+        if errors:
             # The message here is arbitrary - outputting error messages is delegated to the child blocks,
             # which only involves the 'params' list
             raise ValidationError('Validation error in StreamBlock', params=errors)

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -1239,6 +1239,38 @@ class TestStreamBlock(unittest.TestCase):
             html
         )
 
+    def test_validation_errors(self):
+        class ValidatedBlock(blocks.StreamBlock):
+            char = blocks.CharBlock()
+            url = blocks.URLBlock()
+        block = ValidatedBlock()
+
+        value = [
+            blocks.BoundBlock(
+                block=block.child_blocks['char'],
+                value='',
+            ),
+            blocks.BoundBlock(
+                block=block.child_blocks['char'],
+                value='foo',
+            ),
+            blocks.BoundBlock(
+                block=block.child_blocks['url'],
+                value='http://example.com/',
+            ),
+            blocks.BoundBlock(
+                block=block.child_blocks['url'],
+                value='not a url',
+            ),
+        ]
+
+        with self.assertRaises(ValidationError) as catcher:
+            block.clean(value)
+        self.assertEqual(catcher.exception.params, {
+            0: ['This field is required.'],
+            3: ['Enter a valid URL.'],
+        })
+
     def test_html_declarations(self):
         class ArticleBlock(blocks.StreamBlock):
             heading = blocks.CharBlock()


### PR DESCRIPTION
Instead of filling an array with `None` to indicate no errors, a dictionary is only set when there is an actual error. This will allow future functionality for errors to be added to the StreamField itself, rather than a block, similar to adding errors to a form rather than a specific field.