### PR TITLE
Fix static asset building on Windows

### DIFF
--- a/gulpfile.js/lib/normalize-path.js
+++ b/gulpfile.js/lib/normalize-path.js
@@ -1,0 +1,13 @@
+var quoteRegExp = function (str) {
+    return (str + '').replace(/[.?*+^$[\]\\(){}|-]/g, "\\$&");
+};
+var re = new RegExp(quoteRegExp(require("path").sep), "g");
+
+/**
+ * Normalize path separators to forward slashes
+ * @param path A path in either Windows or POSIX format
+ * @returns {string} A path in POSIX format
+ */
+module.exports = function (path) {
+    return ("" + path).replace(re, "/");
+};

--- a/gulpfile.js/lib/simplyCopy.js
+++ b/gulpfile.js/lib/simplyCopy.js
@@ -3,6 +3,7 @@ var rename = require('gulp-rename');
 var gutil = require('gulp-util');
 var path = require('path');
 var config = require('../config');
+var normalizePath = require('../lib/normalize-path');
 
 /*
  * Simple copy task - just copoes files from the source to the destination,
@@ -12,7 +13,7 @@ var config = require('../config');
  
 var renameSrcToDest = function() {
     return rename(function(filePath) {
-        filePath.dirname = filePath.dirname.replace(
+        filePath.dirname = normalizePath(filePath.dirname).replace(
             '/' + config.srcDir + '/',
             '/' + config.destDir + '/');
     });

--- a/gulpfile.js/tasks/styles.js
+++ b/gulpfile.js/tasks/styles.js
@@ -3,6 +3,7 @@ var sass = require('gulp-sass');
 var config = require('../config');
 var autoprefixer = require('gulp-autoprefixer');
 var simpleCopyTask = require('../lib/simplyCopy');
+var normalizePath = require('../lib/normalize-path');
 var gutil = require('gulp-util');
 
 var flatten = function(arrOfArr) {
@@ -38,9 +39,9 @@ gulp.task('styles:sass', function () {
         .pipe(gulp.dest(function(file) {
             // e.g. wagtailadmin/scss/core.scss -> wagtailadmin/css/core.css
             // Changing the suffix is done by Sass automatically
-            return file.base
+            return normalizePath(file.base)
                 .replace(
-                    '/' + config.srcDir + '/', 
+                    '/' + config.srcDir + '/',
                     '/' + config.destDir + '/'
                 )
                 .replace('/scss/', '/css/');


### PR DESCRIPTION
Using `path.sep` instead of the constant `'/'` makes the build pipeline copy the files into the correct directories.