### PR TITLE
Add python version to all Travis matrix options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,19 @@ sudo: false
 matrix:
   include:
    - env: TOXENV=py27-dj18-postgres
+     python: 2.7
    - env: TOXENV=py27-dj18-mysql
+     python: 2.7
    - env: TOXENV=py27-dj18-sqlite
+     python: 2.7
    - env: TOXENV=py33-dj18-postgres
+     python: 3.3
    - env: TOXENV=py34-dj18-postgres
+     python: 3.4
    - env: TOXENV=py34-dj18-sqlite
+     python: 3.4
    - env: TOXENV=py34-dj18-mysql
+     python: 3.4
    - env: TOXENV=py35-dj18-postgres
      python: 3.5
    - env: TOXENV=py35-dj18-sqlite
@@ -20,12 +27,16 @@ matrix:
    - env: TOXENV=py35-dj18-mysql
      python: 3.5
    - env: TOXENV=py27-dj19-postgres
+     python: 2.7
 #   - env: TOXENV=py27-dj19-mysql
 #   - env: TOXENV=py27-dj19-sqlite
 #  - env: TOXENV=py33-dj19-postgres
    - env: TOXENV=py34-dj19-postgres
+     python: 3.4
    - env: TOXENV=py34-dj19-sqlite
+     python: 3.4
    - env: TOXENV=py34-dj19-mysql
+     python: 3.4
    - env: TOXENV=py35-dj19-postgres
      python: 3.5
    - env: TOXENV=py35-dj19-sqlite


### PR DESCRIPTION
Here is a small change to show the correct Python version in the Travis build job results, rather than "no language set"

We were already doing it for Python 3.5