### PR TITLE
Permission policy modules

### DIFF
--- a/wagtail/tests/customuser/models.py
+++ b/wagtail/tests/customuser/models.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import (
 
 class CustomUserManager(BaseUserManager):
     def _create_user(self, username, email, password,
-                     is_staff, is_superuser, **extra_fields):
+                     is_staff, is_superuser, is_active=True, **extra_fields):
         """
         Creates and saves a User with the given username, email and password.
         """
@@ -16,7 +16,7 @@ class CustomUserManager(BaseUserManager):
             raise ValueError('The given username must be set')
         email = self.normalize_email(email)
         user = self.model(username=username, email=email,
-                          is_staff=is_staff, is_active=True,
+                          is_staff=is_staff, is_active=is_active,
                           is_superuser=is_superuser, **extra_fields)
         user.set_password(password)
         user.save(using=self._db)

--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -124,6 +124,27 @@ def any_permission_required(*perms):
     return user_passes_test(test)
 
 
+class PermissionPolicyChecker(object):
+    """
+    Provides a view decorator that enforces the given permission policy,
+    returning the wagtailadmin 'permission denied' response if permission not granted
+    """
+    def __init__(self, policy):
+        self.policy = policy
+
+    def require(self, action):
+        def test(user):
+            return self.policy.user_has_permission(user, action)
+
+        return user_passes_test(test)
+
+    def require_any(self, *actions):
+        def test(user):
+            return self.policy.user_has_any_permission(user, actions)
+
+        return user_passes_test(test)
+
+
 def send_mail(subject, message, recipient_list, from_email=None, **kwargs):
     if not from_email:
         if hasattr(settings, 'WAGTAILADMIN_NOTIFICATION_FROM_EMAIL'):

--- a/wagtail/wagtailadmin/views/generic.py
+++ b/wagtail/wagtailadmin/views/generic.py
@@ -9,36 +9,41 @@ from wagtail.wagtailadmin.utils import permission_denied
 
 class PermissionCheckedMixin(object):
     """
-    Mixin for class-based views to enforce permission checks.
-    Subclasses should set either of the following class properties:
-    * permission_required (a single permission string)
-    * any_permission_required (a list of permission strings - the user must have
+    Mixin for class-based views to enforce permission checks according to
+    a permission policy (see wagtail.wagtailcore.permission_policies).
+
+    To take advantage of this, subclasses should set the class property:
+    * permission_policy (a policy object)
+    and either of:
+    * permission_required (an action name such as 'add', 'change' or 'delete')
+    * any_permission_required (a list of action names - the user must have
       one or more of those permissions)
     """
+    permission_policy = None
     permission_required = None
     any_permission_required = None
 
     def dispatch(self, request, *args, **kwargs):
-        if self.permission_required is not None:
-            if not request.user.has_perm(self.permission_required):
-                return permission_denied(request)
+        if self.permission_policy is not None:
 
-        if self.any_permission_required is not None:
-            has_permission = False
+            if self.permission_required is not None:
+                if not self.permission_policy.user_has_permission(
+                    request.user, self.permission_required
+                ):
+                    return permission_denied(request)
 
-            for perm in self.any_permission_required:
-                if request.user.has_perm(perm):
-                    has_permission = True
-                    break
-
-            if not has_permission:
-                return permission_denied(request)
+            if self.any_permission_required is not None:
+                if not self.permission_policy.user_has_any_permission(
+                    request.user, self.any_permission_required
+                ):
+                    return permission_denied(request)
 
         return super(PermissionCheckedMixin, self).dispatch(request, *args, **kwargs)
 
 
 class IndexView(PermissionCheckedMixin, View):
     context_object_name = None
+    any_permission_required = ['add', 'change', 'delete']
 
     def get_queryset(self):
         return self.model.objects.all()
@@ -49,7 +54,10 @@ class IndexView(PermissionCheckedMixin, View):
         context = {
             'view': self,
             'object_list': object_list,
-            'can_add': self.request.user.has_perm(self.add_permission_name),
+            'can_add': (
+                self.permission_policy is None
+                or self.permission_policy.user_has_permission(self.request.user, 'add')
+            ),
         }
         if self.context_object_name:
             context[self.context_object_name] = object_list
@@ -59,6 +67,7 @@ class IndexView(PermissionCheckedMixin, View):
 
 class CreateView(PermissionCheckedMixin, View):
     template_name = 'wagtailadmin/generic/create.html'
+    permission_required = 'add'
 
     def get_add_url(self):
         return reverse(self.add_url_name)
@@ -90,6 +99,7 @@ class EditView(PermissionCheckedMixin, View):
     page_title = __("Editing")
     context_object_name = None
     template_name = 'wagtailadmin/generic/edit.html'
+    permission_required = 'change'
 
     def get_page_subtitle(self):
         return str(self.instance)
@@ -124,7 +134,10 @@ class EditView(PermissionCheckedMixin, View):
             'view': self,
             'object': self.instance,
             'form': self.form,
-            'can_delete': self.request.user.has_perm(self.delete_permission_name),
+            'can_delete': (
+                self.permission_policy is None
+                or self.permission_policy.user_has_permission(self.request.user, 'delete')
+            ),
         }
         if self.context_object_name:
             context[self.context_object_name] = self.instance
@@ -135,6 +148,7 @@ class EditView(PermissionCheckedMixin, View):
 class DeleteView(PermissionCheckedMixin, View):
     template_name = 'wagtailadmin/generic/confirm_delete.html'
     context_object_name = None
+    permission_required = 'delete'
 
     def get_page_subtitle(self):
         return str(self.instance)

