### PR TITLE
Work around Django db_index=True / unique=True bug

### DIFF
--- a/wagtail/wagtailimages/migrations/0005_make_filter_spec_unique.py
+++ b/wagtail/wagtailimages/migrations/0005_make_filter_spec_unique.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='filter',
             name='spec',
-            field=models.CharField(unique=True, max_length=255, db_index=True),
+            field=models.CharField(unique=True, max_length=255),
             preserve_default=True,
         ),
     ]

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -366,7 +366,7 @@ class Filter(models.Model):
     """
 
     # The spec pattern is operation1-var1-var2|operation2-var1
-    spec = models.CharField(max_length=255, db_index=True, unique=True)
+    spec = models.CharField(max_length=255, unique=True)
 
     @cached_property
     def operations(self):


### PR DESCRIPTION
Fixes #2084

Remove redundant db_index flag from Filter.spec field, as a workaround for Django bug https://code.djangoproject.com/ticket/26034