### PR TITLE
Fix oembed regex pattern for Wistia

### DIFF
--- a/wagtail/wagtailembeds/oembed_providers.py
+++ b/wagtail/wagtailembeds/oembed_providers.py
@@ -152,7 +152,7 @@ OEMBED_ENDPOINTS = {
         "^http://www\\.funnyordie\\.com/videos/.+$"
     ],
     "http://fast.wistia.com/oembed.{format}": [
-        "^https?:\/\/(.+)?(wistia.com|wi.st)\/(medias|embed)\/.+$"
+        "^https?://([^/]+\.)?(wistia.com|wi.st)/(medias|embed)/.+$"
     ],
     "http://www.ustream.tv/oembed": [
         "^http(?:s)?://(?:www\\.)?ustream\\.tv/.+$",

--- a/wagtail/wagtailembeds/oembed_providers.py
+++ b/wagtail/wagtailembeds/oembed_providers.py
@@ -152,7 +152,7 @@ OEMBED_ENDPOINTS = {
         "^http://www\\.funnyordie\\.com/videos/.+$"
     ],
     "http://fast.wistia.com/oembed.{format}": [
-        "^http://[-\\w]+\\.wista\\.com/medias/.+$"
+        "^https?:\/\/(.+)?(wistia.com|wi.st)\/(medias|embed)\/.+$"
     ],
     "http://www.ustream.tv/oembed": [
         "^http(?:s)?://(?:www\\.)?ustream\\.tv/.+$",


### PR DESCRIPTION
This pull request fixes the regex pattern for identifying Wistia videos with oembed in the wagtail.wagtailembeds app. The old regex pattern had a typo in it, preventing it from matching any and all Wistia videos. Here is the current version:
```
^http://[-\\w]+\\.wista\\.com/medias/.+$
```
and here is the proposed new version, derived from [Wistia's recommended regex pattern](http://wistia.com/doc/construct-an-embed-code#the_regex):
```
^https?:\/\/(.+)?(wistia.com|wi.st)\/(medias|embed)\/.+$
```
This new version also includes Wistia's short embed code and different URL patterns. 

I hope I did this right! This is my first GitHub pull request. Just let me know if I need to submit this differently.