--- a/wagtail/wagtailcore/permission_policies.py
+++ b/wagtail/wagtailcore/permission_policies.py
@@ -1,0 +1,351 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
+from django.db.models import Q
+from django.utils.functional import cached_property
+
+
+class BasePermissionPolicy(object):
+    """
+    A 'permission policy' is an object that handles all decisions about the actions
+    users are allowed to perform on a given model. The mechanism by which it does this
+    is arbitrary, and may or may not involve the django.contrib.auth Permission model;
+    it could be as simple as "allow all users to do everything".
+
+    In this way, admin apps can change their permission-handling logic just by swapping
+    to a different policy object, rather than having that logic spread across numerous
+    view functions.
+
+    BasePermissionPolicy is an abstract class that all permission policies inherit from.
+    The only method that subclasses need to implement is users_with_any_permission;
+    all other methods can be derived from that (but in practice, subclasses will probably
+    want to override additional methods, either for efficiency or to implement more
+    fine-grained permission logic).
+    """
+
+    def __init__(self, model):
+        self.model = model
+
+    # Basic user permission tests. Most policies are expected to override these,
+    # since the default implementation is to query the set of permitted users
+    # (which is pretty inefficient).
+
+    def user_has_permission(self, user, action):
+        """
+        Return whether the given user has permission to perform the given action
+        on some or all instances of this model
+        """
+        return (user in self.users_with_permission(action))
+
+    def user_has_any_permission(self, user, actions):
+        """
+        Return whether the given user has permission to perform any of the given actions
+        on some or all instances of this model
+        """
+        return any(self.user_has_permission(user, action) for action in actions)
+
+    # Operations for retrieving a list of users matching the permission criteria.
+    # All policies must implement, at minimum, users_with_any_permission.
+
+    def users_with_any_permission(self, actions):
+        """
+        Return a queryset of users who have permission to perform any of the given actions
+        on some or all instances of this model
+        """
+        raise NotImplementedError
+
+    def users_with_permission(self, action):
+        """
+        Return a queryset of users who have permission to perform the given action on
+        some or all instances of this model
+        """
+        return self.users_with_any_permission([action])
+
+    # Per-instance permission tests. In the simplest cases - corresponding to the
+    # basic Django permission model - permissions are enforced on a per-model basis
+    # and so these methods can simply defer to the per-model tests. Policies that
+    # require per-instance permission logic must override, at minimum:
+    #     user_has_permission_for_instance
+    #     instances_user_has_any_permission_for
+    #     users_with_any_permission_for_instance
+
+    def user_has_permission_for_instance(self, user, action, instance):
+        """
+        Return whether the given user has permission to perform the given action on the
+        given model instance
+        """
+        return self.user_has_permission(user, action)
+
+    def user_has_any_permission_for_instance(self, user, actions, instance):
+        """
+        Return whether the given user has permission to perform any of the given actions
+        on the given model instance
+        """
+        return any(
+            self.user_has_permission_for_instance(user, action, instance)
+            for action in actions
+        )
+
+    def instances_user_has_any_permission_for(self, user, actions):
+        """
+        Return a queryset of all instances of this model for which the given user has
+        permission to perform any of the given actions
+        """
+        if self.user_has_any_permission(user, actions):
+            return self.model.objects.all()
+        else:
+            return self.model.objects.none()
+
+    def instances_user_has_permission_for(self, user, action):
+        """
+        Return a queryset of all instances of this model for which the given user has
+        permission to perform the given action
+        """
+        return self.instances_user_has_any_permission_for(user, [action])
+
+    def users_with_any_permission_for_instance(self, actions, instance):
+        """
+        Return a queryset of all users who have permission to perform any of the given
+        actions on the given model instance
+        """
+        return self.users_with_any_permission(actions)
+
+    def users_with_permission_for_instance(self, action, instance):
+        return self.users_with_any_permission_for_instance([action], instance)
+
+
+class BlanketPermissionPolicy(BasePermissionPolicy):
+    """
+    A permission policy that gives everyone (including anonymous users)
+    full permission over the given model
+    """
+    def user_has_permission(self, user, action):
+        return True
+
+    def user_has_any_permission(self, user, actions):
+        return True
+
+    def users_with_any_permission(self, actions):
+        # Here we filter out inactive users from the results, even though inactive users
+        # - and for that matter anonymous users - still have permission according to the
+        # user_has_permission method. This is appropriate because, for most applications,
+        # setting is_active=False is equivalent to deleting the user account; you would
+        # not want these accounts to appear in, for example, a dropdown of users to
+        # assign a task to. The result here could never be completely logically correct
+        # (because it will not include anonymous users), so as the next best thing we
+        # return the "least surprise" result.
+        return get_user_model().objects.filter(is_active=True)
+
+    def users_with_permission(self, action):
+        return get_user_model().objects.filter(is_active=True)
+
+
+class AuthenticationOnlyPermissionPolicy(BasePermissionPolicy):
+    """
+    A permission policy that gives all active authenticated users
+    full permission over the given model
+    """
+    def user_has_permission(self, user, action):
+        return user.is_authenticated() and user.is_active
+
+    def user_has_any_permission(self, user, actions):
+        return user.is_authenticated() and user.is_active
+
+    def users_with_any_permission(self, actions):
+        return get_user_model().objects.filter(is_active=True)
+
+    def users_with_permission(self, action):
+        return get_user_model().objects.filter(is_active=True)
+
+
+class BaseDjangoAuthPermissionPolicy(BasePermissionPolicy):
+    """
+    Extends BasePermissionPolicy with helper methods useful for policies that need to
+    perform lookups against the django.contrib.auth permission model
+    """
+    def __init__(self, model):
+        super(BaseDjangoAuthPermissionPolicy, self).__init__(model)
+        self.app_label = self.model._meta.app_label
+        self.model_name = self.model._meta.model_name
+
+    @cached_property
+    def _content_type(self):
+        return ContentType.objects.get_for_model(self.model)
+
+    def _get_permission_name(self, action):
+        """
+        Get the full app-label-qualified permission name (as required by
+        user.has_perm(...) ) for the given action on this model
+        """
+        return '%s.%s_%s' % (self.app_label, action, self.model_name)
+
+    def _get_users_with_any_permission_codenames_filter(self, permission_codenames):
+        """
+        Given a list of permission codenames, return a filter expression which
+        will find all users which have any of those permissions - either
+        through group permissions, user permissions, or implicitly through
+        being a superuser.
+        """
+        permissions = Permission.objects.filter(
+            content_type=self._content_type,
+            codename__in=permission_codenames
+        )
+        return (
+            Q(is_superuser=True)
+            | Q(user_permissions__in=permissions)
+            | Q(groups__permissions__in=permissions)
+        ) & Q(is_active=True)
+
+    def _get_users_with_any_permission_codenames(self, permission_codenames):
+        """
+        Given a list of permission codenames, return a queryset of users which
+        have any of those permissions - either through group permissions, user
+        permissions, or implicitly through being a superuser.
+        """
+        filter_expr = self._get_users_with_any_permission_codenames_filter(permission_codenames)
+        return get_user_model().objects.filter(filter_expr).distinct()
+
+
+class ModelPermissionPolicy(BaseDjangoAuthPermissionPolicy):
+    """
+    A permission policy that enforces permissions at the model level, by consulting
+    the standard django.contrib.auth permission model directly
+    """
+    def user_has_permission(self, user, action):
+        return user.has_perm(self._get_permission_name(action))
+
+    def users_with_any_permission(self, actions):
+        permission_codenames = [
+            '%s_%s' % (action, self.model_name)
+            for action in actions
+        ]
+        return self._get_users_with_any_permission_codenames(permission_codenames)
+
+
+class OwnershipPermissionPolicy(BaseDjangoAuthPermissionPolicy):
+    """
+    A permission policy for objects that support a concept of 'ownership', where
+    the owner is typically the user who created the object.
+
+    This policy piggybacks off 'add' and 'change' permissions defined through the
+    django.contrib.auth Permission model, as follows:
+
+    * any user with 'add' permission can create instances, and ALSO edit instances
+    that they own
+    * any user with 'change' permission can edit instances regardless of ownership
+    * ability to edit also implies ability to delete
+
+    Besides 'add', 'change' and 'delete', no other actions are recognised or permitted
+    (unless the user is an active superuser, in which case they can do everything).
+    """
+    def __init__(self, model, owner_field_name='owner'):
+        super(OwnershipPermissionPolicy, self).__init__(model)
+        self.owner_field_name = owner_field_name
+
+        # make sure owner_field_name is a field that exists on the model
+        try:
+            self.model._meta.get_field(self.owner_field_name)
+        except FieldDoesNotExist:
+            raise ImproperlyConfigured(
+                "%s has no field named '%s'. To use this model with OwnershipPermissionPolicy, "
+                "you must specify a valid field name as owner_field_name."
+                % (self.model, self.owner_field_name)
+            )
+
+    def user_has_permission(self, user, action):
+        if action == 'add':
+            return user.has_perm(self._get_permission_name('add'))
+        elif action == 'change' or action == 'delete':
+            return (
+                # having 'add' permission means that there are *potentially*
+                # some instances they can edit (namely: ones they own),
+                # which is sufficient for returning True here
+                user.has_perm(self._get_permission_name('add'))
+                or user.has_perm(self._get_permission_name('change'))
+            )
+        else:
+            # unrecognised actions are only allowed for active superusers
+            return user.is_active and user.is_superuser
+
+    def users_with_any_permission(self, actions):
+        if 'change' in actions or 'delete' in actions:
+            # either 'add' or 'change' permission means that there are *potentially*
+            # some instances they can edit
+            permission_codenames = [
+                'add_%s' % self.model_name,
+                'change_%s' % self.model_name
+            ]
+        elif 'add' in actions:
+            permission_codenames = [
+                'add_%s' % self.model_name,
+            ]
+        else:
+            # none of the actions passed in here are ones that we recognise, so only
+            # allow them for active superusers
+            return get_user_model().objects.filter(is_active=True, is_superuser=True)
+
+        return self._get_users_with_any_permission_codenames(permission_codenames)
+
+    def user_has_permission_for_instance(self, user, action, instance):
+        return self.user_has_any_permission_for_instance(user, [action], instance)
+
+    def user_has_any_permission_for_instance(self, user, actions, instance):
+        if 'change' in actions or 'delete' in actions:
+            if user.has_perm(self._get_permission_name('change')):
+                return True
+            elif (
+                user.has_perm(self._get_permission_name('add'))
+                and getattr(instance, self.owner_field_name) == user
+            ):
+                return True
+            else:
+                return False
+        else:
+            # 'change' and 'delete' are the only actions that are well-defined
+            # for specific instances. Other actions are only available to
+            # active superusers.
+            return user.is_active and user.is_superuser
+
+    def instances_user_has_any_permission_for(self, user, actions):
+        if user.is_active and user.is_superuser:
+            # active superusers can perform any action (including unrecognised ones)
+            # on any instance
+            return self.model.objects.all()
+        elif 'change' in actions or 'delete' in actions:
+            if user.has_perm(self._get_permission_name('change')):
+                # user can edit all instances
+                return self.model.objects.all()
+            elif user.has_perm(self._get_permission_name('add')):
+                # user can edit their own instances
+                return self.model.objects.filter(**{self.owner_field_name: user})
+            else:
+                # user has no permissions at all on this model
+                return self.model.objects.none()
+        else:
+            # action is either not recognised, or is the 'add' action which is
+            # not meaningful for existing instances. As such, non-superusers
+            # cannot perform it on any existing instances.
+            return self.model.objects.none()
+
+    def users_with_any_permission_for_instance(self, actions, instance):
+        if 'change' in actions or 'delete' in actions:
+            # get filter expression for users with 'change' permission
+            filter_expr = self._get_users_with_any_permission_codenames_filter([
+                'change_%s' % self.model_name
+            ])
+
+            # add on the item's owner, if they still have 'add' permission
+            # (and the owner field isn't blank)
+            owner = getattr(instance, self.owner_field_name)
+            if owner is not None and owner.has_perm(self._get_permission_name('add')):
+                filter_expr = filter_expr | Q(pk=owner.pk)
+
+            # return the filtered queryset
+            return get_user_model().objects.filter(filter_expr).distinct()
+
+        else:
+            # action is either not recognised, or is the 'add' action which is
+            # not meaningful for existing instances. As such, the action is only
+            # available to superusers
+            return get_user_model().objects.filter(is_active=True, is_superuser=True)

--- a/wagtail/wagtailcore/permissions.py
+++ b/wagtail/wagtailcore/permissions.py
@@ -1,0 +1,4 @@
+from wagtail.wagtailcore.models import Site
+from wagtail.wagtailcore.permission_policies import ModelPermissionPolicy
+
+site_permission_policy = ModelPermissionPolicy(Site)

