### PR TITLE
Minor adjustment to settings docs

### DIFF
--- a/docs/reference/contrib/settings.rst
+++ b/docs/reference/contrib/settings.rst
@@ -112,7 +112,7 @@ Add the ``settings`` context processor to your settings:
     ]
 
 
-Then access the settings through ``{{ settings }}``:
+Then access the settings through ``{{ settings }}``, where ``app_label`` is the label of the app containing your settings model:
 
 .. code-block:: html+django
 


### PR DESCRIPTION
I was playing with the settings contrib module, and was confuse by the template implementation:

``{{ settings.app_label.SocialMediaSettings.instagram }}``

took me a while to realise ``app_label`` was the name of the app containing the specific settings model. Updated the docs to make this clear.