### PR TITLE
z-index audit

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -59,6 +59,10 @@ function makeRichTextEditable(id) {
             $(window).trigger('scroll');
         });
     });
+
+    $(document).on('show.bs.modal', '.modal', function() {
+        richText.trigger('hallodeactivated');
+    });
 }
 
 function insertRichTextDeleteControl(elem) {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
@@ -71,8 +71,9 @@ $thumbnail-width: 130px;
 $menu-width: 180px;
 
 // Z-indexes by type
-$z-indexes:(
-
-    modals,
-    widgetpopups
-)
+$z-indexes: (
+    user-fe-css-trump:  999999, // Ridiculously high one to try and avoid clashes with implementation FE CSS
+    ui-widgets:         300,     // Popups that come from parts of the main UI, such as explorer
+    input-widgets:      200,    // Popups from all input widget. These might occur within modal windows
+    modals:             100    // Modal windows
+);

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
@@ -70,10 +70,10 @@ $font-serif: Roboto Slab, Georgia, serif;
 $thumbnail-width: 130px;
 $menu-width: 180px;
 
-// Z-indexes by type
+// Z-indexes by height
 $z-indexes: (
-    user-fe-css-trump:  999999, // Ridiculously high one to try and avoid clashes with implementation FE CSS
-    ui-widgets:         300,     // Popups that come from parts of the main UI, such as explorer
-    input-widgets:      200,    // Popups from all input widget. These might occur within modal windows
-    modals:             100    // Modal windows
+    user-fe-css-trump: 999999,  // Ridiculously high one to try and avoid clashes with implementation FE CSS
+    ui-widgets: 300,            // Popups that come from parts of the main UI, such as explorer
+    input-widgets: 200,         // Popups from all input widget. These might occur within modal windows
+    modals: 100                 // Modal windows
 );

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
@@ -1,4 +1,4 @@
-// paths 
+// paths
 
 // We can't use absolute paths here, because those are dependent on Django's
 // STATIC_URL setting. However, django-compressor consistently places the compiled
@@ -69,3 +69,10 @@ $font-serif: Roboto Slab, Georgia, serif;
 // misc sizing
 $thumbnail-width: 130px;
 $menu-width: 180px;
+
+// Z-indexes by type
+$z-indexes:(
+
+    modals,
+    widgetpopups
+)

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
@@ -73,7 +73,9 @@ $menu-width: 180px;
 // Z-indexes by height
 $z-indexes: (
     user-fe-css-trump: 999999,  // Ridiculously high one to try and avoid clashes with implementation FE CSS
-    ui-widgets: 300,            // Popups that come from parts of the main UI, such as explorer
+    ui-widgets-high: 400,       // Popups that come from parts of the main UI, such as explorer
+    ui-widgets-low: 300,        // Other widgets that should be higher than all others, just not as high as those above
     input-widgets: 200,         // Popups from all input widget. These might occur within modal windows
-    modals: 100                 // Modal windows
+    modals: 100,                // Modal windows
+    nominal: 1                  // Necessary in rare occasions where DOM order is insufficient, or too high
 );

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_datetimepicker.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_datetimepicker.scss
@@ -6,7 +6,7 @@
     padding-left: 0;
     padding-top: 2px;
     position: absolute;
-    z-index: 5;
+    z-index: map-get($z-indexes, input-widgets);
     box-sizing: border-box;
     display: none;
 
@@ -26,7 +26,7 @@
         border: 0;
     }
 
-    .xdsoft_datepicker, 
+    .xdsoft_datepicker,
     .xdsoft_timepicker {
         display: none;
 
@@ -50,8 +50,8 @@
         text-align: center;
     }
 