--- a/wagtail/wagtailcore/tests/test_permission_policies.py
+++ b/wagtail/wagtailcore/tests/test_permission_policies.py
@@ -1,0 +1,1374 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group, Permission, AnonymousUser
+from django.contrib.contenttypes.models import ContentType
+
+from wagtail.wagtailcore.permission_policies import (
+    BlanketPermissionPolicy, AuthenticationOnlyPermissionPolicy,
+    ModelPermissionPolicy, OwnershipPermissionPolicy
+)
+from wagtail.wagtailimages.models import Image
+from wagtail.wagtailimages.tests.utils import get_test_image_file
+
+
+class PermissionPolicyTestCase(TestCase):
+    def setUp(self):
+        # Permissions
+        image_content_type = ContentType.objects.get_for_model(Image)
+        add_image_permission = Permission.objects.get(
+            content_type=image_content_type, codename='add_image'
+        )
+        change_image_permission = Permission.objects.get(
+            content_type=image_content_type, codename='change_image'
+        )
+        delete_image_permission = Permission.objects.get(
+            content_type=image_content_type, codename='delete_image'
+        )
+
+        # Groups
+        image_adders_group = Group.objects.create(name="Image adders")
+        image_adders_group.permissions.add(add_image_permission)
+
+        image_changers_group = Group.objects.create(name="Image changers")
+        image_changers_group.permissions.add(change_image_permission)
+
+        # Users
+        User = get_user_model()
+
+        self.superuser = User.objects.create_superuser(
+            'superuser', 'superuser@example.com', 'password'
+        )
+        self.inactive_superuser = User.objects.create_superuser(
+            'inactivesuperuser', 'inactivesuperuser@example.com', 'password', is_active=False
+        )
+
+        # a user with add_image permission through the 'Image adders' group
+        self.image_adder = User.objects.create_user(
+            'imageadder', 'imageadder@example.com', 'password'
+        )
+        self.image_adder.groups.add(image_adders_group)
+
+        # a user with add_image permission through user_permissions
+        self.oneoff_image_adder = User.objects.create_user(
+            'oneoffimageadder', 'oneoffimageadder@example.com', 'password'
+        )
+        self.oneoff_image_adder.user_permissions.add(add_image_permission)
+
+        # a user that has add_image permission, but is inactive
+        self.inactive_image_adder = User.objects.create_user(
+            'inactiveimageadder', 'inactiveimageadder@example.com', 'password', is_active=False
+        )
+        self.inactive_image_adder.groups.add(image_adders_group)
+
+        # a user with change_image permission through the 'Image changers' group
+        self.image_changer = User.objects.create_user(
+            'imagechanger', 'imagechanger@example.com', 'password'
+        )
+        self.image_changer.groups.add(image_changers_group)
+
+        # a user with change_image permission through user_permissions
+        self.oneoff_image_changer = User.objects.create_user(
+            'oneoffimagechanger', 'oneoffimagechanger@example.com', 'password'
+        )
+        self.oneoff_image_changer.user_permissions.add(change_image_permission)
+
+        # a user that has change_image permission, but is inactive
+        self.inactive_image_changer = User.objects.create_user(
+            'inactiveimagechanger', 'inactiveimagechanger@example.com', 'password',
+            is_active=False
+        )
+        self.inactive_image_changer.groups.add(image_changers_group)
+
+        # a user with delete_image permission through user_permissions
+        self.oneoff_image_deleter = User.objects.create_user(
+            'oneoffimagedeleter', 'oneoffimagedeleter@example.com', 'password'
+        )
+        self.oneoff_image_deleter.user_permissions.add(delete_image_permission)
+
+        # a user with no permissions
+        self.useless_user = User.objects.create_user(
+            'uselessuser', 'uselessuser@example.com', 'password'
+        )
+
+        self.anonymous_user = AnonymousUser()
+
+        # Images
+
+        # an image owned by 'imageadder'
+        self.adder_image = Image.objects.create(
+            title="imageadder's image", file=get_test_image_file(),
+            uploaded_by_user=self.image_adder
+        )
+
+        # an image owned by 'uselessuser'
+        self.useless_image = Image.objects.create(
+            title="uselessuser's image", file=get_test_image_file(),
+            uploaded_by_user=self.useless_user
+        )
+
+        # an image with no owner
+        self.anonymous_image = Image.objects.create(
+            title="anonymous image", file=get_test_image_file(),
+        )
+
+    def assertResultSetEqual(self, actual, expected):
+        self.assertEqual(set(actual), set(expected))
+
+    def assertUserPermissionMatrix(self, test_cases):
+        """
+        Given a list of (user, can_add, can_change, can_delete, can_frobnicate) tuples
+        (where 'frobnicate' is an unrecognised action not defined on the model),
+        confirm that all tuples correctly represent permissions for that user as
+        returned by user_has_permission
+        """
+        actions = ['add', 'change', 'delete', 'frobnicate']
+        for test_case in test_cases:
+            user = test_case[0]
+            expected_results = zip(actions, test_case[1:])
+
+            for (action, expected_result) in expected_results:
+                if expected_result:
+                    self.assertTrue(
+                        self.policy.user_has_permission(user, action),
+                        "User %s should be able to %s, but can't" % (user, action)
+                    )
+                else:
+                    self.assertFalse(
+                        self.policy.user_has_permission(user, action),
+                        "User %s should not be able to %s, but can" % (user, action)
+                    )
+
+    def assertUserInstancePermissionMatrix(self, instance, test_cases):
+        """
+        Given a list of (user, can_change, can_delete, can_frobnicate) tuples
+        (where 'frobnicate' is an unrecognised action not defined on the model),
+        confirm that all tuples correctly represent permissions for that user on
+        the given instance, as returned by user_has_permission_for_instance
+        """
+        actions = ['change', 'delete', 'frobnicate']
+        for test_case in test_cases:
+            user = test_case[0]
+            expected_results = zip(actions, test_case[1:])
+
+            for (action, expected_result) in expected_results:
+                if expected_result:
+                    self.assertTrue(
+                        self.policy.user_has_permission_for_instance(user, action, instance),
+                        "User %s should be able to %s instance %s, but can't" % (
+                            user, action, instance
+                        )
+                    )
+                else:
+                    self.assertFalse(
+                        self.policy.user_has_permission_for_instance(user, action, instance),
+                        "User %s should not be able to %s instance %s, but can" % (
+                            user, action, instance
+                        )
+                    )
+
+
+class TestBlanketPermissionPolicy(PermissionPolicyTestCase):
+    def setUp(self):
+        super(TestBlanketPermissionPolicy, self).setUp()
+        self.policy = BlanketPermissionPolicy(Image)
+
+        self.active_users = [
+            self.superuser,
+            self.image_adder,
+            self.oneoff_image_adder,
+            self.image_changer,
+            self.oneoff_image_changer,
+            self.oneoff_image_deleter,
+            self.useless_user,
+        ]
+        self.all_users = self.active_users + [
+            self.inactive_superuser,
+            self.inactive_image_adder,
+            self.inactive_image_changer,
+            self.anonymous_user,
+        ]
+
+    def test_user_has_permission(self):
+        # All users have permission to do everything
+        self.assertUserPermissionMatrix([
+            (user, True, True, True, True)
+            for user in self.all_users
+        ])
+
+    def test_user_has_any_permission(self):
+        for user in self.all_users:
+            self.assertTrue(
+                self.policy.user_has_any_permission(user, ['add', 'change'])
+            )
+
+    def test_users_with_permission(self):
+        # all active users have permission
+        users_with_add_permission = self.policy.users_with_permission('add')
+
+        self.assertResultSetEqual(users_with_add_permission, self.active_users)
+
+    def test_users_with_any_permission(self):
+        # all active users have permission
+        users_with_add_or_change_permission = self.policy.users_with_any_permission(
+            ['add', 'change']
+        )
+
+        self.assertResultSetEqual(users_with_add_or_change_permission, self.active_users)
+
+    def test_user_has_permission_for_instance(self):
+        # All users have permission to do everything on any given instance
+        self.assertUserInstancePermissionMatrix(self.adder_image, [
+            (user, True, True, True)
+            for user in self.all_users
+        ])
+
+    def test_user_has_any_permission_for_instance(self):
+        for user in self.all_users:
+            self.assertTrue(
+                self.policy.user_has_any_permission_for_instance(
+                    user, ['change', 'delete'], self.adder_image
+                )
+            )
+
+    def test_instances_user_has_permission_for(self):
+        all_images = [
+            self.adder_image, self.useless_image, self.anonymous_image
+        ]
+
+        # all users can edit all instances
+        for user in self.all_users:
+            self.assertResultSetEqual(
+                self.policy.instances_user_has_permission_for(user, 'change'),
+                all_images
+            )
+
+    def test_instances_user_has_any_permission_for(self):
+        all_images = [
+            self.adder_image, self.useless_image, self.anonymous_image
+        ]
+
+        for user in self.all_users:
+            self.assertResultSetEqual(
+                self.policy.instances_user_has_any_permission_for(user, ['change', 'delete']),
+                all_images
+            )
+
+    def test_users_with_permission_for_instance(self):
+        # all active users have permission
+        users_with_change_permission = self.policy.users_with_permission_for_instance(
+            'change', self.useless_image
+        )
+
+        self.assertResultSetEqual(users_with_change_permission, self.active_users)
+
+    def test_users_with_any_permission_for_instance(self):
+        # all active users have permission
+        users_with_change_or_del_permission = self.policy.users_with_any_permission_for_instance(
+            ['change', 'delete'], self.useless_image
+        )
+
+        self.assertResultSetEqual(users_with_change_or_del_permission, self.active_users)
+
+
+class TestAuthenticationOnlyPermissionPolicy(PermissionPolicyTestCase):
+    def setUp(self):
+        super(TestAuthenticationOnlyPermissionPolicy, self).setUp()
+        self.policy = AuthenticationOnlyPermissionPolicy(Image)
+
+    def test_user_has_permission(self):
+        # All active authenticated users have permission to do everything;
+        # inactive and anonymous users have permission to do nothing
+        self.assertUserPermissionMatrix([
+            (self.superuser, True, True, True, True),
+            (self.inactive_superuser, False, False, False, False),
+            (self.image_adder, True, True, True, True),
+            (self.oneoff_image_adder, True, True, True, True),
+            (self.inactive_image_adder, False, False, False, False),
+            (self.image_changer, True, True, True, True),
+            (self.oneoff_image_changer, True, True, True, True),
+            (self.inactive_image_changer, False, False, False, False),
+            (self.oneoff_image_deleter, True, True, True, True),
+            (self.useless_user, True, True, True, True),
+            (self.anonymous_user, False, False, False, False),
+        ])
+
+    def test_user_has_any_permission(self):
+        self.assertTrue(
+            self.policy.user_has_any_permission(self.superuser, ['add', 'change'])
+        )
+
+        self.assertFalse(
+            self.policy.user_has_any_permission(self.inactive_superuser, ['add', 'change'])
+        )
+
+        self.assertTrue(
+            self.policy.user_has_any_permission(self.useless_user, ['add', 'change'])
+        )
+
+        self.assertFalse(
+            self.policy.user_has_any_permission(self.anonymous_user, ['add', 'change'])
+        )
+
+    def test_users_with_permission(self):
+        # all active users have permission
+        users_with_add_permission = self.policy.users_with_permission('add')
+
+        self.assertResultSetEqual(users_with_add_permission, [
+            self.superuser,
+            self.image_adder,
+            self.oneoff_image_adder,
+            self.image_changer,
+            self.oneoff_image_changer,
+            self.oneoff_image_deleter,
+            self.useless_user,
+        ])
+
+    def test_users_with_any_permission(self):
+        # all active users have permission
+        users_with_add_or_change_permission = self.policy.users_with_any_permission(
+            ['add', 'change']
+        )
+
+        self.assertResultSetEqual(users_with_add_or_change_permission, [
+            self.superuser,
+            self.image_adder,
+            self.oneoff_image_adder,
+            self.image_changer,
+            self.oneoff_image_changer,
+            self.oneoff_image_deleter,
+            self.useless_user,
+        ])
+
+    def test_user_has_permission_for_instance(self):
+        # Permissions for this policy are applied at the model level,
+        # so rules for a specific instance will match rules for the
+        # model as a whole
+        self.assertUserInstancePermissionMatrix(self.adder_image, [
+            (self.superuser, True, True, True),
+            (self.inactive_superuser, False, False, False),
+            (self.image_adder, True, True, True),
+            (self.oneoff_image_adder, True, True, True),
+            (self.inactive_image_adder, False, False, False),
+            (self.image_changer, True, True, True),
+            (self.oneoff_image_changer, True, True, True),
+            (self.inactive_image_changer, False, False, False),
+            (self.oneoff_image_deleter, True, True, True),
+            (self.useless_user, True, True, True),
+            (self.anonymous_user, False, False, False),
+        ])
+
+    def test_user_has_any_permission_for_instance(self):
+        # superuser has permission
+        self.assertTrue(
+            self.policy.user_has_any_permission_for_instance(
+                self.superuser, ['change', 'delete'], self.adder_image
+            )
+        )
+
+        # inactive user has no permission
+        self.assertFalse(
+            self.policy.user_has_any_permission_for_instance(
+                self.inactive_superuser, ['change', 'delete'], self.adder_image
+            )
+        )
+
+        # ordinary user has permission
+        self.assertTrue(
+            self.policy.user_has_any_permission_for_instance(
+                self.useless_user, ['change', 'delete'], self.adder_image
+            )
+        )
+
+        # anonymous user has no permission
+        self.assertFalse(
+            self.policy.user_has_any_permission_for_instance(
+                self.anonymous_user, ['change', 'delete'], self.adder_image
+            )
+        )
+
+    def test_instances_user_has_permission_for(self):
+        all_images = [
+            self.adder_image, self.useless_image, self.anonymous_image
+        ]
+        no_images = []
+
+        # the set of images editable by superuser includes all images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.superuser, 'change'
+            ),
+            all_images
+        )
+
+        # the set of images editable by inactive superuser includes no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.inactive_superuser, 'change'
+            ),
+            no_images
+        )
+
+        # the set of images editable by ordinary user includes all images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.useless_user, 'change'
+            ),
+            all_images
+        )
+
+        # the set of images editable by anonymous user includes no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.anonymous_user, 'change'
+            ),
+            no_images
+        )
+
+    def test_instances_user_has_any_permission_for(self):
+        all_images = [
+            self.adder_image, self.useless_image, self.anonymous_image
+        ]
+        no_images = []
+
+        # the set of images editable by superuser includes all images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.superuser, ['change', 'delete']
+            ),
+            all_images
+        )
+
+        # the set of images editable by inactive superuser includes no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.inactive_superuser, ['change', 'delete']
+            ),
+            no_images
+        )
+
+        # the set of images editable by ordinary user includes all images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.useless_user, ['change', 'delete']
+            ),
+            all_images
+        )
+
+        # the set of images editable by anonymous user includes no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.anonymous_user, ['change', 'delete']
+            ),
+            no_images
+        )
+
+    def test_users_with_permission_for_instance(self):
+        # all active users have permission
+        users_with_change_permission = self.policy.users_with_permission_for_instance(
+            'change', self.useless_image
+        )
+
+        self.assertResultSetEqual(users_with_change_permission, [
+            self.superuser,
+            self.image_adder,
+            self.oneoff_image_adder,
+            self.image_changer,
+            self.oneoff_image_changer,
+            self.oneoff_image_deleter,
+            self.useless_user,
+        ])
+
+    def test_users_with_any_permission_for_instance(self):
+        # all active users have permission
+        users_with_change_or_del_permission = self.policy.users_with_any_permission_for_instance(
+            ['change', 'delete'], self.useless_image
+        )
+
+        self.assertResultSetEqual(users_with_change_or_del_permission, [
+            self.superuser,
+            self.image_adder,
+            self.oneoff_image_adder,
+            self.image_changer,
+            self.oneoff_image_changer,
+            self.oneoff_image_deleter,
+            self.useless_user,
+        ])
+
+
+class TestModelPermissionPolicy(PermissionPolicyTestCase):
+    def setUp(self):
+        super(TestModelPermissionPolicy, self).setUp()
+        self.policy = ModelPermissionPolicy(Image)
+
+    def test_user_has_permission(self):
+        self.assertUserPermissionMatrix([
+            # Superuser has permission to do everything
+            (self.superuser, True, True, True, True),
+
+            # Inactive superuser can do nothing
+            (self.inactive_superuser, False, False, False, False),
+
+            # User with 'add' permission via group can only add
+            (self.image_adder, True, False, False, False),
+
+            # User with 'add' permission via user can only add
+            (self.oneoff_image_adder, True, False, False, False),
+
+            # Inactive user with 'add' permission can do nothing
+            (self.inactive_image_adder, False, False, False, False),
+
+            # User with 'change' permission via group can only change
+            (self.image_changer, False, True, False, False),
+
+            # User with 'change' permission via user can only change
+            (self.oneoff_image_changer, False, True, False, False),
+
+            # Inactive user with 'add' permission can do nothing
+            (self.inactive_image_changer, False, False, False, False),
+
+            # User with 'delete' permission can only delete
+            (self.oneoff_image_deleter, False, False, True, False),
+
+            # User with no permissions can do nothing
+            (self.useless_user, False, False, False, False),
+
+            # Anonymous user can do nothing
+            (self.anonymous_user, False, False, False, False),
+        ])
+
+    def test_user_has_any_permission(self):
+        # Superuser can do everything
+        self.assertTrue(
+            self.policy.user_has_any_permission(self.superuser, ['add', 'change'])
+        )
+
+        # Inactive superuser can do nothing
+        self.assertFalse(
+            self.policy.user_has_any_permission(self.inactive_superuser, ['add', 'change'])
+        )
+
+        # Only one of the permissions in the list needs to pass
+        # in order for user_has_any_permission to return true
+        self.assertTrue(
+            self.policy.user_has_any_permission(self.image_adder, ['add', 'change'])
+        )
+        self.assertTrue(
+            self.policy.user_has_any_permission(self.oneoff_image_adder, ['add', 'change'])
+        )
+        self.assertTrue(
+            self.policy.user_has_any_permission(self.image_changer, ['add', 'change'])
+        )
+
+        # User with some permission, but not the ones in the list,
+        # should return false
+        self.assertFalse(
+            self.policy.user_has_any_permission(self.image_changer, ['add', 'delete'])
+        )
+
+        # Inactive user with the appropriate permissions can do nothing
+        self.assertFalse(
+            self.policy.user_has_any_permission(self.inactive_image_adder, ['add', 'delete'])
+        )
+
+        # User with no permissions can do nothing
+        self.assertFalse(
+            self.policy.user_has_any_permission(self.useless_user, ['add', 'change'])
+        )
+
+        # Anonymous user can do nothing
+        self.assertFalse(
+            self.policy.user_has_any_permission(self.anonymous_user, ['add', 'change'])
+        )
+
+    def test_users_with_permission(self):
+        users_with_add_permission = self.policy.users_with_permission('add')
+
+        self.assertResultSetEqual(users_with_add_permission, [
+            self.superuser,
+            self.image_adder,
+            self.oneoff_image_adder,
+        ])
+
+        users_with_change_permission = self.policy.users_with_permission('change')
+
+        self.assertResultSetEqual(users_with_change_permission, [
+            self.superuser,
+            self.image_changer,
+            self.oneoff_image_changer,
+        ])
+
+    def test_users_with_any_permission(self):
+        users_with_add_or_change_permission = self.policy.users_with_any_permission(
+            ['add', 'change']
+        )
+
+        self.assertResultSetEqual(users_with_add_or_change_permission, [
+            self.superuser,
+            self.image_adder,
+            self.oneoff_image_adder,
+            self.image_changer,
+            self.oneoff_image_changer,
+        ])
+
+        users_with_change_or_delete_permission = self.policy.users_with_any_permission(
+            ['change', 'delete']
+        )
+
+        self.assertResultSetEqual(users_with_change_or_delete_permission, [
+            self.superuser,
+            self.image_changer,
+            self.oneoff_image_changer,
+            self.oneoff_image_deleter,
+        ])
+
+    def test_user_has_permission_for_instance(self):
+        # Permissions for this policy are applied at the model level,
+        # so rules for a specific instance will match rules for the
+        # model as a whole
+        self.assertUserInstancePermissionMatrix(self.adder_image, [
+            (self.superuser, True, True, True),
+            (self.inactive_superuser, False, False, False),
+            (self.image_adder, False, False, False),
+            (self.oneoff_image_adder, False, False, False),
+            (self.inactive_image_adder, False, False, False),
+            (self.image_changer, True, False, False),
+            (self.oneoff_image_changer, True, False, False),
+            (self.inactive_image_changer, False, False, False),
+            (self.oneoff_image_deleter, False, True, False),
+            (self.useless_user, False, False, False),
+            (self.anonymous_user, False, False, False),
+        ])
+
+    def test_user_has_any_permission_for_instance(self):
+        # Superuser can do everything
+        self.assertTrue(
+            self.policy.user_has_any_permission_for_instance(
+                self.superuser, ['change', 'delete'], self.adder_image
+            )
+        )
+
+        # Inactive superuser can do nothing
+        self.assertFalse(
+            self.policy.user_has_any_permission_for_instance(
+                self.inactive_superuser, ['change', 'delete'], self.adder_image
+            )
+        )
+
+        # Only one of the permissions in the list needs to pass
+        # in order for user_has_any_permission to return true
+        self.assertTrue(
+            self.policy.user_has_any_permission_for_instance(
+                self.image_changer, ['change', 'delete'], self.adder_image
+            )
+        )
+        self.assertTrue(
+            self.policy.user_has_any_permission_for_instance(
+                self.oneoff_image_changer, ['change', 'delete'], self.adder_image
+            )
+        )
+
+        # User with some permission, but not the ones in the list,
+        # should return false
+        self.assertFalse(
+            self.policy.user_has_any_permission_for_instance(
+                self.image_adder, ['change', 'delete'], self.adder_image
+            )
+        )
+
+        # Inactive user with the appropriate permissions can do nothing
+        self.assertFalse(
+            self.policy.user_has_any_permission_for_instance(
+                self.inactive_image_changer, ['change', 'delete'], self.adder_image
+            )
+        )
+
+        # User with no permissions can do nothing
+        self.assertFalse(
+            self.policy.user_has_any_permission_for_instance(
+                self.useless_user, ['change', 'delete'], self.adder_image
+            )
+        )
+
+        # Anonymous user can do nothing
+        self.assertFalse(
+            self.policy.user_has_any_permission_for_instance(
+                self.anonymous_user, ['change', 'delete'], self.adder_image
+            )
+        )
+
+    def test_instances_user_has_permission_for(self):
+        all_images = [
+            self.adder_image, self.useless_image, self.anonymous_image
+        ]
+        no_images = []
+
+        # the set of images editable by superuser includes all images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.superuser, 'change'
+            ),
+            all_images
+        )
+
+        # the set of images editable by inactive superuser includes no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.inactive_superuser, 'change'
+            ),
+            no_images
+        )
+
+        # given the relevant model permission at the group level, a user can edit all images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.image_changer, 'change'
+            ),
+            all_images
+        )
+
+        # given the relevant model permission at the user level, a user can edit all images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.oneoff_image_changer, 'change'
+            ),
+            all_images
+        )
+
+        # a user with no permission can edit no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.useless_user, 'change'
+            ),
+            no_images
+        )
+
+        # an inactive user with the relevant permission can edit no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.inactive_image_changer, 'change'
+            ),
+            no_images
+        )
+
+        # a user with permission, but not the matching one, can edit no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.image_changer, 'delete'
+            ),
+            no_images
+        )
+
+        # the set of images editable by anonymous user includes no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.anonymous_user, 'change'
+            ),
+            no_images
+        )
+
+    def test_instances_user_has_any_permission_for(self):
+        all_images = [
+            self.adder_image, self.useless_image, self.anonymous_image
+        ]
+        no_images = []
+
+        # the set of images editable by superuser includes all images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.superuser, ['change', 'delete']
+            ),
+            all_images
+        )
+
+        # the set of images editable by inactive superuser includes no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.inactive_superuser, ['change', 'delete']
+            ),
+            no_images
+        )
+
+        # given the relevant model permission at the group level, a user can edit all images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.image_changer, ['change', 'delete']
+            ),
+            all_images
+        )
+
+        # given the relevant model permission at the user level, a user can edit all images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.oneoff_image_changer, ['change', 'delete']
+            ),
+            all_images
+        )
+
+        # a user with no permission can edit no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.useless_user, ['change', 'delete']
+            ),
+            no_images
+        )
+
+        # an inactive user with the relevant permission can edit no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.inactive_image_changer, ['change', 'delete']
+            ),
+            no_images
+        )
+
+        # a user with permission, but not the matching one, can edit no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.image_adder, ['change', 'delete']
+            ),
+            no_images
+        )
+
+        # the set of images editable by anonymous user includes no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.anonymous_user, ['change', 'delete']
+            ),
+            no_images
+        )
+
+    def test_users_with_permission_for_instance(self):
+        users_with_change_permission = self.policy.users_with_permission_for_instance(
+            'change', self.useless_image
+        )
+
+        self.assertResultSetEqual(users_with_change_permission, [
+            self.superuser,
+            self.image_changer,
+            self.oneoff_image_changer,
+        ])
+
+        users_with_delete_permission = self.policy.users_with_permission_for_instance(
+            'delete', self.useless_image
+        )
+
+        self.assertResultSetEqual(users_with_delete_permission, [
+            self.superuser,
+            self.oneoff_image_deleter,
+        ])
+
+    def test_users_with_any_permission_for_instance(self):
+        users_with_change_or_del_permission = self.policy.users_with_any_permission_for_instance(
+            ['change', 'delete'], self.useless_image
+        )
+
+        self.assertResultSetEqual(users_with_change_or_del_permission, [
+            self.superuser,
+            self.image_changer,
+            self.oneoff_image_changer,
+            self.oneoff_image_deleter,
+        ])
+
+
+class TestOwnershipPermissionPolicy(PermissionPolicyTestCase):
+    def setUp(self):
+        super(TestOwnershipPermissionPolicy, self).setUp()
+        self.policy = OwnershipPermissionPolicy(Image, owner_field_name='uploaded_by_user')
+
+    def test_user_has_permission(self):
+        self.assertUserPermissionMatrix([
+            # Superuser has permission to do everything
+            (self.superuser, True, True, True, True),
+
+            # Inactive superuser can do nothing
+            (self.inactive_superuser, False, False, False, False),
+
+            # User with 'add' permission via group can add,
+            # and by extension, change and delete their own instances
+            (self.image_adder, True, True, True, False),
+
+            # User with 'add' permission via user can add,
+            # and by extension, change and delete their own instances
+            (self.oneoff_image_adder, True, True, True, False),
+
+            # Inactive user with 'add' permission can do nothing
+            (self.inactive_image_adder, False, False, False, False),
+
+            # User with 'change' permission via group can change and delete but not add
+            (self.image_changer, False, True, True, False),
+
+            # User with 'change' permission via user can change and delete but not add
+            (self.oneoff_image_changer, False, True, True, False),
+
+            # Inactive user with 'change' permission can do nothing
+            (self.inactive_image_changer, False, False, False, False),
+
+            # 'delete' permission is ignored for this policy
+            (self.oneoff_image_deleter, False, False, False, False),
+
+            # User with no permission can do nothing
+            (self.useless_user, False, False, False, False),
+
+            # Anonymous user can do nothing
+            (self.anonymous_user, False, False, False, False),
+        ])
+
+    def test_user_has_any_permission(self):
+        # Superuser can do everything
+        self.assertTrue(
+            self.policy.user_has_any_permission(self.superuser, ['add', 'change'])
+        )
+
+        # Inactive superuser can do nothing
+        self.assertFalse(
+            self.policy.user_has_any_permission(self.inactive_superuser, ['add', 'change'])
+        )
+
+        # Only one of the permissions in the list needs to pass
+        # in order for user_has_any_permission to return true
+        self.assertTrue(
+            self.policy.user_has_any_permission(self.image_changer, ['add', 'change'])
+        )
+        self.assertTrue(
+            self.policy.user_has_any_permission(self.oneoff_image_changer, ['add', 'change'])
+        )
+
+        # User with some permission, but not the ones in the list,
+        # should return false
+        self.assertFalse(
+            self.policy.user_has_any_permission(self.oneoff_image_deleter, ['add', 'change'])
+        )
+
+        # Inactive user with the appropriate permissions can do nothing
+        self.assertFalse(
+            self.policy.user_has_any_permission(self.inactive_image_changer, ['add', 'delete'])
+        )
+
+        # User with no permissions can do nothing
+        self.assertFalse(
+            self.policy.user_has_any_permission(self.useless_user, ['add', 'change'])
+        )
+
+        # Anonymous user can do nothing
+        self.assertFalse(
+            self.policy.user_has_any_permission(self.anonymous_user, ['add', 'change'])
+        )
+
+    def test_users_with_permission(self):
+        users_with_add_permission = self.policy.users_with_permission('add')
+
+        self.assertResultSetEqual(users_with_add_permission, [
+            self.superuser,
+            self.image_adder,
+            self.oneoff_image_adder,
+        ])
+
+        # users with add permission have change permission too (i.e. for their own images)
+        users_with_change_permission = self.policy.users_with_permission('change')
+
+        self.assertResultSetEqual(users_with_change_permission, [
+            self.superuser,
+            self.image_adder,
+            self.oneoff_image_adder,
+            self.image_changer,
+            self.oneoff_image_changer,
+        ])
+
+        # conditions for deletion are the same as for change; 'delete' permission
+        # records in django.contrib.auth are ignored
+        users_with_delete_permission = self.policy.users_with_permission('delete')
+
+        self.assertResultSetEqual(users_with_delete_permission, [
+            self.superuser,
+            self.image_adder,
+            self.oneoff_image_adder,
+            self.image_changer,
+            self.oneoff_image_changer,
+        ])
+
+        # non-standard permissions are only available to superusers
+        users_with_frobnicate_permission = self.policy.users_with_permission('frobnicate')
+
+        self.assertResultSetEqual(users_with_frobnicate_permission, [
+            self.superuser,
+        ])
+
+    def test_users_with_any_permission(self):
+        users_with_add_or_change_permission = self.policy.users_with_any_permission(
+            ['add', 'change']
+        )
+
+        self.assertResultSetEqual(users_with_add_or_change_permission, [
+            self.superuser,
+            self.image_adder,
+            self.oneoff_image_adder,
+            self.image_changer,
+            self.oneoff_image_changer,
+        ])
+
+        users_with_add_or_frobnicate_permission = self.policy.users_with_any_permission(
+            ['add', 'frobnicate']
+        )
+
+        self.assertResultSetEqual(users_with_add_or_frobnicate_permission, [
+            self.superuser,
+            self.image_adder,
+            self.oneoff_image_adder,
+        ])
+
+    def test_user_has_permission_for_instance(self):
+        # Test permissions for an image owned by image_adder
+        self.assertUserInstancePermissionMatrix(self.adder_image, [
+            # superuser can do everything
+            (self.superuser, True, True, True),
+
+            # inactive superuser can do nothing
+            (self.inactive_superuser, False, False, False),
+
+            # image_adder can change and delete their own images,
+            # but not perform custom actions
+            (self.image_adder, True, True, False),
+
+            # user with add permission cannot edit images owned by others
+            (self.oneoff_image_adder, False, False, False),
+
+            # inactive user with 'add' permission can do nothing
+            (self.inactive_image_adder, False, False, False),
+
+            # user with change permission can change and delete all images
+            (self.image_changer, True, True, False),
+
+            # likewise for change permission specified at the user level
+            (self.oneoff_image_changer, True, True, False),
+
+            # inactive user with 'change' permission can do nothing
+            (self.inactive_image_changer, False, False, False),
+
+            # delete permissions are ignored
+            (self.oneoff_image_deleter, False, False, False),
+
+            # user with no permissions can do nothing
+            (self.useless_user, False, False, False),
+
+            # anonymous user can do nothing
+            (self.anonymous_user, False, False, False),
+        ])
+
+        # Test permissions for an image owned by useless_user
+        self.assertUserInstancePermissionMatrix(self.useless_image, [
+            # superuser can do everything
+            (self.superuser, True, True, True),
+
+            # image_adder cannot edit images owned by others
+            (self.image_adder, False, False, False),
+            (self.oneoff_image_adder, False, False, False),
+
+            # user with change permission can change and delete all images
+            (self.image_changer, True, True, False),
+            (self.oneoff_image_changer, True, True, False),
+
+            # inactive users can do nothing
+            (self.inactive_superuser, False, False, False),
+            (self.inactive_image_adder, False, False, False),
+            (self.inactive_image_changer, False, False, False),
+
+            # delete permissions are ignored
+            (self.oneoff_image_deleter, False, False, False),
+
+            # user with no permissions can do nothing, even on images
+            # they own
+            (self.useless_user, False, False, False),
+
+            # anonymous user can do nothing
+            (self.anonymous_user, False, False, False),
+        ])
+
+        # Instances with a null owner should always follow the same rules
+        # as 'an instance owned by someone else'
+        self.assertUserInstancePermissionMatrix(self.anonymous_image, [
+            (self.superuser, True, True, True),
+            (self.image_adder, False, False, False),
+            (self.oneoff_image_adder, False, False, False),
+            (self.image_changer, True, True, False),
+            (self.oneoff_image_changer, True, True, False),
+            (self.inactive_superuser, False, False, False),
+            (self.inactive_image_adder, False, False, False),
+            (self.inactive_image_changer, False, False, False),
+            (self.oneoff_image_deleter, False, False, False),
+            (self.useless_user, False, False, False),
+            (self.anonymous_user, False, False, False),
+        ])
+
+    def test_user_has_any_permission_for_instance(self):
+        # Superuser can do everything
+        self.assertTrue(
+            self.policy.user_has_any_permission_for_instance(
+                self.superuser, ['change', 'delete'], self.adder_image
+            )
+        )
+
+        # Inactive superuser can do nothing
+        self.assertFalse(
+            self.policy.user_has_any_permission_for_instance(
+                self.inactive_superuser, ['change', 'delete'], self.adder_image
+            )
+        )
+
+        # Only one of the permissions in the list needs to pass
+        # in order for user_has_any_permission to return true
+        self.assertTrue(
+            self.policy.user_has_any_permission_for_instance(
+                self.image_changer, ['change', 'frobnicate'], self.adder_image
+            )
+        )
+        self.assertTrue(
+            self.policy.user_has_any_permission_for_instance(
+                self.oneoff_image_changer, ['change', 'frobnicate'], self.adder_image
+            )
+        )
+
+        # User with some permission, but not the ones in the list,
+        # should return false
+        self.assertFalse(
+            self.policy.user_has_any_permission_for_instance(
+                self.oneoff_image_deleter, ['change', 'delete'], self.adder_image
+            )
+        )
+
+        # Inactive user with the appropriate permissions can do nothing
+        self.assertFalse(
+            self.policy.user_has_any_permission_for_instance(
+                self.inactive_image_changer, ['change', 'delete'], self.adder_image
+            )
+        )
+
+        # User with no permissions can do nothing
+        self.assertFalse(
+            self.policy.user_has_any_permission_for_instance(
+                self.useless_user, ['change', 'delete'], self.adder_image
+            )
+        )
+
+        # Anonymous user can do nothing
+        self.assertFalse(
+            self.policy.user_has_any_permission_for_instance(
+                self.anonymous_user, ['change', 'delete'], self.adder_image
+            )
+        )
+
+    def test_instances_user_has_permission_for(self):
+        all_images = [
+            self.adder_image, self.useless_image, self.anonymous_image
+        ]
+        no_images = []
+
+        # the set of images editable by superuser includes all images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.superuser, 'change'
+            ),
+            all_images
+        )
+
+        # the set of images editable by inactive superuser includes no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.inactive_superuser, 'change'
+            ),
+            no_images
+        )
+
+        # a user with 'add' permission can change their own images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.image_adder, 'change'
+            ),
+            [self.adder_image]
+        )
+        # a user with 'add' permission can also delete their own images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.image_adder, 'delete'
+            ),
+            [self.adder_image]
+        )
+
+        # a user with 'change' permission can change all images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.image_changer, 'change'
+            ),
+            all_images
+        )
+
+        # ditto for 'change' permission assigned at the user level
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.oneoff_image_changer, 'change'
+            ),
+            all_images
+        )
+
+        # an inactive user with the relevant permission can edit no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.inactive_image_changer, 'change'
+            ),
+            no_images
+        )
+
+        # a user with no permission can edit no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.useless_user, 'change'
+            ),
+            no_images
+        )
+
+        # the set of images editable by anonymous user includes no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_permission_for(
+                self.anonymous_user, 'change'
+            ),
+            no_images
+        )
+
+    def test_instances_user_has_any_permission_for(self):
+        all_images = [
+            self.adder_image, self.useless_image, self.anonymous_image
+        ]
+        no_images = []
+
+        # the set of images editable by superuser includes all images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.superuser, ['change', 'delete']
+            ),
+            all_images
+        )
+
+        # the set of images editable by inactive superuser includes no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.inactive_superuser, ['change', 'delete']
+            ),
+            no_images
+        )
+
+        # a user with 'add' permission can change/delete their own images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.image_adder, ['delete', 'frobnicate']
+            ),
+            [self.adder_image]
+        )
+
+        # a user with 'edit' permission can change/delete all images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.oneoff_image_changer, ['delete', 'frobnicate']
+            ),
+            all_images
+        )
+
+        # a user with no permission can edit no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.useless_user, ['change', 'delete']
+            ),
+            no_images
+        )
+
+        # an inactive user with the relevant permission can edit no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.inactive_image_changer, ['change', 'delete']
+            ),
+            no_images
+        )
+
+        # a user with permission, but not the matching one, can edit no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.oneoff_image_deleter, ['change', 'delete']
+            ),
+            no_images
+        )
+
+        # the set of images editable by anonymous user includes no images
+        self.assertResultSetEqual(
+            self.policy.instances_user_has_any_permission_for(
+                self.anonymous_user, ['change', 'delete']
+            ),
+            no_images
+        )
+
+    def test_users_with_permission_for_instance(self):
+        # adder_image can be edited by its owner (who has add permission) and
+        # all users with 'change' permission
+        users_with_change_permission = self.policy.users_with_permission_for_instance(
+            'change', self.adder_image
+        )
+
+        self.assertResultSetEqual(users_with_change_permission, [
+            self.superuser,
+            self.image_adder,
+            self.image_changer,
+            self.oneoff_image_changer,
+        ])
+
+        # the same set of users can also delete
+        users_with_delete_permission = self.policy.users_with_permission_for_instance(
+            'delete', self.adder_image
+        )
+
+        self.assertResultSetEqual(users_with_delete_permission, [
+            self.superuser,
+            self.image_adder,
+            self.image_changer,
+            self.oneoff_image_changer,
+        ])
+
+        # custom actions are available to superusers only
+        users_with_delete_permission = self.policy.users_with_permission_for_instance(
+            'frobnicate', self.adder_image
+        )
+
+        self.assertResultSetEqual(users_with_delete_permission, [
+            self.superuser,
+        ])
+
+        # useless_user can NOT edit their own image, because they do not have
+        # 'add' permission
+        users_with_change_permission = self.policy.users_with_permission_for_instance(
+            'change', self.useless_image
+        )
+
+        self.assertResultSetEqual(users_with_change_permission, [
+            self.superuser,
+            self.image_changer,
+            self.oneoff_image_changer,
+        ])
+
+        # an image with no owner is treated as if it's owned by 'somebody else' -
+        # i.e. users with 'change' permission can edit it
+        users_with_change_permission = self.policy.users_with_permission_for_instance(
+            'change', self.anonymous_image
+        )
+
+        self.assertResultSetEqual(users_with_change_permission, [
+            self.superuser,
+            self.image_changer,
+            self.oneoff_image_changer,
+        ])
+
+    def test_users_with_any_permission_for_instance(self):
+        users_with_change_or_frob_permission = self.policy.users_with_any_permission_for_instance(
+            ['change', 'frobnicate'], self.adder_image
+        )
+
+        self.assertResultSetEqual(users_with_change_or_frob_permission, [
+            self.superuser,
+            self.image_adder,
+            self.image_changer,
+            self.oneoff_image_changer,
+        ])

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -69,14 +69,8 @@ class AbstractDocument(models.Model, TagSearchable):
                        args=(self.id,))
 
     def is_editable_by_user(self, user):
