### PR TITLE
Remove double tagit initialisation

### DIFF
--- a/wagtail/wagtailimages/static_src/wagtailimages/js/add-multiple.js
+++ b/wagtail/wagtailimages/static_src/wagtailimages/js/add-multiple.js
@@ -105,9 +105,6 @@ $(function() {
                 itemElement.addClass('upload-success')
 
                 $('.right', itemElement).append(response.form);
-
-                // run tagit enhancement
-                $('.tag_field input', itemElement).tagit(window.tagit_opts);
             } else {
                 itemElement.addClass('upload-failure');
                 $('.right .error_messages', itemElement).append(response.error_message);


### PR DESCRIPTION
tagit was initialized from both the AdminTagWidget, and from the `done`
method in the image uploader. Initializing it twice led to strange
errors and ultimately the tags not being saved on the image model.

As the tag widget now contains its own initialisation `<script>`, tag
inputs do not need to be specially handled by AJAX code any more, so
this can simply be removed.

Fixes bug #2142.