### PR TITLE
making datetimepicker aware of FIRST_DAY_OF_WEEK

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -71,9 +71,9 @@ function insertRichTextDeleteControl(elem) {
     });
 }
 
-function initDateChooser(id) {
+function initDateChooser(id, opts) {
     if (window.dateTimePickerTranslations) {
-        $('#' + id).datetimepicker({
+        $('#' + id).datetimepicker($.extend({
             closeOnDateSelect: true,
             timepicker: false,
             scrollInput:false,
@@ -82,13 +82,13 @@ function initDateChooser(id) {
                 lang: window.dateTimePickerTranslations
             },
             lang: 'lang'
-        });
+        }, opts || {}));
     } else {
-        $('#' + id).datetimepicker({
+        $('#' + id).datetimepicker($.extend({
             timepicker: false,
             scrollInput:false,
             format: 'Y-m-d'
-        });
+        }, opts || {}));
     }
 }
 
@@ -112,9 +112,9 @@ function initTimeChooser(id) {
     }
 }
 
-function initDateTimeChooser(id) {
+function initDateTimeChooser(id, opts) {
     if (window.dateTimePickerTranslations) {
-        $('#' + id).datetimepicker({
+        $('#' + id).datetimepicker($.extend({
             closeOnDateSelect: true,
             format: 'Y-m-d H:i',
             scrollInput:false,
@@ -122,11 +122,11 @@ function initDateTimeChooser(id) {
                 lang: window.dateTimePickerTranslations
             },
             language: 'lang'
-        });
+        }, opts || {}));
     } else {
-        $('#' + id).datetimepicker({
+        $('#' + id).datetimepicker($.extend({
             format: 'Y-m-d H:i'
-        });
+        }, opts || {}));
     }
 }
 

--- a/wagtail/wagtailadmin/widgets.py
+++ b/wagtail/wagtailadmin/widgets.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import json
 
+from django.utils.formats import get_format
 from django.core.urlresolvers import reverse
 from django.forms import widgets
 from django.contrib.contenttypes.models import ContentType
@@ -36,7 +37,7 @@ class AdminDateInput(WidgetWithScript, widgets.DateInput):
         super(AdminDateInput, self).__init__(attrs=attrs, format=format)
 
     def render_js_init(self, id_, name, value):
-        return 'initDateChooser({0});'.format(json.dumps(id_))
+        return 'initDateChooser({0});'.format(json.dumps(id_), json.dumps(dict(dayOfWeekStart=get_format('FIRST_DAY_OF_WEEK'))))
 
 
 class AdminTimeInput(WidgetWithScript, widgets.TimeInput):
@@ -52,7 +53,7 @@ class AdminDateTimeInput(WidgetWithScript, widgets.DateTimeInput):
         super(AdminDateTimeInput, self).__init__(attrs=attrs, format=format)
 
     def render_js_init(self, id_, name, value):
-        return 'initDateTimeChooser({0});'.format(json.dumps(id_))
+        return 'initDateTimeChooser({0}, {1});'.format(json.dumps(id_), json.dumps(dict(dayOfWeekStart=get_format('FIRST_DAY_OF_WEEK'))))
 
 
 class AdminTagWidget(WidgetWithScript, TagWidget):


### PR DESCRIPTION
Adds support for passing arbitrary options on to the datepicker widget to ``initDateChooser`` and ``initDateTimeChooser``. Passes django's ``FIRST_DAY_OF_WEEK`` as ``dayOfWeekStart``in ``render_js_init``.

See #2129.