-        if user.has_perm('wagtaildocs.change_document'):
-            # user has global permission to change documents
-            return True
-        elif user.has_perm('wagtaildocs.add_document') and self.uploaded_by_user == user:
-            # user has document add permission, which also implicitly provides permission to edit their own documents
-            return True
-        else:
-            return False
+        from wagtail.wagtaildocs.permissions import permission_policy
+        return permission_policy.user_has_permission_for_instance(user, 'change', self)
 
     class Meta:
         abstract = True

--- a/wagtail/wagtaildocs/permissions.py
+++ b/wagtail/wagtaildocs/permissions.py
@@ -1,0 +1,9 @@
+from wagtail.wagtailcore.permission_policies import OwnershipPermissionPolicy
+from wagtail.wagtaildocs.models import Document, get_document_model
+
+
+permission_policy = OwnershipPermissionPolicy(
+    get_document_model(),
+    auth_model=Document,
+    owner_field_name='uploaded_by_user'
+)

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
@@ -29,7 +29,12 @@
                             {% include "wagtailadmin/shared/field_as_li.html" %}
                         {% endif %}
                     {% endfor %}
-                    <li><input type="submit" value="{% trans 'Save' %}" /> <a href="{% url 'wagtaildocs:delete' document.id %}" class="button button-secondary no">{% trans "Delete document" %}</a></li>
+                    <li>
+                        <input type="submit" value="{% trans 'Save' %}" />
+                        {% if user_can_delete %}
+                            <a href="{% url 'wagtaildocs:delete' document.id %}" class="button button-secondary no">{% trans "Delete document" %}</a>
+                        {% endif %}
+                    </li>
                 </ul>
             </form>
         </div>

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/index.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/index.html
@@ -15,7 +15,7 @@
 {% block content %}
     {% trans "Documents" as doc_str %}
 
