### PR TITLE
Use translation for the Groups menu item

### DIFF
--- a/wagtail/wagtailusers/wagtail_hooks.py
+++ b/wagtail/wagtailusers/wagtail_hooks.py
@@ -59,7 +59,7 @@ class GroupsMenuItem(MenuItem):
 @hooks.register('register_settings_menu_item')
 def register_groups_menu_item():
     return GroupsMenuItem(
-        ('Groups'),
+        _('Groups'),
         urlresolvers.reverse('wagtailusers_groups:index'),
         classnames='icon icon-group',
         order=601


### PR DESCRIPTION
I think translation for the Groups menu item has been removed by mistake. I return the translation back.