### PR TITLE
Clarify what the Administrator flag does

### DIFF
--- a/wagtail/wagtailusers/forms.py
+++ b/wagtail/wagtailusers/forms.py
@@ -53,7 +53,7 @@ class UserCreationForm(UsernameForm):
     is_superuser = forms.BooleanField(
         label=_("Administrator"),
         required=False,
-        help_text=_("If ticked, this user has the ability to manage user accounts.")
+        help_text=_("Administrators have full access to manage any object or setting.")
     )
 
     password1 = forms.CharField(
@@ -139,7 +139,7 @@ class UserEditForm(UsernameForm):
     is_superuser = forms.BooleanField(
         label=_("Administrator"),
         required=False,
-        help_text=_("Administrators have the ability to manage user accounts.")
+        help_text=_("Administrators have full access to manage any object or setting.")
     )
 
     class Meta:
@@ -200,7 +200,7 @@ class GroupForm(forms.ModelForm):
     is_superuser = forms.BooleanField(
         label=_("Administrator"),
         required=False,
-        help_text=_("Administrators have the ability to manage user accounts.")
+        help_text=_("Administrators have full access to manage any object or setting.")
     )
 
     class Meta:


### PR DESCRIPTION
This is something that confused me a little as a Wagtail newcomer.

In user admin the Administrator flag actually sets the `is_superuser` field, which then goes on to shortcut all the normal permissions checking. So saying that it gives _"the ability to manage user accounts"_ is rather an understatement. For example, a user with very little privilege will suddenly be able to delete sites, groups, documents and more as soon as this is ticked.

This change just modifies the help text for the Administrator field. You could argue that the group membership list should be disabled when `is_superuser` is `True`, but in my opinion that isn't necessary.