-    {% if perms.wagtaildocs.add_document %}
+    {% if user_can_add %}
         {% trans "Add a document" as add_doc_str %}
         {% include "wagtailadmin/shared/header.html" with title=doc_str add_link="wagtaildocs:add" icon="doc-full-inverse" add_text=add_doc_str search_url="wagtaildocs:index" %}
     {% else %}

--- a/wagtail/wagtaildocs/views/chooser.py
+++ b/wagtail/wagtaildocs/views/chooser.py
@@ -6,11 +6,15 @@ from django.shortcuts import get_object_or_404, render
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 from wagtail.wagtailadmin.forms import SearchForm
-from wagtail.wagtailadmin.utils import permission_required
+from wagtail.wagtailadmin.utils import PermissionPolicyChecker
 from wagtail.wagtailsearch.backends import get_search_backends
 
 from wagtail.wagtaildocs.models import get_document_model
 from wagtail.wagtaildocs.forms import get_document_form
+from wagtail.wagtaildocs.permissions import permission_policy
+
+
+permission_checker = PermissionPolicyChecker(permission_policy)
 
 
 def get_document_json(document):
@@ -29,7 +33,7 @@ def get_document_json(document):
 def chooser(request):
     Document = get_document_model()
 
-    if request.user.has_perm('wagtaildocs.add_document'):
+    if permission_policy.user_has_permission(request.user, 'add'):
         DocumentForm = get_document_form(Document)
         uploadform = DocumentForm()
     else:
