### PR TITLE
Teach StreamBlocks about NON_FIELD_ERRORS

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/block_forms/sequence.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/block_forms/sequence.html
@@ -14,8 +14,15 @@
 {% endcomment %}
 <div class="sequence-container sequence-type-{% block sequence_type_class %}{% endblock %}">
     <input type="hidden" name="{{ prefix }}-count" id="{{ prefix }}-count" value="{{ list_members_html|length }}">
-    
+
     {% block header %}{% endblock %}
+
+    {% if block_errors %}
+        {% for error in block_errors %}
+            <div class="help-block help-critical">{{ error }}</div>
+        {% endfor %}
+    {% endif %}
+
     <div class="sequence-container-inner">
         <ul id="{{ prefix }}-list" class="sequence">
             {% for list_member_html in list_members_html %}

--- a/wagtail/wagtailcore/blocks/stream_block.py
+++ b/wagtail/wagtailcore/blocks/stream_block.py
@@ -20,7 +20,18 @@ from .base import Block, DeclarativeSubBlocksMetaclass, BoundBlock
 from .utils import indent, js_dict
 
 
-__all__ = ['BaseStreamBlock', 'StreamBlock', 'StreamValue']
+__all__ = ['BaseStreamBlock', 'StreamBlock', 'StreamValue', 'StreamBlockValidationError']
+
+
+class StreamBlockValidationError(ValidationError):
+    def __init__(self, block_errors=None, non_block_errors=None):
+        params = {}
+        if block_errors:
+            params.update(block_errors)
+        if non_block_errors:
+            params[NON_FIELD_ERRORS] = non_block_errors
+        super(StreamBlockValidationError, self).__init__(
+            'Validation error in StreamBlock', params=params)
 
 
 class BaseStreamBlock(Block):
@@ -111,9 +122,11 @@ class BaseStreamBlock(Block):
         error_dict = {}
         if errors:
             if len(errors) > 1:
-                # We rely on ListBlock.clean throwing a single ValidationError with a specially crafted
-                # 'params' attribute that we can pull apart and distribute to the child blocks
-                raise TypeError('ListBlock.render_form unexpectedly received multiple errors')
+                # We rely on StreamBlock.clean throwing a single
+                # StreamBlockValidationError with a specially crafted 'params'
+                # attribute that we can pull apart and distribute to the child
+                # blocks
+                raise TypeError('StreamBlock.render_form unexpectedly received multiple errors')
             error_dict = errors.as_data()[0].params
 
         # drop any child values that are an unrecognised block type
@@ -173,7 +186,7 @@ class BaseStreamBlock(Block):
         if errors:
             # The message here is arbitrary - outputting error messages is delegated to the child blocks,
             # which only involves the 'params' list
-            raise ValidationError('Validation error in StreamBlock', params=errors)
+            raise StreamBlockValidationError(block_errors=errors)
 
         return StreamValue(self, cleaned_data)
 

--- a/wagtail/wagtailcore/blocks/stream_block.py
+++ b/wagtail/wagtailcore/blocks/stream_block.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import collections
 
 from django import forms
-from django.core.exceptions import ValidationError
+from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.forms.utils import ErrorList
 from django.template.loader import render_to_string
 from django.utils.encoding import python_2_unicode_compatible, force_text
@@ -130,6 +130,7 @@ class BaseStreamBlock(Block):
             'list_members_html': list_members_html,
             'child_blocks': self.child_blocks.values(),
             'header_menu_prefix': '%s-before' % prefix,
+            'block_errors': error_dict.get(NON_FIELD_ERRORS),
         })
 
     def value_from_datadict(self, data, files, prefix):


### PR DESCRIPTION
A StreamBlock can now have NON_FIELD_ERRORS as part of its error dict.
These will be displayed as error messages above the StreamBlock in the
admin upon form submission.

No code in Wagtail currently makes use of this feautre. It is available
for developers of sites to use in their custom StreamField blocks.