### PR TITLE
Remove unnecessary dirs on .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,9 +5,7 @@ branch = True
 source = wagtail
 
 omit =
-    */south_migrations/*
     */migrations/*
-    wagtail/vendor/*
 
 
 [report]


### PR DESCRIPTION
Remove south_migrations and vendors , those dirs are not used anymore