@@ -81,7 +85,7 @@ def document_chosen(request, document_id):
     )
 
 
-@permission_required('wagtaildocs.add_document')
+@permission_checker.require('add')
 def chooser_upload(request):
     Document = get_document_model()
     DocumentForm = get_document_form(Document)

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -1,26 +1,31 @@
 from django.shortcuts import render, redirect, get_object_or_404
-from django.core.exceptions import PermissionDenied
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 from django.core.urlresolvers import reverse
 
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.forms import SearchForm
-from wagtail.wagtailadmin.utils import permission_required, any_permission_required
+from wagtail.wagtailadmin.utils import PermissionPolicyChecker, permission_denied
 from wagtail.wagtailsearch.backends import get_search_backends
 from wagtail.wagtailadmin import messages
 
 from wagtail.wagtaildocs.models import get_document_model
 from wagtail.wagtaildocs.forms import get_document_form
+from wagtail.wagtaildocs.permissions import permission_policy
 
 
-@any_permission_required('wagtaildocs.add_document', 'wagtaildocs.change_document')
+permission_checker = PermissionPolicyChecker(permission_policy)
+
+
+@permission_checker.require_any('add', 'change', 'delete')
 @vary_on_headers('X-Requested-With')
 def index(request):
     Document = get_document_model()
 
-    # Get documents
-    documents = Document.objects.all()
+    # Get documents (filtered by user permission)
+    documents = permission_policy.instances_user_has_any_permission_for(
+        request.user, ['change', 'delete']
+    )
 
     # Ordering
     if 'ordering' in request.GET and request.GET['ordering'] in ['title', '-created_at']:
@@ -28,11 +33,6 @@ def index(request):
     else:
         ordering = '-created_at'
     documents = documents.order_by(ordering)
-
-    # Permissions
-    if not request.user.has_perm('wagtaildocs.change_document'):
-        # restrict to the user's own documents
-        documents = documents.filter(uploaded_by_user=request.user)
 
     # Search
     query_string = None
@@ -64,10 +64,11 @@ def index(request):
 
             'search_form': form,
             'popular_tags': Document.popular_tags(),
+            'user_can_add': permission_policy.user_has_permission(request.user, 'add'),
         })
 
 
-@permission_required('wagtaildocs.add_document')
+@permission_checker.require('add')
 def add(request):
     Document = get_document_model()
     DocumentForm = get_document_form(Document)
@@ -96,14 +97,15 @@ def add(request):
     })
 
 
+@permission_checker.require('change')
 def edit(request, document_id):
     Document = get_document_model()
     DocumentForm = get_document_form(Document)
 
     doc = get_object_or_404(Document, id=document_id)
 
-    if not doc.is_editable_by_user(request.user):
-        raise PermissionDenied
+    if not permission_policy.user_has_permission_for_instance(request.user, 'change', doc):
+        return permission_denied(request)
 
     if request.POST:
         original_file = doc.file
@@ -149,16 +151,20 @@ def edit(request, document_id):
     return render(request, "wagtaildocs/documents/edit.html", {
         'document': doc,
         'filesize': filesize,
-        'form': form
+        'form': form,
+        'user_can_delete': permission_policy.user_has_permission_for_instance(
+            request.user, 'delete', doc
+        ),
     })
 
 
+@permission_checker.require('delete')
 def delete(request, document_id):
     Document = get_document_model()
     doc = get_object_or_404(Document, id=document_id)
 
-    if not doc.is_editable_by_user(request.user):
-        raise PermissionDenied
+    if not permission_policy.user_has_permission_for_instance(request.user, 'delete', doc):
+        return permission_denied(request)
 
     if request.POST:
         doc.delete()

