### PR TITLE
[RFC] Admin modules

### DIFF
--- a/wagtail/wagtailadmin/modules/__init__.py
+++ b/wagtail/wagtailadmin/modules/__init__.py
@@ -1,0 +1,21 @@
+from django.conf.urls import url, include
+
+from wagtail.wagtailcore import hooks
+
+
+def register_modules():
+    for fn in hooks.get_hooks('register_admin_module'):
+        module = fn()
+
+        if module:
+            urlpatterns = module.get_urlpatterns()
+
+            if urlpatterns:
+                @hooks.register('register_admin_urls')
+                def register_admin_urls():
+                    return  [
+                        url(
+                            r'^{}/'.format(module.name),
+                            include(urlpatterns, app_name=module.name, namespace=module.name)
+                        ),
+                    ]

--- a/wagtail/wagtailadmin/modules/base.py
+++ b/wagtail/wagtailadmin/modules/base.py
@@ -1,0 +1,9 @@
+class Module(object):
+    def __init__(self, name, **kwargs):
+        self.name = name
+
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def get_urlpatterns(self):
+        return []

--- a/wagtail/wagtailadmin/modules/model.py
+++ b/wagtail/wagtailadmin/modules/model.py
@@ -1,0 +1,84 @@
+from django.conf.urls import url
+from django.utils.translation import ugettext as _, ugettext_lazy as __
+from django.forms.models import modelform_factory
+
+from .base import Module
+
+from wagtail.wagtailadmin.views import generic
+
+
+class ModelModule(Module):
+    icon = ""
+
+    index_view_class = generic.IndexView
+    add_view_class = generic.CreateView
+    edit_view_class = generic.EditView
+    delete_view_class = generic.DeleteView
+
+    def get_url_name(self, view_name):
+        return self.name + ':' + view_name
+
+    def get_template_name(self, view_name):
+        return self.name + '/' + view_name + '.html'
+
+    @property
+    def index_view(self):
+        return self.index_view_class.as_view(
+            model=self.model,
+            template_name=self.get_template_name('index'),
+            index_url_name=self.get_url_name('index'),
+            add_url_name=self.get_url_name('add'),
+            edit_url_name=self.get_url_name('edit'),
+            header_icon=self.icon,
+        )
+
+    @property
+    def add_view(self):
+        return self.add_view_class.as_view(
+            model=self.model,
+            form_class=self.get_form_class(),
+            template_name=self.get_template_name('create'),
+            index_url_name=self.get_url_name('index'),
+            add_url_name=self.get_url_name('add'),
+            edit_url_name=self.get_url_name('edit'),
+            header_icon=self.icon,
+        )
+
+    @property
+    def edit_view(self):
+        return self.edit_view_class.as_view(
+            model=self.model,
+            form_class=self.get_form_class(for_update=True),
+            template_name=self.get_template_name('edit'),
+            index_url_name=self.get_url_name('index'),
+            edit_url_name=self.get_url_name('edit'),
+            delete_url_name=self.get_url_name('delete'),
+            header_icon=self.icon,
+        )
+
+    @property
+    def delete_view(self):
+        return self.delete_view_class.as_view(
+            model=self.model,
+            index_url_name=self.get_url_name('index'),
+            delete_url_name=self.get_url_name('delete'),
+            header_icon=self.icon,
+        )
+
+    def formfield_for_dbfield(self, db_field, **kwargs):
+        return db_field.formfield(**kwargs)
+
+    def get_form_class(self, for_update=False):
+        return modelform_factory(
+            self.model,
+            formfield_callback=self.formfield_for_dbfield,
+            fields='__all__'
+        )
+
+    def get_urlpatterns(self):
+        return [
+            url(r'^$', self.index_view, name='index'),
+            url(r'^new/$', self.add_view, name='add'),
+            url(r'^(\d+)/$', self.edit_view, name='edit'),
+            url(r'^(\d+)/delete/$', self.delete_view, name='delete'),
+        ]

