### PR TITLE
Replaced SubFieldBase with Field.from_db_value

### DIFF
--- a/wagtail/wagtailcore/fields.py
+++ b/wagtail/wagtailcore/fields.py
@@ -5,7 +5,7 @@ import json
 from django.db import models
 from django import forms
 from django.core.serializers.json import DjangoJSONEncoder
-from django.utils.six import with_metaclass, string_types
+from django.utils.six import string_types
 
 from wagtail.wagtailcore.rich_text import DbWhitelister, expand_db_html
 from wagtail.utils.widgets import WidgetWithScript

--- a/wagtail/wagtailcore/fields.py
+++ b/wagtail/wagtailcore/fields.py
@@ -41,7 +41,7 @@ class RichTextField(models.TextField):
         return super(RichTextField, self).formfield(**defaults)
 
 
-class StreamField(with_metaclass(models.SubfieldBase, models.Field)):
+class StreamField(models.Field):
     def __init__(self, block_types, **kwargs):
         if isinstance(block_types, Block):
             self.stream_block = block_types
@@ -108,6 +108,9 @@ class StreamField(with_metaclass(models.SubfieldBase, models.Field)):
             return value.raw_text
         else:
             return json.dumps(self.stream_block.get_prep_value(value), cls=DjangoJSONEncoder)
+
+    def from_db_value(self, value, expression, connection, context):
+        return self.to_python(value)
 
     def formfield(self, **kwargs):
         """

--- a/wagtail/wagtailcore/fields.py
+++ b/wagtail/wagtailcore/fields.py
@@ -41,6 +41,23 @@ class RichTextField(models.TextField):
         return super(RichTextField, self).formfield(**defaults)
 
 
+# https://github.com/django/django/blob/64200c14e0072ba0ffef86da46b2ea82fd1e019a/django/db/models/fields/subclassing.py#L31-L44
+class Creator(object):
+    """
+    A placeholder class that provides a way to set the attribute on the model.
+    """
+    def __init__(self, field):
+        self.field = field
+
+    def __get__(self, obj, type=None):
+        if obj is None:
+            return self
+        return obj.__dict__[self.field.name]
+
+    def __set__(self, obj, value):
+        obj.__dict__[self.field.name] = self.field.to_python(value)
+
+
 class StreamField(models.Field):
     def __init__(self, block_types, **kwargs):
         if isinstance(block_types, Block):
@@ -132,3 +149,10 @@ class StreamField(models.Field):
         errors = super(StreamField, self).check(**kwargs)
         errors.extend(self.stream_block.check(field=self, **kwargs))
         return errors
+
+    def contribute_to_class(self, cls, name, **kwargs):
+        super(StreamField, self).contribute_to_class(cls, name, **kwargs)
+
+        # Add Creator descriptor to allow the field to be set from a list or a
+        # JSON string.
+        setattr(cls, self.name, Creator(self))


### PR DESCRIPTION
Fixes #2070 

Doing this fix broke the ability to assign a string or a list to a streamfield. It looks like this is behaviour we want to support so the second commit reinstates it by copying some code from Django.