### PR TITLE
Rewrite group page permissions form to use checkboxes

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1438,11 +1438,16 @@ class PageRevision(models.Model):
         verbose_name_plural = _('page revisions')
 
 
+PAGE_PERMISSION_TYPES = [
+    ('add', _("Add"), _("Add/edit pages you own")),
+    ('edit', _("Edit"), _("Edit any page")),
+    ('publish', _("Publish"), _("Publish any page")),
+    ('lock', _("Lock"), _("Lock/unlock any page")),
+]
+
 PAGE_PERMISSION_TYPE_CHOICES = [
-    ('add', _('Add/edit pages you own')),
-    ('edit', _('Edit any page')),
-    ('publish', _('Publish any page')),
-    ('lock', _('Lock/unlock any page')),
+    (identifier, long_label)
+    for identifier, short_label, long_label in PAGE_PERMISSION_TYPES
 ]
 
 

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/includes/page_permissions_form.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/includes/page_permissions_form.html
@@ -2,13 +2,12 @@
 
 <td>
     {% include "wagtailadmin/shared/field.html" with field=form.page only %}
-</td>
-<td>
-    {% include "wagtailadmin/shared/field.html" with field=form.permission_type only %}
-
-    {{ form.id }}
     {{ form.DELETE }}
 </td>
+
+{% for option in form.permission_types %}
+    <td>{{ option.tag }}</td>
+{% endfor %}
 
 <td>
     <button class="button-secondary button-small no" type="button" id="{{ form.DELETE.id_for_label }}-button">{% trans "Delete" %}</button>

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/includes/page_permissions_formset.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/includes/page_permissions_formset.html
@@ -3,14 +3,26 @@
 
 {{ formset.management_form }}
 
+{% if formset.non_form_errors %}
+    <p class="error-message">
+        {% for error in formset.non_form_errors %}
+            <span>{{ error }}</span>
+        {% endfor %}
+    </p>
+{% endif %}
+
 <table class="listing">
-    <col width="40%"/>
-    <col width="40%" />
+    <col />
+    {% for i in formset.permission_types %}
+        <col width="15%" />
+    {% endfor %}
     <col />
     <thead>
         <tr>
             <th>{% trans "Page" %}</th>
-            <th>{% trans "Permission type" %}</th>
+            {% for identifier, short_label, long_label in formset.permission_types %}
+                <th title="{{ long_label }}">{{ short_label }}</th>
+            {% endfor %}
             <th></th>
         </tr>
     </thead>

--- a/wagtail/wagtailusers/tests.py
+++ b/wagtail/wagtailusers/tests.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-import unittest
-
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 from django.contrib.auth import get_user_model
@@ -244,13 +242,9 @@ class TestGroupCreateView(TestCase, WagtailTestUtils):
     def test_group_create_adding_permissions(self):
         response = self.post({
             'name': "test group",
-            'page_permissions-0-id': [''],
             'page_permissions-0-page': ['1'],
-            'page_permissions-0-permission_type': ['publish'],
-            'page_permissions-1-id': [''],
-            'page_permissions-1-page': ['1'],
-            'page_permissions-1-permission_type': ['edit'],
-            'page_permissions-TOTAL_FORMS': ['2'],
+            'page_permissions-0-permission_types': ['edit', 'publish'],
+            'page_permissions-TOTAL_FORMS': ['1'],
         })
 
         self.assertRedirects(response, reverse('wagtailusers_groups:index'))
@@ -258,24 +252,20 @@ class TestGroupCreateView(TestCase, WagtailTestUtils):
         new_group = Group.objects.get(name='test group')
         self.assertEqual(new_group.page_permissions.all().count(), 2)
 
-    @unittest.expectedFailure
     def test_duplicate_page_permissions_error(self):
-        # Try to submit duplicate page permission entries
+        # Try to submit multiple page permission entries for the same page
         response = self.post({
             'name': "test group",
-            'page_permissions-0-id': [''],
             'page_permissions-0-page': ['1'],
-            'page_permissions-0-permission_type': ['publish'],
-            'page_permissions-1-id': [''],
+            'page_permissions-0-permission_types': ['publish'],
             'page_permissions-1-page': ['1'],
-            'page_permissions-1-permission_type': ['publish'],
+            'page_permissions-1-permission_types': ['edit'],
             'page_permissions-TOTAL_FORMS': ['2'],
         })
 
         self.assertEqual(response.status_code, 200)