--- a/wagtail/wagtailadmin/urls/__init__.py
+++ b/wagtail/wagtailadmin/urls/__init__.py
@@ -5,8 +5,12 @@ from django.views.decorators.cache import cache_control
 from wagtail.wagtailadmin.urls import pages as wagtailadmin_pages_urls
 from wagtail.wagtailadmin.urls import password_reset as wagtailadmin_password_reset_urls
 from wagtail.wagtailadmin.views import account, chooser, home, pages, tags, userbar
+from wagtail.wagtailadmin.modules import register_modules
 from wagtail.wagtailcore import hooks
 from wagtail.utils.urlpatterns import decorate_urlpatterns
+
+
+register_modules()
 
 
 urlpatterns = [

--- a/wagtail/wagtailadmin/views/generic.py
+++ b/wagtail/wagtailadmin/views/generic.py
@@ -38,7 +38,13 @@ class PermissionCheckedMixin(object):
 
 
 class IndexView(PermissionCheckedMixin, View):
+    model = None
+    header_icon = ''
+    index_url_name = None
+    add_url_name = None
+    edit_url_name = None
     context_object_name = None
+    template_name = None
 
     def get_queryset(self):
         return self.model.objects.all()
@@ -58,6 +64,12 @@ class IndexView(PermissionCheckedMixin, View):
 
 
 class CreateView(PermissionCheckedMixin, View):
+    model = None
+    form_class = None
+    header_icon = ''
+    index_url_name = None
+    add_url_name = None
+    edit_url_name = None
     template_name = 'wagtailadmin/generic/create.html'
 
     def get_add_url(self):
@@ -87,6 +99,12 @@ class CreateView(PermissionCheckedMixin, View):
 
 
 class EditView(PermissionCheckedMixin, View):
+    model = None
+    form_class = None
+    header_icon = ''
+    index_url_name = None
+    edit_url_name = None
+    delete_url_name = None
     page_title = __("Editing")
     context_object_name = None
     template_name = 'wagtailadmin/generic/edit.html'
@@ -133,6 +151,10 @@ class EditView(PermissionCheckedMixin, View):
 
 
 class DeleteView(PermissionCheckedMixin, View):
+    model = None
+    header_icon = ''
+    index_url_name = None
+    delete_url_name = None
     template_name = 'wagtailadmin/generic/confirm_delete.html'
     context_object_name = None
 

--- a/wagtail/wagtailsites/urls.py
+++ b/wagtail/wagtailsites/urls.py
@@ -1,4 +1,0 @@
-from .views import SiteModule
-
-
-urlpatterns = SiteModule('wagtailsites').get_urlpatterns()

--- a/wagtail/wagtailsites/urls.py
+++ b/wagtail/wagtailsites/urls.py
@@ -1,9 +1,4 @@
-from django.conf.urls import url
-from wagtail.wagtailsites import views
+from .views import SiteModule
 
-urlpatterns = [
-    url(r'^$', views.Index.as_view(), name='index'),
-    url(r'^add/$', views.Create.as_view(), name='add'),
-    url(r'^(\d+)/$', views.Edit.as_view(), name='edit'),
-    url(r'^(\d+)/delete/$', views.Delete.as_view(), name='delete'),
-]
+
+urlpatterns = SiteModule('wagtailsites').get_urlpatterns()

--- a/wagtail/wagtailsites/views.py
+++ b/wagtail/wagtailsites/views.py
@@ -2,55 +2,51 @@ from django.utils.translation import ugettext_lazy as __
 
 from wagtail.wagtailcore.models import Site
 from wagtail.wagtailsites.forms import SiteForm
-from wagtail.wagtailadmin.views.generic import IndexView, CreateView, EditView, DeleteView
+from wagtail.wagtailadmin.views import generic
+from wagtail.wagtailadmin.modules.model import ModelModule
 
 
-class Index(IndexView):
+class IndexView(generic.IndexView):
     any_permission_required = ['wagtailcore.add_site', 'wagtailcore.change_site', 'wagtailcore.delete_site']
-    model = Site
     context_object_name = 'sites'
-    template_name = 'wagtailsites/index.html'
-    add_url_name = 'wagtailsites:add'
     add_permission_name = 'wagtailcore.add_site'
     page_title = __("Sites")
     add_item_label = __("Add a site")
-    header_icon = 'site'
 
 
-class Create(CreateView):
+class CreateView(generic.CreateView):
     permission_required = 'wagtailcore.add_site'
-    form_class = SiteForm
     page_title = __("Add site")
     success_message = __("Site '{0}' created.")
-    add_url_name = 'wagtailsites:add'
-    edit_url_name = 'wagtailsites:edit'
-    index_url_name = 'wagtailsites:index'
-    template_name = 'wagtailsites/create.html'
-    header_icon = 'site'
 
 
-class Edit(EditView):
+class EditView(generic.EditView):
     permission_required = 'wagtailcore.change_site'
-    model = Site
-    form_class = SiteForm
     success_message = __("Site '{0}' updated.")
     error_message = __("The site could not be saved due to errors.")
     delete_item_label = __("Delete site")
-    edit_url_name = 'wagtailsites:edit'
-    index_url_name = 'wagtailsites:index'
-    delete_url_name = 'wagtailsites:delete'
     delete_permission_name = 'wagtailcore.delete_site'
     context_object_name = 'site'
-    template_name = 'wagtailsites/edit.html'
-    header_icon = 'site'
 
 
-class Delete(DeleteView):
+class DeleteView(generic.DeleteView):
     permission_required = 'wagtailcore.delete_site'
-    model = Site
     success_message = __("Site '{0}' deleted.")
-    index_url_name = 'wagtailsites:index'
-    delete_url_name = 'wagtailsites:delete'
     page_title = __("Delete site")
     confirmation_message = __("Are you sure you want to delete this site?")
-    header_icon = 'site'
+
+
+class SiteModule(ModelModule):
+    icon = 'site'
+    model = Site
+
+    index_view_class = IndexView
+    add_view_class = CreateView
+    edit_view_class = EditView
+    delete_view_class = DeleteView
+
+    def get_form_class(self, for_update=False):
+        return SiteForm
+
+
+module = SiteModule('wagtailsites')

--- a/wagtail/wagtailsites/wagtail_hooks.py
+++ b/wagtail/wagtailsites/wagtail_hooks.py
@@ -6,14 +6,12 @@ from django.contrib.auth.models import Permission
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailadmin.menu import MenuItem
 
-from wagtail.wagtailsites import urls
+from .views import SiteModule
 
 
-@hooks.register('register_admin_urls')
-def register_admin_urls():
-    return [
-        url(r'^sites/', include(urls, app_name='wagtailsites', namespace='wagtailsites')),
-    ]
+@hooks.register('register_admin_module')
+def register_admin_module():
+    return SiteModule('wagtailsites')
 
 
 class SitesMenuItem(MenuItem):


### PR DESCRIPTION
This PR reimplements my old admin modules PR #890 for recent versions of Wagtail (using the new namespaced URLs and generic views features).

The idea is to build the admin site up using "modules". These provide a url config, menu items, permissions and other things for Wagtail. Modules are all class based and are easy to subclass.

I think there's a few good reasons for modularising the admin interface like this:
 - Reduces duplicated view code
 - Makes it easier to add/remove/modify/duplicate sections of the admin
 - Moves model view permission logic to a higher level (currently each view is responsible for permissions, which is a source of mistakes)
  - Also allows each component of a module (urls, menu item, dashboard panel, etc) to share permission logic

This PR adds modules into Wagtailadmin and refactors the sites section to use one.

To use admin modules to register a model in the admin, just add the following to a ``wagtail_hooks.py`` file:

```python
# app/wagtail_hooks.py
from wagtail.wagtailadmin.modules.model import ModelModule

from .models import MyModel


@hooks.register('register_admin_module')
def register_admin_module():
    return ModelModule('mymodel', model=MyModel, icon='the-icon')
```


TODO:
 - Permission checks
 - Permissions (for the groups interface)
 - Menu items
 - Search areas
 - Dashboard panels