### PR TITLE
Explicitly set wagtailcore_page.path to use the 'C' collation

### DIFF
--- a/wagtail/wagtailcore/migrations/0001_initial.py
+++ b/wagtail/wagtailcore/migrations/0001_initial.py
@@ -6,6 +6,20 @@ from django.conf import settings
 import wagtail.wagtailsearch.index
 
 
+def set_page_path_collation(apps, schema_editor):
+    """
+    Treebeard's path comparison logic can fail on certain locales such as sk_SK, which
+    sort numbers after letters. To avoid this, we explicitly set the collation for the
+    'path' column to the (non-locale-specific) 'C' collation.
+
+    See: https://groups.google.com/d/msg/wagtail/q0leyuCnYWI/I9uDvVlyBAAJ
+    """
+    if schema_editor.connection.vendor == 'postgresql':
+        schema_editor.execute("""
+            ALTER TABLE wagtailcore_page ALTER COLUMN path TYPE VARCHAR(255) COLLATE "C"
+        """)
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -81,6 +95,9 @@ class Migration(migrations.Migration):
                 'abstract': False,
             },
             bases=(models.Model, wagtail.wagtailsearch.index.Indexed),
+        ),
+        migrations.RunPython(
+            set_page_path_collation, migrations.RunPython.noop
         ),
         migrations.CreateModel(
             name='PageRevision',


### PR DESCRIPTION
Treebeard's path comparison logic can fail on certain locales such as sk_SK, which
sort numbers after letters. To avoid this, we explicitly set the collation for the
'path' column to the (non-locale-specific) 'C' collation.

Ref: https://groups.google.com/d/msg/wagtail/q0leyuCnYWI/I9uDvVlyBAAJ

To reproduce the original issue (on a standard wagtaildemo vagrant installation):

    sudo locale-gen sk_SK.UTF-8
    sudo dpkg-reconfigure locales
    sudo /etc/init.d/postgresql restart
    dropdb wagtaildemo
    createdb wagtaildemo --locale=sk_SK.UTF-8 --template=template0
    ./manage.py migrate
    ./manage.py load_initial_data