-        # the second form should have errors
-        self.assertEqual(bool(response.context['formset'].errors[0]), False)
-        self.assertEqual(bool(response.context['formset'].errors[1]), True)
+        # formset should have a non-form error about the duplication
+        self.assertTrue(response.context['formset'].non_form_errors)
 
 
 class TestGroupEditView(TestCase, WagtailTestUtils):
@@ -286,6 +276,8 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         self.root_add_permission = GroupPagePermission.objects.create(page=self.root_page,
                                                                       permission_type='add',
                                                                       group=self.test_group)
+        self.home_page = Page.objects.get(id=2)
+
         # Get the hook-registered permissions, and add one to this group
         self.registered_permissions = Permission.objects.none()
         for fn in hooks.get_hooks('register_permissions'):
@@ -307,10 +299,9 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
             'permissions': [self.existing_permission.id],
             'page_permissions-TOTAL_FORMS': ['1'],
             'page_permissions-MAX_NUM_FORMS': ['1000'],
-            'page_permissions-INITIAL_FORMS': ['1'],  # as we have one page permission already
-            'page_permissions-0-id': [self.root_add_permission.id],
-            'page_permissions-0-page': [self.root_add_permission.page.id],
-            'page_permissions-0-permission_type': [self.root_add_permission.permission_type]
+            'page_permissions-INITIAL_FORMS': ['1'],
+            'page_permissions-0-page': [self.root_page.id],
+            'page_permissions-0-permission_types': ['add']
         }
         for k, v in six.iteritems(post_defaults):
             post_data[k] = post_data.get(k, v)
@@ -352,17 +343,26 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         # Should not redirect to index
         self.assertEqual(response.status_code, 200)
 
-    def test_group_edit_adding_page_permissions(self):
-        # The test group has one page permission to begin with
+    def test_group_edit_adding_page_permissions_same_page(self):
+        # The test group has one page permission to begin with - 'add' permission on root.
+        # Add two additional permission types on the root page
         self.assertEqual(self.test_group.page_permissions.count(), 1)
         response = self.post({
-            'page_permissions-1-id': [''],
-            'page_permissions-1-page': ['1'],
-            'page_permissions-1-permission_type': ['publish'],
-            'page_permissions-2-id': [''],
-            'page_permissions-2-page': ['1'],
-            'page_permissions-2-permission_type': ['edit'],
-            'page_permissions-TOTAL_FORMS': ['3'],
+            'page_permissions-0-permission_types': ['add', 'publish', 'edit'],
+        })
+
+        self.assertRedirects(response, reverse('wagtailusers_groups:index'))
+        # The test group now has three page permissions
+        self.assertEqual(self.test_group.page_permissions.count(), 3)
+
+    def test_group_edit_adding_page_permissions_different_page(self):
+        # The test group has one page permission to begin with - 'add' permission on root.
+        # Add two additional permission types, on the home page
+        self.assertEqual(self.test_group.page_permissions.count(), 1)
+        response = self.post({
+            'page_permissions-TOTAL_FORMS': ['2'],
+            'page_permissions-1-page': [self.home_page.id],
+            'page_permissions-1-permission_types': ['add', 'publish']
         })
 
         self.assertRedirects(response, reverse('wagtailusers_groups:index'))
@@ -388,34 +388,75 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         response = self.get()
 
         self.assertEqual(response.context['formset'].management_form['INITIAL_FORMS'].value(), 1)
-        self.assertEqual(response.context['formset'].forms[0].instance, self.root_add_permission)
+        self.assertEqual(
+            response.context['formset'].forms[0]['page'].value(),
+            self.root_page.id
+        )
+        self.assertEqual(
+            response.context['formset'].forms[0]['permission_types'].value(),
+            ['add']
+        )
 
-        root_edit_perm = GroupPagePermission.objects.create(page=self.root_page,
-                                                            permission_type='edit',
-                                                            group=self.test_group)
+        # add edit permission on root
+        GroupPagePermission.objects.create(
+            page=self.root_page, permission_type='edit', group=self.test_group
+        )
 
-        # The test group now has two page permissions
+        # The test group now has two page permissions on root (but only one form covering both)
         self.assertEqual(self.test_group.page_permissions.count(), 2)
 
         # Reload the page and check the form instances
         response = self.get()