--- a/wagtail/wagtaildocs/wagtail_hooks.py
+++ b/wagtail/wagtaildocs/wagtail_hooks.py
@@ -12,6 +12,7 @@ from wagtail.wagtailadmin.search import SearchArea
 
 from wagtail.wagtaildocs import admin_urls
 from wagtail.wagtaildocs.models import get_document_model
+from wagtail.wagtaildocs.permissions import permission_policy
 from wagtail.wagtaildocs.rich_text import DocumentLinkHandler
 
 
@@ -24,7 +25,9 @@ def register_admin_urls():
 
 class DocumentsMenuItem(MenuItem):
     def is_shown(self, request):
-        return request.user.has_perm('wagtaildocs.add_document') or request.user.has_perm('wagtaildocs.change_document')
+        return permission_policy.user_has_any_permission(
+            request.user, ['add', 'change', 'delete']
+        )
 
 
 @hooks.register('register_admin_menu_item')
@@ -87,7 +90,9 @@ def add_documents_summary_item(request, items):
 
 class DocsSearchArea(SearchArea):
     def is_shown(self, request):
-        return request.user.has_perm('wagtaildocs.add_document') or request.user.has_perm('wagtaildocs.change_document')
+        return permission_policy.user_has_any_permission(
+            request.user, ['add', 'change', 'delete']
+        )
 
 
 @hooks.register('register_admin_search_area')

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -295,14 +295,8 @@ class AbstractImage(models.Model, TagSearchable):
         return self.title
 
     def is_editable_by_user(self, user):
-        if user.has_perm('wagtailimages.change_image'):
-            # user has global permission to change images
-            return True
-        elif user.has_perm('wagtailimages.add_image') and self.uploaded_by_user == user:
-            # user has image add permission, which also implicitly provides permission to edit their own images
-            return True
-        else:
-            return False
+        from wagtail.wagtailimages.permissions import permission_policy
+        return permission_policy.user_has_permission_for_instance(user, 'change', self)
 
     class Meta:
         abstract = True

--- a/wagtail/wagtailimages/permissions.py
+++ b/wagtail/wagtailimages/permissions.py
@@ -1,0 +1,9 @@
+from wagtail.wagtailcore.permission_policies import OwnershipPermissionPolicy
+from wagtail.wagtailimages.models import Image, get_image_model
+
+
+permission_policy = OwnershipPermissionPolicy(
+    get_image_model(),
+    auth_model=Image,
+    owner_field_name='uploaded_by_user'
+)

--- a/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
@@ -45,7 +45,12 @@
                         {% endif %}
 
                     {% endfor %}
-                    <li><input type="submit" value="{% trans 'Save' %}" /><a href="{% url 'wagtailimages:delete' image.id %}" class="button button-secondary no">{% trans "Delete image" %}</a></li>
+                    <li>
+                        <input type="submit" value="{% trans 'Save' %}" />
+                        {% if user_can_delete %}
+                            <a href="{% url 'wagtailimages:delete' image.id %}" class="button button-secondary no">{% trans "Delete image" %}</a>
+                        {% endif %}
+                    </li>
                 </ul>
             </form>
         </div>

--- a/wagtail/wagtailimages/templates/wagtailimages/images/index.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/index.html
@@ -17,7 +17,7 @@
 {% block content %}
     {% trans "Images" as im_str %}
 
-    {% if perms.wagtailimages.add_image %}
+    {% if user_can_add %}
         {% trans "Add an image" as add_img_str %}
         {% include "wagtailadmin/shared/header.html" with title=im_str add_link="wagtailimages:add_multiple" icon="image" add_text=add_img_str search_url="wagtailimages:index" %}
     {% else %}

--- a/wagtail/wagtailimages/tests/test_admin_views.py
+++ b/wagtail/wagtailimages/tests/test_admin_views.py
@@ -640,7 +640,8 @@ class TestURLGeneratorView(TestCase, WagtailTestUtils):
 
     def test_get_bad_permissions(self):
         """
-        This tests that the view gives a 403 if a user without correct permissions attemts to access it
+        This tests that the view returns a "permission denied" redirect if a user without correct
+        permissions attemts to access it
         """
         # Remove privileges from user
         self.user.is_superuser = False
@@ -653,7 +654,7 @@ class TestURLGeneratorView(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtailimages:url_generator', args=(self.image.id, )))
 
         # Check response
-        self.assertEqual(response.status_code, 403)
+        self.assertRedirects(response, reverse('wagtailadmin_home'))
 
 
 class TestGenerateURLView(TestCase, WagtailTestUtils):

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -6,12 +6,16 @@ from django.shortcuts import get_object_or_404, render
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 from wagtail.wagtailadmin.forms import SearchForm
-from wagtail.wagtailadmin.utils import permission_required
+from wagtail.wagtailadmin.utils import PermissionPolicyChecker
 from wagtail.wagtailsearch.backends import get_search_backends
 
 from wagtail.wagtailimages.models import get_image_model
 from wagtail.wagtailimages.forms import get_image_form, ImageInsertionForm
 from wagtail.wagtailimages.formats import get_image_format
+from wagtail.wagtailimages.permissions import permission_policy
+
+
+permission_checker = PermissionPolicyChecker(permission_policy)
 
 
 def get_image_json(image):
@@ -36,7 +40,7 @@ def get_image_json(image):
 def chooser(request):
     Image = get_image_model()
 
-    if request.user.has_perm('wagtailimages.add_image'):
+    if permission_policy.user_has_permission(request.user, 'add'):
         ImageForm = get_image_form(Image)
         uploadform = ImageForm()
     else:
@@ -96,7 +100,7 @@ def image_chosen(request, image_id):
     )
 
 
-@permission_required('wagtailimages.add_image')
+@permission_checker.require('add')
 def chooser_upload(request):
     Image = get_image_model()
     ImageForm = get_image_form(Image)

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -1,7 +1,6 @@
 import os
 
 from django.shortcuts import render, redirect, get_object_or_404
-from django.core.exceptions import PermissionDenied
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 from django.core.urlresolvers import reverse, NoReverseMatch
@@ -11,27 +10,28 @@ from wagtail.utils.pagination import paginate
 from wagtail.wagtailcore.models import Site
 from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailadmin import messages
-from wagtail.wagtailadmin.utils import permission_required, any_permission_required
+from wagtail.wagtailadmin.utils import PermissionPolicyChecker, permission_denied
 from wagtail.wagtailsearch.backends import get_search_backends
 
 from wagtail.wagtailimages.models import get_image_model, Filter
 from wagtail.wagtailimages.forms import get_image_form, URLGeneratorForm
+from wagtail.wagtailimages.permissions import permission_policy
 from wagtail.wagtailimages.utils import generate_signature
 from wagtail.wagtailimages.exceptions import InvalidFilterSpecError
 
 
-@any_permission_required('wagtailimages.add_image', 'wagtailimages.change_image')
+permission_checker = PermissionPolicyChecker(permission_policy)
+
+
+@permission_checker.require_any('add', 'change', 'delete')
 @vary_on_headers('X-Requested-With')
 def index(request):
     Image = get_image_model()
 
-    # Get images
-    images = Image.objects.order_by('-created_at')
-
-    # Permissions
-    if not request.user.has_perm('wagtailimages.change_image'):
-        # restrict to the user's own images
-        images = images.filter(uploaded_by_user=request.user)
+    # Get images (filtered by user permission)
+    images = permission_policy.instances_user_has_any_permission_for(
+        request.user, ['change', 'delete']
+    ).order_by('-created_at')
 
     # Search
     query_string = None
@@ -61,17 +61,19 @@ def index(request):
 
             'search_form': form,
             'popular_tags': Image.popular_tags(),
+            'user_can_add': permission_policy.user_has_permission(request.user, 'add'),
         })
 
 
+@permission_checker.require('change')
 def edit(request, image_id):
     Image = get_image_model()
     ImageForm = get_image_form(Image)
 
     image = get_object_or_404(Image, id=image_id)
 
-    if not image.is_editable_by_user(request.user):
-        raise PermissionDenied
+    if not permission_policy.user_has_permission_for_instance(request.user, 'change', image):
+        return permission_denied(request)
 
     if request.POST:
         original_file = image.file
@@ -123,14 +125,17 @@ def edit(request, image_id):
         'form': form,
         'url_generator_enabled': url_generator_enabled,
         'filesize': image.get_file_size(),
+        'user_can_delete': permission_policy.user_has_permission_for_instance(
+            request.user, 'delete', image
+        ),
     })
 
 
 def url_generator(request, image_id):
     image = get_object_or_404(get_image_model(), id=image_id)
 
-    if not image.is_editable_by_user(request.user):
-        raise PermissionDenied
+    if not permission_policy.user_has_permission_for_instance(request.user, 'change', image):
+        return permission_denied(request)
 
     form = URLGeneratorForm(initial={
         'filter_method': 'original',
@@ -155,7 +160,7 @@ def generate_url(request, image_id, filter_spec):
         }, status=404)
 
     # Check if this user has edit permission on this image
-    if not image.is_editable_by_user(request.user):
+    if not permission_policy.user_has_permission_for_instance(request.user, 'change', image):
         return JsonResponse({
             'error': "You do not have permission to generate a URL for this image."
         }, status=403)
@@ -195,11 +200,12 @@ def preview(request, image_id, filter_spec):
         return HttpResponse("Invalid filter spec: " + filter_spec, content_type='text/plain', status=400)
 
 
+@permission_checker.require('delete')
 def delete(request, image_id):
     image = get_object_or_404(get_image_model(), id=image_id)
 
-    if not image.is_editable_by_user(request.user):
-        raise PermissionDenied
+    if not permission_policy.user_has_permission_for_instance(request.user, 'delete', image):
+        return permission_denied(request)
 
     if request.POST:
         image.delete()
@@ -211,7 +217,7 @@ def delete(request, image_id):
     })
 
 
-@permission_required('wagtailimages.add_image')
+@permission_checker.require('add')
 def add(request):
     ImageModel = get_image_model()
     ImageForm = get_image_form(ImageModel)

--- a/wagtail/wagtailimages/wagtail_hooks.py
+++ b/wagtail/wagtailimages/wagtail_hooks.py
@@ -12,6 +12,7 @@ from wagtail.wagtailadmin.search import SearchArea
 
 from wagtail.wagtailimages import admin_urls, image_operations
 from wagtail.wagtailimages.models import get_image_model
+from wagtail.wagtailimages.permissions import permission_policy
 from wagtail.wagtailimages.rich_text import ImageEmbedHandler
 
 
@@ -24,7 +25,9 @@ def register_admin_urls():
 
 class ImagesMenuItem(MenuItem):
     def is_shown(self, request):
-        return request.user.has_perm('wagtailimages.add_image') or request.user.has_perm('wagtailimages.change_image')
+        return permission_policy.user_has_any_permission(
+            request.user, ['add', 'change', 'delete']
+        )
 
 
 @hooks.register('register_admin_menu_item')
