### PR TITLE
Update settings in 'configuring Django' docs for Django 1.9

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -57,52 +57,34 @@ Apps (``settings.py``)
 
 .. code-block:: python
 
-  INSTALLED_APPS = (
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
+  INSTALLED_APPS = [
+
+    'myapp',  # your own app
+
+    'wagtail.wagtailforms',
+    'wagtail.wagtailredirects',
+    'wagtail.wagtailembeds',
+    'wagtail.wagtailsites',
+    'wagtail.wagtailusers',
+    'wagtail.wagtailsnippets',
+    'wagtail.wagtaildocs',
+    'wagtail.wagtailimages',
+    'wagtail.wagtailsearch',
+    'wagtail.wagtailadmin',
+    'wagtail.wagtailcore',
 
     'compressor',
     'taggit',
     'modelcluster',
 
-    'wagtail.wagtailcore',
-    'wagtail.wagtailadmin',
-    'wagtail.wagtaildocs',
-    'wagtail.wagtailsnippets',
-    'wagtail.wagtailusers',
-    'wagtail.wagtailimages',
-    'wagtail.wagtailembeds',
-    'wagtail.wagtailsearch',
-    'wagtail.wagtailsites',
-    'wagtail.wagtailredirects',
-    'wagtail.wagtailforms',
-
-    'myapp',  # your own app
-  )
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+  ]
 
 Wagtail requires several Django app modules, third-party apps, and defines several apps of its own. Wagtail was built to be modular, so many Wagtail apps can be omitted to suit your needs. Your own app (here ``myapp``) is where you define your models, templates, static assets, template tags, and other custom functionality for your site.
-
-
-Third-Party Apps
-----------------
-
-``compressor``
-  Static asset combiner and minifier for Django. Compressor also enables for the use of preprocessors. See `Compressor Documentation`_.
-
-.. _Compressor Documentation: http://django-compressor.readthedocs.org/en/latest/
-
-``taggit``
-  Tagging framework for Django. This is used internally within Wagtail for image and document tagging and is available for your own models as well. See :ref:`tagging` for a Wagtail model recipe or the `Taggit Documentation`_.
-
-.. _Taggit Documentation: http://django-taggit.readthedocs.org/en/latest/index.html
-
-``modelcluster``
-  Extension of Django ForeignKey relation functionality, which is used in Wagtail pages for on-the-fly related object creation. For more information, see :ref:`inline_panels` or `the django-modelcluster github project page`_.
-
-.. _the django-modelcluster github project page: https://github.com/torchbox/django-modelcluster
 
 
 Wagtail Apps
@@ -137,6 +119,25 @@ Wagtail Apps
 
 ``wagtailforms``
   Models for creating forms on your pages and viewing submissions. See :ref:`form_builder`.
+
+
+Third-Party Apps
+----------------
+
+``compressor``
+  Static asset combiner and minifier for Django. Compressor also enables for the use of preprocessors. See `Compressor Documentation`_.
+
+.. _Compressor Documentation: http://django-compressor.readthedocs.org/en/latest/
+
+``taggit``
+  Tagging framework for Django. This is used internally within Wagtail for image and document tagging and is available for your own models as well. See :ref:`tagging` for a Wagtail model recipe or the `Taggit Documentation`_.
+
+.. _Taggit Documentation: http://django-taggit.readthedocs.org/en/latest/index.html
+
+``modelcluster``
+  Extension of Django ForeignKey relation functionality, which is used in Wagtail pages for on-the-fly related object creation. For more information, see :ref:`inline_panels` or `the django-modelcluster github project page`_.
+
+.. _the django-modelcluster github project page: https://github.com/torchbox/django-modelcluster
 
 
 Settings Variables (``settings.py``)