+        self.assertEqual(response.context['formset'].management_form['INITIAL_FORMS'].value(), 1)
+        self.assertEqual(len(response.context['formset'].forms), 1)
+        self.assertEqual(
+            response.context['formset'].forms[0]['page'].value(),
+            self.root_page.id
+        )
+        self.assertEqual(
+            response.context['formset'].forms[0]['permission_types'].value(),
+            ['add', 'edit']
+        )
+
+        # add edit permission on home
+        GroupPagePermission.objects.create(
+            page=self.home_page, permission_type='edit', group=self.test_group
+        )
+
+        # The test group now has three page permissions, over two forms
+        self.assertEqual(self.test_group.page_permissions.count(), 3)
+
+        # Reload the page and check the form instances
+        response = self.get()
         self.assertEqual(response.context['formset'].management_form['INITIAL_FORMS'].value(), 2)
-        self.assertEqual(response.context['formset'].forms[0].instance, self.root_add_permission)
-        self.assertEqual(response.context['formset'].forms[1].instance, root_edit_perm)
+        self.assertEqual(
+            response.context['formset'].forms[0]['page'].value(),
+            self.root_page.id
+        )
+        self.assertEqual(
+            response.context['formset'].forms[0]['permission_types'].value(),
+            ['add', 'edit']
+        )
+        self.assertEqual(
+            response.context['formset'].forms[1]['page'].value(),
+            self.home_page.id
+        )
+        self.assertEqual(
+            response.context['formset'].forms[1]['permission_types'].value(),
+            ['edit']
+        )
 
     def test_duplicate_page_permissions_error(self):
-        # Try to submit duplicate page permission entries
+        # Try to submit multiple page permission entries for the same page
         response = self.post({
-            'page_permissions-1-id': [''],
-            'page_permissions-1-page': [self.root_add_permission.page.id],
-            'page_permissions-1-permission_type': [self.root_add_permission.permission_type],
+            'page_permissions-1-page': [self.root_page.id],
+            'page_permissions-1-permission_types': ['edit'],
             'page_permissions-TOTAL_FORMS': ['2'],
         })
 
         self.assertEqual(response.status_code, 200)
-        # the second form should have errors
-        self.assertEqual(bool(response.context['formset'].errors[0]), False)
-        self.assertEqual(bool(response.context['formset'].errors[1]), True)
+        # the formset should have a non-form error
+        self.assertTrue(response.context['formset'].non_form_errors)
 
     def test_group_add_registered_django_permissions(self):
         # The test group has one django permission to begin with

--- a/wagtail/wagtailusers/views/groups.py
+++ b/wagtail/wagtailusers/views/groups.py
@@ -62,12 +62,12 @@ def index(request):
 
 @permission_required('auth.add_group')
 def create(request):
+    group = Group()
     if request.POST:
-        form = GroupForm(request.POST)
-        formset = GroupPagePermissionFormSet(request.POST)
+        form = GroupForm(request.POST, instance=group)
+        formset = GroupPagePermissionFormSet(request.POST, instance=group)
         if form.is_valid() and formset.is_valid():
-            group = form.save()
-            formset.instance = group
+            form.save()
             formset.save()
             messages.success(request, _("Group '{0}' created.").format(group), buttons=[
                 messages.button(reverse('wagtailusers_groups:edit', args=(group.id,)), _('Edit'))
@@ -76,8 +76,8 @@ def create(request):
         else:
             messages.error(request, _("The group could not be created due to errors."))
     else:
-        form = GroupForm()
-        formset = GroupPagePermissionFormSet()
+        form = GroupForm(instance=group)
+        formset = GroupPagePermissionFormSet(instance=group)
 
     return render(request, 'wagtailusers/groups/create.html', {
         'form': form,
@@ -92,7 +92,7 @@ def edit(request, group_id):
         form = GroupForm(request.POST, instance=group)
         formset = GroupPagePermissionFormSet(request.POST, instance=group)
         if form.is_valid() and formset.is_valid():
-            group = form.save()
+            form.save()
             formset.save()
             messages.success(request, _("Group '{0}' updated.").format(group), buttons=[
                 messages.button(reverse('wagtailusers_groups:edit', args=(group.id,)), _('Edit'))


### PR DESCRIPTION
Fixes #1488. All permission types for a particular page are now displayed as a row of checkboxes, avoiding the impression given by the old dropdown interface that the permission types were mutually exclusive:

<img width="847" alt="screen shot 2016-01-18 at 23 28 29" src="https://cloud.githubusercontent.com/assets/85097/12405356/44f91512-be3b-11e5-83f6-d4842efe0962.png">

This also serves as (yet more) foundational work for collections - collection-based permissions will use a similar interface, since it's essential that we keep the UI for image / document permissions as close as possible to the pre-collections version (where images/documents are part of the 'Object Permissions' block).
