### PR TITLE
Changed success message for when a page is published with go_live_at

### DIFF
--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -173,10 +173,15 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
 
             # Notifications
             if is_publishing:
-                messages.success(request, _("Page '{0}' created and published.").format(page.title), buttons=[
-                    messages.button(page.url, _('View live')),
-                    messages.button(reverse('wagtailadmin_pages:edit', args=(page.id,)), _('Edit'))
-                ])
+                if page.go_live_at and page.go_live_at > timezone.now():
+                    messages.success(request, _("Page '{0}' created and scheduled for publishing.").format(page.title), buttons=[
+                        messages.button(reverse('wagtailadmin_pages:edit', args=(page.id,)), _('Edit'))
+                    ])
+                else:
+                    messages.success(request, _("Page '{0}' created and published.").format(page.title), buttons=[
+                        messages.button(page.url, _('View live')),
+                        messages.button(reverse('wagtailadmin_pages:edit', args=(page.id,)), _('Edit'))
+                    ])
             elif is_submitting:
                 messages.success(
                     request,
@@ -260,10 +265,15 @@ def edit(request, page_id):
 
             # Notifications
             if is_publishing:
-                messages.success(request, _("Page '{0}' published.").format(page.title), buttons=[
-                    messages.button(page.url, _('View live')),
-                    messages.button(reverse('wagtailadmin_pages:edit', args=(page_id,)), _('Edit'))
-                ])
+                if page.go_live_at and page.go_live_at > timezone.now():
+                    messages.success(request, _("Page '{0}' scheduled for publishing.").format(page.title), buttons=[
+                        messages.button(reverse('wagtailadmin_pages:edit', args=(page.id,)), _('Edit'))
+                    ])
+                else:
+                    messages.success(request, _("Page '{0}' published.").format(page.title), buttons=[
+                        messages.button(page.url, _('View live')),
+                        messages.button(reverse('wagtailadmin_pages:edit', args=(page_id,)), _('Edit'))
+                    ])
             elif is_submitting:
                 messages.success(request, _("Page '{0}' submitted for moderation.").format(page.title), buttons=[
                     messages.button(reverse('wagtailadmin_pages:view_draft', args=(page_id,)), _('View draft')),


### PR DESCRIPTION
In relation to #1389.

Changed success message to show page is scheduled for publishing, rather than published. Also removed 'View live' button, as this resulted in a 404, and I can't think of any other suitable alternative button. 