@@ -329,29 +330,32 @@ These two files should reside in your project directory (``myproject/myproject/`
   # Application definition
 
   INSTALLED_APPS = [
-      'django.contrib.auth',
-      'django.contrib.contenttypes',
-      'django.contrib.sessions',
-      'django.contrib.messages',
-      'django.contrib.staticfiles',
 
-      'compressor',
-      'taggit',
-      'modelcluster',
+    'myapp',
 
-      'wagtail.wagtailcore',
-      'wagtail.wagtailadmin',
-      'wagtail.wagtaildocs',
-      'wagtail.wagtailsnippets',
-      'wagtail.wagtailusers',
-      'wagtail.wagtailimages',
-      'wagtail.wagtailembeds',
-      'wagtail.wagtailsearch',
-      'wagtail.wagtailredirects',
-      'wagtail.wagtailforms',
+    'wagtail.wagtailforms',
+    'wagtail.wagtailredirects',
+    'wagtail.wagtailembeds',
+    'wagtail.wagtailsites',
+    'wagtail.wagtailusers',
+    'wagtail.wagtailsnippets',
+    'wagtail.wagtaildocs',
+    'wagtail.wagtailimages',
+    'wagtail.wagtailsearch',
+    'wagtail.wagtailadmin',
+    'wagtail.wagtailcore',
 
-      'myapp',
+    'compressor',
+    'taggit',
+    'modelcluster',
+
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
   ]
+
 
   MIDDLEWARE_CLASSES = [
       'django.contrib.sessions.middleware.SessionMiddleware',

--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -28,18 +28,20 @@ Middleware (``settings.py``)
 
 .. code-block:: python
 
-  MIDDLEWARE_CLASSES = (
-    'django.middleware.common.CommonMiddleware',
+  MIDDLEWARE_CLASSES = [
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.security.SecurityMiddleware',
 
     'wagtail.wagtailcore.middleware.SiteMiddleware',
 
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
-  )
+  ]
 
 Wagtail requires several common Django middleware modules to work and cover basic security. Wagtail provides its own middleware to cover these tasks:
 
@@ -139,6 +141,9 @@ Wagtail Apps
 
 Settings Variables (``settings.py``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Wagtail makes use of the following settings, in addition to `Django's core settings <https://docs.djangoproject.com/en/dev/ref/settings/>`__:
+
 
 Site Name
 ---------
@@ -263,31 +268,9 @@ Case-Insensitive Tags
 
 Tags are case-sensitive by default ('music' and 'Music' are treated as distinct tags). In many cases the reverse behaviour is preferable.
 
-Other Django Settings Used by Wagtail
--------------------------------------
-
-.. code-block:: python
-
-  ALLOWED_HOSTS
-  APPEND_SLASH
-  AUTH_USER_MODEL
-  BASE_URL
-  CACHES
-  DEFAULT_FROM_EMAIL
-  INSTALLED_APPS
-  MEDIA_ROOT
-  SESSION_COOKIE_DOMAIN
-  SESSION_COOKIE_NAME
-  SESSION_COOKIE_PATH
-  STATIC_URL
-  TEMPLATE_CONTEXT_PROCESSORS
-  USE_I18N
-
-For information on what these settings do, see `Django Settings <https://docs.djangoproject.com/en/dev/ref/settings/>`__.
-
 
 URL Patterns
-------------
+~~~~~~~~~~~~
 
 .. code-block:: python
 
@@ -338,126 +321,14 @@ These two files should reside in your project directory (``myproject/myproject/`
 
   import os
 
-  PROJECT_ROOT = os.path.join(os.path.dirname(__file__), '..', '..')
+  PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+  BASE_DIR = os.path.dirname(PROJECT_DIR)
 
   DEBUG = True
-  TEMPLATE_DEBUG = DEBUG
 
-  ADMINS = (
-      # ('Your Name', 'your_email@example.com'),
-  )
+  # Application definition
 
-  MANAGERS = ADMINS
-
-  # Default to dummy email backend. Configure dev/production/local backend
-  # as per https://docs.djangoproject.com/en/dev/topics/email/#email-backends
-  EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
-
-  DATABASES = {
-      'default': {
-          'ENGINE': 'django.db.backends.postgresql_psycopg2',
-          'NAME': 'myprojectdb',
-          'USER': 'postgres',
-          'PASSWORD': '',
-          'HOST': '',  # Set to empty string for localhost.
-          'PORT': '',  # Set to empty string for default.
-          'CONN_MAX_AGE': 600,  # number of seconds database connections should persist for
-      }
-  }
-
-  # Hosts/domain names that are valid for this site; required if DEBUG is False
-  # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
-  ALLOWED_HOSTS = []
-
-  # Local time zone for this installation. Choices can be found here:
-  # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
-  # although not all choices may be available on all operating systems.
-  # On Unix systems, a value of None will cause Django to use the same
-  # timezone as the operating system.
-  # If running in a Windows environment this must be set to the same as your
-  # system time zone.
-  TIME_ZONE = 'Europe/London'
-
-  # Language code for this installation. All choices can be found here:
-  # http://www.i18nguy.com/unicode/language-identifiers.html
-  LANGUAGE_CODE = 'en-gb'
-
-  SITE_ID = 1
-
-  # If you set this to False, Django will make some optimizations so as not
-  # to load the internationalization machinery.
-  USE_I18N = True
-
-  # If you set this to False, Django will not format dates, numbers and
-  # calendars according to the current locale.
-  # Note that with this set to True, Wagtail will fall back on using numeric dates
-  # in date fields, as opposed to 'friendly' dates like "24 Sep 2013", because
-  # Python's strptime doesn't support localised month names: https://code.djangoproject.com/ticket/13339
-  USE_L10N = False
-
-  # If you set this to False, Django will not use timezone-aware datetimes.
-  USE_TZ = True
-
-  # Absolute filesystem path to the directory that will hold user-uploaded files.
-  # Example: "/home/media/media.lawrence.com/media/"
-  MEDIA_ROOT = os.path.join(PROJECT_ROOT, 'media')
-
-  # URL that handles the media served from MEDIA_ROOT. Make sure to use a
-  # trailing slash.
-  # Examples: "http://media.lawrence.com/media/", "http://example.com/media/"
-  MEDIA_URL = '/media/'
-
-  # Absolute path to the directory static files should be collected to.
-  # Don't put anything in this directory yourself; store your static files
-  # in apps' "static/" subdirectories and in STATICFILES_DIRS.
-  # Example: "/home/media/media.lawrence.com/static/"
-  STATIC_ROOT = os.path.join(PROJECT_ROOT, 'static')
-
-  # URL prefix for static files.
-  # Example: "http://media.lawrence.com/static/"
-  STATIC_URL = '/static/'
-
-  # List of finder classes that know how to find static files in
-  # various locations.
-  STATICFILES_FINDERS = (
-      'django.contrib.staticfiles.finders.FileSystemFinder',
-      'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-      'compressor.finders.CompressorFinder',
-  )
-
-  # Make this unique, and don't share it with anybody.
-  SECRET_KEY = 'change-me'
-
-  # List of callables that know how to import templates from various sources.
-  TEMPLATE_LOADERS = (
-      'django.template.loaders.filesystem.Loader',
-      'django.template.loaders.app_directories.Loader',
-  )
-
-  MIDDLEWARE_CLASSES = (
-      'django.middleware.common.CommonMiddleware',
-      'django.contrib.sessions.middleware.SessionMiddleware',
-      'django.middleware.csrf.CsrfViewMiddleware',
-      'django.contrib.auth.middleware.AuthenticationMiddleware',
-      'django.contrib.messages.middleware.MessageMiddleware',
-      'django.middleware.clickjacking.XFrameOptionsMiddleware',
-
-      'wagtail.wagtailcore.middleware.SiteMiddleware',
-
-      'wagtail.wagtailredirects.middleware.RedirectMiddleware',
-  )
-
-  from django.conf import global_settings
-  TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
-      'django.core.context_processors.request',
-  )
-
-  ROOT_URLCONF = 'myproject.urls'
-
-  # Python dotted path to the WSGI application used by Django's runserver.
-  WSGI_APPLICATION = 'wagtaildemo.wsgi.application'
-
-  INSTALLED_APPS = (
+  INSTALLED_APPS = [
       'django.contrib.auth',
       'django.contrib.contenttypes',
       'django.contrib.sessions',
@@ -480,7 +351,101 @@ These two files should reside in your project directory (``myproject/myproject/`
       'wagtail.wagtailforms',
 
       'myapp',
-  )
+  ]
+
+  MIDDLEWARE_CLASSES = [
+      'django.contrib.sessions.middleware.SessionMiddleware',
+      'django.middleware.common.CommonMiddleware',
+      'django.middleware.csrf.CsrfViewMiddleware',
+      'django.contrib.auth.middleware.AuthenticationMiddleware',
+      'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+      'django.contrib.messages.middleware.MessageMiddleware',
+      'django.middleware.clickjacking.XFrameOptionsMiddleware',
+      'django.middleware.security.SecurityMiddleware',
+
+      'wagtail.wagtailcore.middleware.SiteMiddleware',
+      'wagtail.wagtailredirects.middleware.RedirectMiddleware',
+  ]
+
+  ROOT_URLCONF = 'myproject.urls'
+
+  TEMPLATES = [
+      {
+          'BACKEND': 'django.template.backends.django.DjangoTemplates',
+          'DIRS': [
+              os.path.join(PROJECT_DIR, 'templates'),
+          ],
+          'APP_DIRS': True,
+          'OPTIONS': {
+              'context_processors': [
+                  'django.template.context_processors.debug',
+                  'django.template.context_processors.request',
+                  'django.contrib.auth.context_processors.auth',
+                  'django.contrib.messages.context_processors.messages',
+              ],
+          },
+      },
+  ]
+
+  WSGI_APPLICATION = 'wagtaildemo.wsgi.application'
+
+
+  # Database
+
+  DATABASES = {
+      'default': {
+          'ENGINE': 'django.db.backends.postgresql_psycopg2',
+          'NAME': 'myprojectdb',
+          'USER': 'postgres',
+          'PASSWORD': '',
+          'HOST': '',  # Set to empty string for localhost.
+          'PORT': '',  # Set to empty string for default.
+          'CONN_MAX_AGE': 600,  # number of seconds database connections should persist for
+      }
+  }
+
+  # Internationalization
+
+  LANGUAGE_CODE = 'en-us'
+  TIME_ZONE = 'UTC'
+  USE_I18N = True
+  USE_L10N = True
+  USE_TZ = True
+
+
+  # Static files (CSS, JavaScript, Images)
+
+  STATICFILES_FINDERS = [
+      'django.contrib.staticfiles.finders.FileSystemFinder',
+      'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+      'compressor.finders.CompressorFinder',
+  ]
+
+  STATICFILES_DIRS = [
+      os.path.join(PROJECT_DIR, 'static'),
+  ]
+
+  STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+  STATIC_URL = '/static/'
+
+  MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+  MEDIA_URL = '/media/'
+
+
+  ADMINS = [
+      # ('Your Name', 'your_email@example.com'),
+  ]
+  MANAGERS = ADMINS
+
+  # Default to dummy email backend. Configure dev/production/local backend
+  # as per https://docs.djangoproject.com/en/dev/topics/email/#email-backends
+  EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
+
+  # Hosts/domain names that are valid for this site; required if DEBUG is False
+  ALLOWED_HOSTS = []
+
+  # Make this unique, and don't share it with anybody.
+  SECRET_KEY = 'change-me'
 
   EMAIL_SUBJECT_PREFIX = '[Wagtail] '
 


### PR DESCRIPTION
* Update the example settings file for Django 1.9 (including converting tuples to lists, and replacing TEMPLATE_CONTEXT_PROCESSORS with TEMPLATES)
* Set USE_L10N to true (the note about displaying localized dates was specific to FriendlyDateInput, which was removed in Wagtail 0.4 - the current AdminDateInput consistently uses numeric dates regardless of the USE_L10N setting)
* Remove the "Other Django Settings Used by Wagtail" list, as it seems to be an entirely arbitrary list - pretty much by definition, *any* Django setting could influence the behaviour of a Wagtail project.