@@ -96,7 +99,9 @@ def add_images_summary_item(request, items):
 
 class ImagesSearchArea(SearchArea):
     def is_shown(self, request):
-        return request.user.has_perm('wagtailimages.add_image') or request.user.has_perm('wagtailimages.change_image')
+        return permission_policy.user_has_any_permission(
+            request.user, ['add', 'change', 'delete']
+        )
 
 
 @hooks.register('register_admin_search_area')

--- a/wagtail/wagtailredirects/permissions.py
+++ b/wagtail/wagtailredirects/permissions.py
@@ -1,0 +1,5 @@
+from wagtail.wagtailcore.permission_policies import ModelPermissionPolicy
+from wagtail.wagtailredirects.models import Redirect
+
+
+permission_policy = ModelPermissionPolicy(Redirect)

--- a/wagtail/wagtailredirects/templates/wagtailredirects/edit.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/edit.html
@@ -25,7 +25,9 @@
 
             <li>
                 <input type="submit" value="{% trans 'Save' %}" />
-                <a href="{% url 'wagtailredirects:delete' redirect.id %}" class="button button-secondary no">{% trans "Delete redirect" %}</a>
+                {% if user_can_delete %}
+                    <a href="{% url 'wagtailredirects:delete' redirect.id %}" class="button button-secondary no">{% trans "Delete redirect" %}</a>
+                {% endif %}
             </li>
         </ul>
     </form>

--- a/wagtail/wagtailredirects/templates/wagtailredirects/index.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/index.html
@@ -16,7 +16,11 @@
 {% block content %}
     {% trans "Redirects" as redirects_str %}
     {% trans "Add redirect" as add_str %}
-    {% include "wagtailadmin/shared/header.html" with title=redirects_str icon="redirect" add_link="wagtailredirects:add" add_text=add_str search_url="wagtailredirects:index" %}
+    {% if user_can_add %}
+        {% include "wagtailadmin/shared/header.html" with title=redirects_str icon="redirect" add_link="wagtailredirects:add" add_text=add_str search_url="wagtailredirects:index" %}
+    {% else %}
+        {% include "wagtailadmin/shared/header.html" with title=redirects_str icon="redirect" search_url="wagtailredirects:index" %}
+    {% endif %}
 
     <div class="nice-padding">
         <div id="redirects-results" class="redirects">

--- a/wagtail/wagtailredirects/views.py
+++ b/wagtail/wagtailredirects/views.py
@@ -5,18 +5,18 @@ from django.core.urlresolvers import reverse
 
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.forms import SearchForm
-from wagtail.wagtailadmin.utils import permission_required, any_permission_required
+from wagtail.wagtailadmin.utils import PermissionPolicyChecker, permission_denied
 from wagtail.wagtailadmin import messages
 
 from wagtail.wagtailredirects import models
 from wagtail.wagtailredirects.forms import RedirectForm
+from wagtail.wagtailredirects.permissions import permission_policy
 
 
-@any_permission_required(
-    'wagtailredirects.add_redirect',
-    'wagtailredirects.change_redirect',
-    'wagtailredirects.delete_redirect'
-)
+permission_checker = PermissionPolicyChecker(permission_policy)
+
+
+@permission_checker.require_any('add', 'change', 'delete')
 @vary_on_headers('X-Requested-With')
 def index(request):
     query_string = request.GET.get('q', "")
@@ -53,12 +53,18 @@ def index(request):
             'search_form': SearchForm(
                 data=dict(q=query_string) if query_string else None, placeholder=_("Search redirects")
             ),
+            'user_can_add': permission_policy.user_has_permission(request.user, 'add'),
         })
 
 
-@permission_required('wagtailredirects.change_redirect')
+@permission_checker.require('change')
 def edit(request, redirect_id):
     theredirect = get_object_or_404(models.Redirect, id=redirect_id)
+
+    if not permission_policy.user_has_permission_for_instance(
+        request.user, 'change', theredirect
+    ):
+        return permission_denied(request)
 
     if request.POST:
         form = RedirectForm(request.POST, request.FILES, instance=theredirect)
@@ -76,12 +82,18 @@ def edit(request, redirect_id):
     return render(request, "wagtailredirects/edit.html", {
         'redirect': theredirect,
         'form': form,
+        'user_can_delete': permission_policy.user_has_permission(request.user, 'delete'),
     })
 
 
-@permission_required('wagtailredirects.delete_redirect')
+@permission_checker.require('delete')
 def delete(request, redirect_id):
     theredirect = get_object_or_404(models.Redirect, id=redirect_id)
+
+    if not permission_policy.user_has_permission_for_instance(
+        request.user, 'delete', theredirect
+    ):
+        return permission_denied(request)
 
     if request.POST:
         theredirect.delete()
@@ -93,7 +105,7 @@ def delete(request, redirect_id):
     })
 
 
-@permission_required('wagtailredirects.add_redirect')
+@permission_checker.require('add')
 def add(request):
     if request.POST:
         form = RedirectForm(request.POST, request.FILES)

--- a/wagtail/wagtailredirects/wagtail_hooks.py
+++ b/wagtail/wagtailredirects/wagtail_hooks.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import Permission
 
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailredirects import urls
+from wagtail.wagtailredirects.permissions import permission_policy
 
 from wagtail.wagtailadmin.menu import MenuItem
 
@@ -18,10 +19,8 @@ def register_admin_urls():
 
 class RedirectsMenuItem(MenuItem):
     def is_shown(self, request):
-        return (
-            request.user.has_perm('wagtailredirects.add_redirect')
-            or request.user.has_perm('wagtailredirects.change_redirect')
-            or request.user.has_perm('wagtailredirects.delete_redirect')
+        return permission_policy.user_has_any_permission(
+            request.user, ['add', 'change', 'delete']
         )
 
 

--- a/wagtail/wagtailsites/views.py
+++ b/wagtail/wagtailsites/views.py
@@ -1,24 +1,24 @@
 from django.utils.translation import ugettext_lazy as __
 
 from wagtail.wagtailcore.models import Site
+from wagtail.wagtailcore.permissions import site_permission_policy
 from wagtail.wagtailsites.forms import SiteForm
 from wagtail.wagtailadmin.views.generic import IndexView, CreateView, EditView, DeleteView
 
 
 class Index(IndexView):
-    any_permission_required = ['wagtailcore.add_site', 'wagtailcore.change_site', 'wagtailcore.delete_site']
+    permission_policy = site_permission_policy
     model = Site
     context_object_name = 'sites'
     template_name = 'wagtailsites/index.html'
     add_url_name = 'wagtailsites:add'
-    add_permission_name = 'wagtailcore.add_site'
     page_title = __("Sites")
     add_item_label = __("Add a site")
     header_icon = 'site'
 
 
 class Create(CreateView):
-    permission_required = 'wagtailcore.add_site'
+    permission_policy = site_permission_policy
     form_class = SiteForm
     page_title = __("Add site")
     success_message = __("Site '{0}' created.")
@@ -30,7 +30,7 @@ class Create(CreateView):
 
 
 class Edit(EditView):
-    permission_required = 'wagtailcore.change_site'
+    permission_policy = site_permission_policy
     model = Site
     form_class = SiteForm
     success_message = __("Site '{0}' updated.")
@@ -39,14 +39,13 @@ class Edit(EditView):
     edit_url_name = 'wagtailsites:edit'
     index_url_name = 'wagtailsites:index'
     delete_url_name = 'wagtailsites:delete'
-    delete_permission_name = 'wagtailcore.delete_site'
     context_object_name = 'site'
     template_name = 'wagtailsites/edit.html'
     header_icon = 'site'
 
 
 class Delete(DeleteView):
-    permission_required = 'wagtailcore.delete_site'
+    permission_policy = site_permission_policy
     model = Site
     success_message = __("Site '{0}' deleted.")
     index_url_name = 'wagtailsites:index'

--- a/wagtail/wagtailsites/wagtail_hooks.py
+++ b/wagtail/wagtailsites/wagtail_hooks.py
@@ -4,6 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth.models import Permission
 
 from wagtail.wagtailcore import hooks
+from wagtail.wagtailcore.permissions import site_permission_policy
 from wagtail.wagtailadmin.menu import MenuItem
 
 from wagtail.wagtailsites import urls
@@ -18,10 +19,8 @@ def register_admin_urls():
 
 class SitesMenuItem(MenuItem):
     def is_shown(self, request):
-        return (
-            request.user.has_perm('wagtailcore.add_site')
-            or request.user.has_perm('wagtailcore.change_site')
-            or request.user.has_perm('wagtailcore.delete_site')
+        return site_permission_policy.user_has_any_permission(
+            request.user, ['add', 'change', 'delete']
         )
 
 


### PR DESCRIPTION
This PR implements permission policies, as originally proposed in https://github.com/torchbox/wagtail/issues/1384#issuecomment-142655487. These are objects that provide a central point for making permission queries for a particular model - such as "can user X perform action Y on instance Z?" or "which instances can user X perform action Y on?". By collecting this logic into a single module, rather than having it distributed across templates, views and models, it's possible to redefine the permission rules for an app by swapping in a new policy object.

The currently defined permission policies are:

* `BlanketPermissionPolicy` - allow everyone (including anonymous users) to do everything, effectively disabling permission rules entirely
* `AuthenticationOnlyPermissionPolicy` - allow all active, authenticated users to do everything
* `ModelPermissionPolicy` - apply standard `django.contrib.auth` permission rules, which act on the model as a whole (i.e. it's not possible to give a user edit access to a subset of a model's instances)
* `OwnershipPermissionPolicy` - the current behaviour of documents / images, appropriate for models that have a concept of 'ownership', where a user with 'add' permission automatically receives permission to change/delete instances they own.

wagtailimages, wagtaildocs and wagtailredirects have been converted to use permission policies, along with wagtailadmin's generic views (which means that wagtailsites uses them as well).

The immediate use-case for this will be to switch wagtailimages and wagtaildocs to the collections system (#1751), but with further work it will be possible to:

* Allow individual Wagtail installations to customise permission policies via settings (#1384). I haven't worked out the best way of doing this - could we pass it as an appconf parameter in INSTALLED_APPS, perhaps?
* Customise the page permission model (#1993). I haven't attempted this here as page permissions will be significantly more complex - more operations to consider (e.g. move / copy), more business rules to account for (e.g. parent_page_types / subpage_types), and the UserPermissionProxy / PagePermissionTester pattern (which would be a useful extension to the permission policy API in general, as it avoids repeated DB hits on listing pages).
* Build up the group permission interface programmatically so that it outputs just the checkboxes relevant to the permission policy in use, rather than the app having to specifically register them. (For example - BlanketPermissionPolicy and AuthenticationOnlyPermissionPolicy would not add anything to the permissions interface, as there's nothing to configure; ModelPermissionPolicy would supply checkboxes for add, change and delete, and OwnershipPermissionPolicy would supply checkboxes for add and change, as it doesn't distinguish between change and delete permissions.)
* Potentially, implement custom workflows (#1712) - as I see it, these can be modelled as a state machine, along with a permission policy that varies permissions on an object according to its current state.