-    .xdsoft_next, 
-    .xdsoft_prev, 
+    .xdsoft_next,
+    .xdsoft_prev,
     .xdsoft_today_button {
         background-color: transparent;
         cursor: pointer;
@@ -163,7 +163,6 @@
     .xdsoft_label {
         display: inline;
         position: relative;
-        z-index: 9999;
         margin: 0;
         padding: 5px 3px;
         font-size: 14px;
@@ -184,7 +183,6 @@
             position: absolute;
             right: 0;
             top: 30px;
-            z-index: 101;
             display: none;
             background: $color-white;
             max-height: 160px;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_dropdowns.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_dropdowns.scss
@@ -2,10 +2,10 @@
     @include clearfix();
     position: relative;
 
-    input[type=submit], 
-    input[type=reset], 
-    input[type=button], 
-    button, 
+    input[type=submit],
+    input[type=reset],
+    input[type=button],
+    button,
     .button {
         padding: 0;
         display: block;
@@ -17,8 +17,8 @@
         float: left;
     }
 
-    input[type=submit], 
-    input[type=reset], 
+    input[type=submit],
+    input[type=reset],
     input[type=button],
     button {
         line-height: inherit;
@@ -31,7 +31,7 @@
         overflow: hidden;
         top: 100%;
         left: -2000px;
-        z-index: 500;
+        z-index: map-get($z-indexes, input-widgets);
         opacity: 0;
 
         li {
@@ -71,11 +71,11 @@
             }
         }
 
-        a, 
-        input[type=submit], 
-        input[type=reset], 
-        input[type=button], 
-        .button, 
+        a,
+        input[type=submit],
+        input[type=reset],
+        input[type=button],
+        .button,
         button {
             border-radius: 0;
             font-size: 0.95em;
@@ -117,10 +117,10 @@
         top: auto;
         bottom: 100%;
 
-        li { 
+        li {
             border-width: 0 0 1px;
         }
-    }   
+    }
 
     .dropdown-toggle {
         color: $color-white;
@@ -162,9 +162,9 @@
         }
 
         &.open {
-            > input[type=button], 
-            > input[type=submit], 
-            > button, 
+            > input[type=button],
+            > input[type=submit],
+            > button,
             > .button {
                 border-radius: 3px 3px 0 0;
             }
@@ -178,8 +178,8 @@
     &.dropup.dropdown-button {
         &.open {
             > input[type=button],
-            > input[type=submit], 
-            > button, 
+            > input[type=submit],
+            > button,
             > .button {
                 border-radius: 0 0 3px 3px;
             }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_explorer.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_explorer.scss
@@ -1,8 +1,3 @@
-// min z-index: 500;
-// max z-index: unknown;
-
-$explorer-z-index: 500;
-
 .explorer {
     pointer-events: none;
     width: 100%;
@@ -65,7 +60,6 @@ $explorer-z-index: 500;
 
     .children {
         position: absolute;
-        z-index: $explorer-z-index + 1;
         right: 0;
         top: 0;
         width: 4em;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_formatters.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_formatters.scss
@@ -9,16 +9,6 @@
     width: 50px;
     height: 50px;
 
-    img {
-        border-radius: 100%;
-        position: absolute;
-        z-index: 2;
-        top: 0;
-        left: 0;
-        right: 0;
-        border: 0;
-    }
-
     &:before {
         border-radius: 100%;
         color: $color-grey-3;
@@ -29,11 +19,19 @@
         height: 42px;
         line-height: 42px;
         margin: 2px 0 0;
-        z-index: 1;
         left: 0;
         font-size: 22px;
     }
-   
+
+    img {
+        border-radius: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        border: 0;
+    }
+
     &.small {
         vertical-align: middle;
         margin: 0 0.5em;
@@ -53,7 +51,7 @@
 
     &.avatar-on-dark:before {
         color: $color-grey-2;
-        border-color: $color-grey-2; 
+        border-color: $color-grey-2;
     }
 }
 
@@ -63,7 +61,7 @@
     background-color: #ccc;
     padding: 5px;
 
-    h3, 
+    h3,
     p {
         margin: 0;
     }
@@ -141,7 +139,7 @@ form.status-tag:hover {
 }
 
 .privacy-indicator {
-    .label-private, 
+    .label-private,
     .label-public {
         &:before {
             font-size: 1.5em;
@@ -150,7 +148,7 @@ form.status-tag:hover {
     }
 
     &.public {
-        .label-private { 
+        .label-private {
             display: none;
         }
     }
@@ -205,7 +203,7 @@ a.tag:hover {
     &.loading {
         position: relative;
 
-        &:before, 
+        &:before,
         &:after {
             position: absolute;
             display: block;
@@ -213,7 +211,7 @@ a.tag:hover {
 
         &:before {
             content: '';
-            top: -5px; 
+            top: -5px;
             left: -5px;
             bottom: -5px;
             right: -5px;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_formatters.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_formatters.scss
@@ -215,7 +215,6 @@ a.tag:hover {
             left: -5px;
             bottom: -5px;
             right: -5px;
-            z-index: 1;
             background-color: rgba(255, 255, 255, 0.5);
         }
 
@@ -231,7 +230,6 @@ a.tag:hover {
             -webkit-animation: spin 0.5s infinite linear;
             -moz-animation: spin 0.5s infinite linear;
             content: '1';
-            z-index: 2;
             color: $color-teal;
         }
     }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -1021,6 +1021,10 @@ li.inline:first-child {
     }
 }
 
+.ui-front {
+    z-index: map-get($z-indexes, input-widgets);
+}
+
 // Transitions
 fieldset,
 input,

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -1,9 +1,9 @@
-// These are the generic stylings for forms of any type. 
+// These are the generic stylings for forms of any type.
 // If you're styling something specific to the page editing interface,
 // it probably ought to go in layouts/page-editor.scss
 
 form {
-    ul, 
+    ul,
 
     li {
         list-style-type: none;
@@ -25,7 +25,7 @@ legend {
     @include visuallyhidden();
 }
 
-label, 
+label,
 .label {
     text-transform: none;
     font-weight: bold;
@@ -42,10 +42,10 @@ label,
     }
 }
 
-input, 
-textarea, 
-select, 
-.richtext, 
+input,
+textarea,
+select,
+.richtext,
 .tagit {
     box-sizing: border-box;
     border-radius: 6px;
@@ -70,14 +70,14 @@ select,
         background-color: $color-input-focus;
     }
 
-    &:disabled, 
-    &[disabled], 
-    &:disabled:hover, 
+    &:disabled,
+    &[disabled],
+    &:disabled:hover,
     &[disabled]:hover {
         background-color: inherit;
         cursor: default;
         color: $color-grey-4;
-    }  
+    }
 }
 
 // select boxes
@@ -93,7 +93,6 @@ select,
     // Add select arrow back on browsers where native ui has been removed
     select ~ span:after {
         border-radius: 0 6px 6px 0;
-        z-index: 0;
         position: absolute;
         right: 0;
         top: 1px;
@@ -116,11 +115,11 @@ select,
         }
     }
 
-    
+
 }
 
 // radio and check boxes
-input[type=radio], 
+input[type=radio],
 input[type=checkbox] {
     border-radius: 0;
     cursor: pointer;
@@ -187,13 +186,13 @@ input[type=checkbox]:checked:before {
     color: $color-teal;
 }
 
-// Core button style 
-// Note that these styles include methods to render buttons the same x-browser, described here: 
+// Core button style
+// Note that these styles include methods to render buttons the same x-browser, described here:
 // http: //cbjdigital.com/blog/2010/08/bulletproof_css_input_button_heights
-input[type=submit], 
-input[type=reset], 
-input[type=button], 
-.button, 
+input[type=submit],
+input[type=reset],
+input[type=button],
+.button,
 button {
     border-radius: 3px;
     font-family: Open Sans,Arial,sans-serif;
@@ -269,7 +268,7 @@ button {
         }
     }
 
-    &.no, 
+    &.no,
     &.serious {
         background-color: $color-button-no;
         border: 1px solid $color-button-no;
@@ -309,7 +308,7 @@ button {
             width: 2em;
             line-height: 1.85em;
             height: 100%;
-            text-align: center;    
+            text-align: center;
             background-color: rgba(0, 0, 0, 0.2);
             display: block;
         }
@@ -404,8 +403,8 @@ button {
         }
     }
 
-    &:disabled, 
-    &[disabled], 
+    &:disabled,
+    &[disabled],
     &.disabled {
         background-color: $color-grey-3;
         border-color: $color-grey-3;
@@ -413,8 +412,8 @@ button {
         cursor: default;
     }
 
-    &.button-secondary:disabled, 
-    &.button-secondary[disabled], 
+    &.button-secondary:disabled,
+    &.button-secondary[disabled],
     &.button-secondary.disabled {
         background-color: $color-white;
         border-color: $color-grey-3;
@@ -428,7 +427,7 @@ button {
     @media screen and (min-width: $breakpoint-mobile){
         font-size: 0.95em;
         padding: 0 1.4em;
-        height: 3em; 
+        height: 3em;
 
         &.icon.text-replace {
             width: 2.2rem;
@@ -437,7 +436,7 @@ button {
             &:before {
                 line-height: 2.1em;
             }
-        }   
+        }
 
         &.button-small {
             &.icon.text-replace {
@@ -486,9 +485,9 @@ a.button {
 }
 
 // Special styles to counteract Firefox's completely unwarranted assumptions about button styles
-input[type=submit], 
-input[type=reset], 
-input[type=button], 
+input[type=submit],
+input[type=reset],
+input[type=button],
 button {
     padding: 0 1em;
 
@@ -502,10 +501,10 @@ button {
 .button-group {
     @include clearfix;
 
-    input[type=submit], 
-    input[type=reset], 
-    input[type=button], 
-    .button, 
+    input[type=submit],
+    input[type=reset],
+    input[type=button],
+    .button,
     button {
         border-radius: 0;
         float: left;
@@ -528,10 +527,10 @@ button {
 
     &.button-group-square {
         &,
-        input[type=submit], 
-        input[type=reset], 
-        input[type=button], 
-        .button, 
+        input[type=submit],
+        input[type=reset],
+        input[type=button],
+        .button,
         button {
             border-radius: 0;
         }
@@ -572,7 +571,6 @@ button {
     // Object controls
     .controls {
         position: absolute;
-        z-index: 1;
         right: 1em;
         top: 1em;
         color: $color-white;
@@ -606,7 +604,7 @@ button {
 }
 
 // Other text
-.help, 
+.help,
 .error-message {
     font-size: 0.85em;
     font-weight: normal;
@@ -639,9 +637,9 @@ li.focused > .help {
     font-size: 13px;
 }
 
-.error input, 
-.error textarea, 
-.error select, 
+.error input,
+.error textarea,
+.error select,
 .error .tagit {
     border-color: $color-red;
     background-color: $color-input-error-bg;
@@ -650,7 +648,7 @@ li.focused > .help {
 // Layouts for particular kinds of of fields
 
 // permanently show checkbox/radio help as they have no focus state
-.boolean_field .help, 
+.boolean_field .help,
 .radio .help {
     opacity: 1;
 }
@@ -666,7 +664,7 @@ li.focused > .help {
     .input {
         position: relative;
 
-        &:before, 
+        &:before,
         &:after {
             font-family: wagtail;
             position: absolute;
@@ -685,17 +683,17 @@ li.focused > .help {
         }
     }
 
-    input:not([type=radio]), 
-    input:not([type=checkbox]), 
-    input:not([type=submit]), 
+    input:not([type=radio]),
+    input:not([type=checkbox]),
+    input:not([type=submit]),
     input:not([type=button]) {
         padding-left: 2.5em;
     }
 
-    // smaller fields required slight repositioning of icons 
+    // smaller fields required slight repositioning of icons
     &.field-small {
         .input {
-            &:before, 
+            &:before,
             &:after {
                 font-size: 1.3rem; // REMs are necessary here because IE doesn't treat generated content correctly
                 top: 0.3em;
@@ -771,10 +769,10 @@ li.focused > .help {
 // field sizing and alignment
 
 .field-small {
-    input, 
-    textarea, 
-    select, 
-    .richtext, 
+    input,
+    textarea,
+    select,
+    .richtext,
     .tagit {
         border-radius: 3px;
         padding: 0.4em 1em;
@@ -812,17 +810,17 @@ li.inline .field {
 }
 
 // solve gutter issues of inline fields
-ul.inline li:first-child, 
+ul.inline li:first-child,
 li.inline:first-child {
     margin-left: -$grid-gutter-width / 2;
 }
 
 
-// TODO this chooser style has been made more generic based on two identical methods 
-// for choosing pages and images that were previously included in their own less files 
-// in each app directory (and since deleted). It would be best if an admin 'theme' provided 
-// all the design for a UI in a single place, but should that be a series of overrides to 
-// the css provided from an app? If so, perhaps those two previous less files should be 
+// TODO this chooser style has been made more generic based on two identical methods
+// for choosing pages and images that were previously included in their own less files
+// in each app directory (and since deleted). It would be best if an admin 'theme' provided
+// all the design for a UI in a single place, but should that be a series of overrides to
+// the css provided from an app? If so, perhaps those two previous less files should be
 // re-instated and then overriden here? hmm.
 
 .chooser {
@@ -839,7 +837,7 @@ li.inline:first-child {
         display: block;
     }
 
-    .unchosen, 
+    .unchosen,
     .chosen {
         position: relative;
 
@@ -864,7 +862,7 @@ li.inline:first-child {
     .actions {
         @include clearfix;
         overflow: hidden;
-        
+
         li {
             float: left;
             margin: 0.3em;
@@ -897,7 +895,7 @@ li.inline:first-child {
 }
 
 .page-chooser {
-    .unchosen, 
+    .unchosen,
     .chosen {
         &:before {
             content: 'b';
@@ -906,7 +904,7 @@ li.inline:first-child {
 }
 
 .snippet-chooser {
-    .unchosen, 
+    .unchosen,
     .chosen {
         &:before {
             content: 'D';
@@ -915,7 +913,7 @@ li.inline:first-child {
 }
 
 .document-chooser {
-    .unchosen, 
+    .unchosen,
     .chosen {
         &:before {
             content: 'r';
@@ -924,7 +922,7 @@ li.inline:first-child {
 }
 
 .image-chooser {
-    .unchosen, 
+    .unchosen,
     .chosen {
         &:before {
             content: 'o';
@@ -932,7 +930,7 @@ li.inline:first-child {
     }
 
     .chosen {
-        padding-left: $thumbnail-width;   
+        padding-left: $thumbnail-width;
 
         &:before {
             content: '';
@@ -976,10 +974,6 @@ li.inline:first-child {
 // which get added after the core CSS, and otherweise trump our styles.
 .admin_tag_widget ul.tagit li.tagit-choice-editable {
     padding: 0 23px 0 0;
-}
-
-.ui-front { // provided by jqueryui but not high enough an index
-    z-index: 1000;
 }
 
 .tagit-close {
@@ -1028,17 +1022,17 @@ li.inline:first-child {
 }
 
 // Transitions
-fieldset, 
-input, 
-textarea, 
+fieldset,
+input,
+textarea,
 select {
     @include transition(background-color 0.2s ease);
 }
 
-input[type=submit], 
-input[type=reset], 
-input[type=button], 
-.button, 
+input[type=submit],
+input[type=reset],
+input[type=button],
+.button,
 button {
     @include transition(background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease);
 }
@@ -1086,7 +1080,7 @@ button {
 
     .field-content {
         @include column(10, 0);
-    } 
+    }
 
     .field-col {
         float: left;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_messages.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_messages.scss
@@ -1,11 +1,10 @@
-// Messages are specific to Django's 'Messaging' system which adds messages into the session, 
+// Messages are specific to Django's 'Messaging' system which adds messages into the session,
 // for display on the next page visited. These appear as an animated banner at the top of the page.
 //
 // For inline help text, see typography.scss
 
 .messages {
     position: relative;
-    z-index: 5;
     background-color: $color-grey-1;
 
     .buttons {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_modals.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_modals.scss
@@ -1,9 +1,7 @@
-$zindex-modal-background: 500;
-
 .fade {
     @include transition(opacity .15s linear);
     opacity: 0;
-    
+
     &.in {
         opacity: 1;
     }
@@ -30,7 +28,7 @@ $zindex-modal-background: 500;
     right: 0;
     bottom: 0;
     left: 0;
-    z-index: $zindex-modal-background;
+    z-index: map-get($z-indexes, modals);
 }
 
 // Shell div to position the modal with bottom padding
@@ -39,7 +37,6 @@ $zindex-modal-background: 500;
     margin-left: auto;
     margin-right: auto;
     padding: 0;
-    z-index: ($zindex-modal-background + 10);
     height: 90%;
     width: 85%;
 
@@ -74,9 +71,9 @@ $zindex-modal-background: 500;
     right: 0;
     bottom: 0;
     left: 0;
-    z-index: ($zindex-modal-background - 10);
+    z-index: map-get($z-indexes, modals) - 1;
     background-color: $color-black;
-    
+
     // Fade for backdrop
     &.fade { opacity: 0; }
     &.in { opacity: 0.5; }
@@ -89,7 +86,6 @@ $zindex-modal-background: 500;
     height: 50px;
     top: 10px;
     right: 10px;
-    z-index: 1;
 }
 
 // Where all modal content resides

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_streamfield.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_streamfield.scss
@@ -120,12 +120,12 @@ li.sequence-member {
 }
 
 
-// This horridly specific selector ensures text inputs, rich text fields and textareas 
+// This horridly specific selector ensures text inputs, rich text fields and textareas
 // that are direct children of highest level sequence should be borderless and full-width
 .block_field > .field-content > .input > .sequence-container > .sequence-container-inner > .sequence > .sequence-member > .sequence-member-inner {
     > .widget-text_input input,
     > .widget-rich_text_area .richtext,
-    > .widget-textarea textarea { 
+    > .widget-textarea textarea {
         border: 0;
         padding: 0;
         background-color: transparent;
@@ -142,9 +142,9 @@ li.sequence-member {
     opacity: 0;
     visibility: hidden;
     position: absolute;
-    top: -30px; 
+    top: -30px;
     right: 0;
-    z-index: 1;
+    z-index: map-get($z-indexes, input-widgets);
     overflow: visible;
     background-color: $color-input-focus;
     padding: 0 0 0 1em;
@@ -190,7 +190,7 @@ li.sequence-member {
 
     .disabled {
         display: none;
-    }       
+    }
 }
 
 // list controls are slightly different as they require closer proximity to their associated fields
@@ -208,14 +208,14 @@ li.sequence-member {
     margin-top: 1.5em;
 }
 
-// Menu of other blocks to be added at each position 
+// Menu of other blocks to be added at each position
 .stream-menu {
     @include transition(all 0.2s ease);
     box-shadow: inset 0 0 45px rgba(0, 0, 0, 0.3);
     position: relative;
     background-color: $color-grey-1;
     opacity: 1;
-    z-index: 5;
+    z-index: map-get($z-indexes, input-widgets);
 
     .toggle {
         @include transition(color 0.2s ease);
@@ -230,7 +230,6 @@ li.sequence-member {
         width: 1em;
         height: 1em;
         display: block;
-        z-index: 5;
         color: $color-grey-1;
         background-color: $color-white;
         outline: none;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_streamfield.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_streamfield.scss
@@ -144,7 +144,6 @@ li.sequence-member {
     position: absolute;
     top: -30px;
     right: 0;
-    z-index: map-get($z-indexes, input-widgets);
     overflow: visible;
     background-color: $color-input-focus;
     padding: 0 0 0 1em;
@@ -215,12 +214,12 @@ li.sequence-member {
     position: relative;
     background-color: $color-grey-1;
     opacity: 1;
-    z-index: map-get($z-indexes, input-widgets);
 
     .toggle {
         @include transition(color 0.2s ease);
         border-radius: 50px;
         position: absolute;
+        z-index: map-get($z-indexes, nominal);
         top: -0.5em;
         left: 0;
         right: 0;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_tabs.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_tabs.scss
@@ -40,7 +40,6 @@
             position: absolute;
             right: -0.5em;
             top: -0.5em;
-            z-index: 5;
             min-width: 0.9em;
             color: $color-white;
             background: $color-red;
@@ -93,7 +92,7 @@
 
 @media screen and (min-width: $breakpoint-mobile) {
     .tab-nav {
-        // For cases where tab-nav should merge with header 
+        // For cases where tab-nav should merge with header
         &.merged {
             background-color: $color-header-bg;
         }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -110,6 +110,7 @@ footer {
     box-shadow: 0 0 2px rgba(255, 255, 255, 0.5);
     background: $color-grey-1;
     position: fixed;
+    z-index: map-get($z-indexes, ui-widgets-low);
     bottom: 0;
     padding: 0.5em;
     width: 90%;
@@ -142,6 +143,10 @@ footer {
             white-space: nowrap;
         }
     }
+}
+
+.modal-open footer {
+    z-index: map-get($z-indexes, nominal);
 }
 
 ::-webkit-scrollbar {
@@ -399,7 +404,7 @@ footer {
 
     .explorer,
     .nav-wrapper.submenu-active {
-        z-index: map-get($z-indexes, ui-widgets);
+        z-index: map-get($z-indexes, ui-widgets-high);
     }
 }
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -107,7 +107,7 @@ footer {
     @include transition(bottom 0.5s ease 1s);
     @include row();
     border-radius: 3px 3px 0 0;
-    box-shadow: 0 0 2px rgba(255, 255, 255, 0.5);    
+    box-shadow: 0 0 2px rgba(255, 255, 255, 0.5);
     background: $color-grey-1;
     position: fixed;
     bottom: 0;
@@ -192,7 +192,6 @@ footer {
 
             &:after {
                 right: 0;
-                // z-index: 5;
                 position: absolute;
                 font-family: wagtail;
                 content: 'n';
@@ -264,34 +263,6 @@ footer {
 .nice-padding {
     padding-left: $mobile-nice-padding;
     padding-right: $mobile-nice-padding;
-}
-
-
-// Z-indexes
-.nav-toggle {
-    z-index: 5;
-}
-
-.nav-wrapper {
-    z-index: 2;
-}
-
-// Avoiding a stacking context for the content-wrapper saves us a world
-// of pain when dealing with overlays that are appended to the end of
-// <body>, eg Hallo & calendars. As long as content-wrapper remains floated,
-// the z-index shouldn't be required.
-
-// .content-wrapper {
-    // z-index: 3;
-// }
-
-.nav-submenu {
-    z-index: 6;
-}
-
-footer,
-.logo {
-    z-index: 100;
 }
 
 @media screen and (min-width: $breakpoint-mobile) {
@@ -426,35 +397,9 @@ footer,
         margin-left: 50px;
     }
 
-
-    // Z-indexes
-    .nav-main {
-        li {
-            z-index: 1;
-        }
-
-        .footer {
-            z-index: 2;
-        }
-    }
-
-    .explorer {
-        z-index: $explorer-z-index;
-    }
-
-    .nav-submenu {
-        z-index: $explorer-z-index;
-    }
-
-    // Allows overspill of messages banner onto left menu, but also explorer
-    // to spill over main content
-    .nav-wrapper {
-        z-index: auto;
-    }
-
-    // footer is z-index: 100, so ensure the navigation sits on top of it.
+    .explorer,
     .nav-wrapper.submenu-active {
-        z-index: 200;
+        z-index: map-get($z-indexes, ui-widgets);
     }
 }
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/login.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/login.scss
@@ -5,8 +5,8 @@
 // overrides default nice padding defined in variables.scss
 $desktop-nice-padding: 100px;
 
-html, 
-body, 
+html,
+body,
 .content-wrapper {
     background-color: $color-grey-1;
     color: $color-grey-3;
@@ -102,7 +102,7 @@ form {
 
         .iconfield .input:before {
             display: none;
-        }   
+        }
 
     // Special full-width, one-off fields i.e a single text or textarea input
     .full input {
@@ -128,7 +128,6 @@ form {
 
 .messages {
     margin: 1em 0;
-    z-index: 5;
 
     ul {
         margin: 0;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -54,7 +54,6 @@
     .object-help {
         display: block;
         position: relative;
-        z-index: 1;
         top: 1em;
         padding-right: $grid-gutter-width/2;
         margin-top: 4em;
@@ -95,7 +94,6 @@
         top: 0;
         left: 0;
         right: 0;
-        z-index: 1;
         overflow: hidden;
 
         label {
@@ -108,7 +106,7 @@
             font-size: inherit;
         }
 
-        &:before, 
+        &:before,
         label:before {
             text-shadow: none;
             font-family: wagtail;
@@ -117,7 +115,6 @@
             text-align: center;
             display: block;
             position: absolute;
-            z-index: 2;
             font-size: 2em;
             top: 0;
             line-height: 1.8em;
@@ -299,7 +296,7 @@
         min-height: 41px;
 
         h2 {
-            &:before, 
+            &:before,
             label:before {
                 content: '6';
                 cursor: pointer;
@@ -308,7 +305,7 @@
 
         &.collapsed {
             h2 {
-                &:before, 
+                &:before,
                 label:before {
                     content: '5';
                 }
@@ -318,8 +315,8 @@
 }
 
 // Custom styles that make some fields look more important
-.full input, 
-.full textarea, 
+.full input,
+.full textarea,
 .full .richtext {
     @include nice-padding();
     border-radius: 0;
@@ -338,7 +335,7 @@
 
 // Footer control bar for perfoming actions on the page
 footer .preview {
-    button, 
+    button,
     .button {
         background-color: lighten($color-grey-2, 10%);
         border-color: lighten($color-grey-2, 10%);
@@ -350,9 +347,9 @@ footer .preview {
     }
 
     .dropdown {
-        input[type=button], 
-        input[type=submit], 
-        button, 
+        input[type=button],
+        input[type=submit],
+        button,
         .button {
             background-color: lighten($color-grey-2, 10%);
             border-color: lighten($color-grey-2, 10%);
@@ -363,7 +360,7 @@ footer .preview {
             }
         }
 
-        ul, 
+        ul,
         .dropdown-toggle {
             background-color: lighten($color-grey-2, 10%);
         }
@@ -420,8 +417,8 @@ footer .preview {
                 padding: 3.2em 0 0;
             }
 
-            input, 
-            textarea, 
+            input,
+            textarea,
             .richtext {
                 border-width: 0 1px;
             }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -255,7 +255,6 @@
         .add {
             @include transition(background-color 0.2s ease);
             position: relative;
-            z-index: 2;
             top: 0;
             left: 0;
             width: 3.3em;
@@ -393,7 +392,6 @@ footer .preview {
             @include column(2);
             display: block;
             position: absolute;
-            z-index: 1;
             right: 0;
             top: 1em;
             padding-right: $grid-gutter-width/2;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/preview.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/preview.scss
@@ -24,9 +24,9 @@ body {
     height: 100%;
     width: 100%;
     font-size: 0;
-    z-index: 999999;
+    z-index: map-get($z-indexes, user-fe-css-trump);
     background: $color-white;
-    
+
     &.remove {
         @include transition(all 0.3s ease);
         bottom: -100%;
@@ -61,7 +61,7 @@ body {
         width: 1em;
         animation: spin 0.8s infinite linear;
         -webkit-animation: spin 0.8s infinite linear;
-        -moz-animation: spin 0.8s infinite linear;   
+        -moz-animation: spin 0.8s infinite linear;
     }
 }
 
@@ -69,7 +69,6 @@ body {
     height: 100%;
     width: 100%;
     position: absolute;
-    z-index: 1;
     border: 0;
 }
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/panels/rich-text.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/panels/rich-text.scss
@@ -3,7 +3,7 @@
 
 .hallotoolbar {
     position: absolute;
-    z-index: 5;
+    z-index: map-get($z-indexes, input-widgets);
     margin-top: 4em;
     margin-left: 1.2em;
 
@@ -19,7 +19,7 @@
     margin-left: $mobile-nice-padding;
 }
 
-// stream-field is added to hallotoolbar when invoked on a field within a stream-field 
+// stream-field is added to hallotoolbar when invoked on a field within a stream-field
 .hallotoolbar.stream-field {
     margin-top: -1em;
     margin-left: 0;
@@ -146,11 +146,11 @@
         border-left: 0;
     }
 
-    
+
     // These styles correspond to the image formats defined in wagtailimages/formats.py,
     // so that images displayed in the rich text field receive more or less the same
     // styling that they would receive on the site front-end.
-    // 
+    //
     // Wagtail installations that define their own image formats (in a myapp.image_formats module)
     // should ideally use the insert_editor_css hook to pass in their own custom CSS to have those
     // images render within the rich text area in the same styles that would appear on the front-end.

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/userbar.scss
@@ -3,7 +3,7 @@
 @import 'wagtailadmin/scss/components/icons';
 @import 'wagtailadmin/scss/fonts';
 
-html, 
+html,
 body {
     background-color: transparent;
 }
@@ -106,7 +106,7 @@ li,
 }
 
 // actions which can be accomplished just with a link tag
-a.action, 
+a.action,
 a {
     display: block;
     width: 10em;
@@ -117,8 +117,14 @@ a {
     padding: 0.85em 1em;
 }
 
-// actions which require wrapping a form input
+// actions which require wrapping a form input: currently just moderator submit/reject buttons
 div.action {
+    &:before {
+        position: absolute;
+        top: 0.4em;
+        left: 0.5em;
+    }
+
     input {
         color: $color-white;
         -webkit-font-smoothing: antialiased; // Do not remove!
@@ -130,15 +136,7 @@ div.action {
         padding: 1em;
         width: 10em;
         position: relative;
-        z-index: 1;
         text-align: left;
         padding-left: 3.5em;
-    }
-
-    &:before {
-        position: absolute;
-        top: 0.4em;
-        left: 0.5em;
-        z-index: 0;
     }
 }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/userbar_embed.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/userbar_embed.scss
@@ -1,14 +1,13 @@
+@import 'wagtailadmin/scss/variables';
+
 .wagtail-userbar {
     background: transparent;
     position: fixed;
     top: 0;
     right: 0;
-    z-index: 9000;
+    z-index: map-get($z-indexes, user-fe-css-trump);
     border: 0;
     width: 150px;
     height: 300px;
-    -webkit-transition: opacity 0.2s ease;
-    -moz-transition: opacity 0.2s ease;
-    -o-transition: opacity 0.2s ease;
     transition: opacity 0.2s ease;
 }


### PR DESCRIPTION
Fixes #1958. I think.

Most of this has boiled down to removing z-indexes widely. DOM element order naturally provides most of the implications on Z-index, making many of them unnecessary.
