### PR TITLE
Fix for ambigious filenames

### DIFF
--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -272,7 +272,6 @@ class AbstractImage(models.Model, TagSearchable):
                 output_filename_without_extension = base_name + digest
             else:
                 output_filename_without_extension = input_filename_without_extension
-            
             output_filename = output_filename_without_extension + '.' + output_extension
 
             rendition, created = self.renditions.get_or_create(

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -265,8 +265,15 @@ class AbstractImage(models.Model, TagSearchable):
             if cache_key:
                 output_extension = cache_key + '.' + output_extension
 
-            # Truncate filename to prevent it going over 60 chars
-            output_filename_without_extension = input_filename_without_extension[:(59 - len(output_extension))]
+            # Shorten longer filenames with md5 to prevent it going over 60 chars
+            if len(input_filename_without_extension) - len(output_extension) > 59:
+                output_filename_without_extension = input_filename_without_extension[:(27 - len(output_extension))] + \
+                                                    hashlib.md5(
+                                                            input_filename_without_extension.encode('utf-8')
+                                                    ).hexdigest()
+            else:
+                output_filename_without_extension = input_filename_without_extension
+                
             output_filename = output_filename_without_extension + '.' + output_extension
 
             rendition, created = self.renditions.get_or_create(

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -266,7 +266,7 @@ class AbstractImage(models.Model, TagSearchable):
                 output_extension = cache_key + '.' + output_extension
 
             # Shorten longer filenames with md5 to prevent it going over 60 chars
-            if len(input_filename_without_extension) - len(output_extension) > 59:
+            if len(input_filename_without_extension) + len(output_extension) > 59:
                 base_name = input_filename_without_extension[:(27 - len(output_extension))]
                 digest = hashlib.md5(input_filename_without_extension.encode('utf-8')).hexdigest()
                 output_filename_without_extension = base_name + digest

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -267,7 +267,11 @@ class AbstractImage(models.Model, TagSearchable):
 
             # Shorten longer filenames with md5 to prevent it going over 60 chars
             if len(input_filename_without_extension) + len(output_extension) > 59:
-                base_name = input_filename_without_extension[:(27 - len(output_extension))]
+                max_length_basename = (20 - len(output_extension))
+                if max_length_basename < 1:
+                    base_name = ''
+                else:
+                    base_name = input_filename_without_extension[:max_length_basename]
                 digest = hashlib.md5(input_filename_without_extension.encode('utf-8')).hexdigest()
                 output_filename_without_extension = base_name + digest
             else:

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -267,13 +267,12 @@ class AbstractImage(models.Model, TagSearchable):
 
             # Shorten longer filenames with md5 to prevent it going over 60 chars
             if len(input_filename_without_extension) - len(output_extension) > 59:
-                output_filename_without_extension = input_filename_without_extension[:(27 - len(output_extension))] + \
-                                                    hashlib.md5(
-                                                            input_filename_without_extension.encode('utf-8')
-                                                    ).hexdigest()
+                base_name = input_filename_without_extension[:(27 - len(output_extension))]
+                digest = hashlib.md5(input_filename_without_extension.encode('utf-8')).hexdigest()
+                output_filename_without_extension = base_name + digest
             else:
                 output_filename_without_extension = input_filename_without_extension
-                
+            
             output_filename = output_filename_without_extension + '.' + output_extension
 
             rendition, created = self.renditions.get_or_create(


### PR DESCRIPTION
Long filenames become ambigious and can't be displayed.

This is because https://github.com/torchbox/wagtail/pull/574 cuts long filenames.

Given the tag:

```
    {% image image fill-192x144-c100 class="rsTmb" %}
```

And the following URLs:

```
https://neuraum.s3.amazonaws.com/media/public/images/very_long_name_with_appended_incrementor_interior_0.original.jpg

https://neuraum.s3.amazonaws.com/media/public/images/very_long_name_with_appended_incrementor_interior_1.original.jpg

https://neuraum.s3.amazonaws.com/media/public/images/very_long_name_with_appended_incrementor_interior_2.original.jpg
```

... the images thumbs are getting an URL like:

```
https://neuraum.s3.amazonaws.com/media/public/images/very_long_name_with_appended_incrementor_interi.2e16d0ba.fill-192x144-c100.jpg
```

... essentially cutting off the differentiator. This means the renditions are overriding each other and only the last one is displayed.

This is unfortunate, as i have to wrestle with thousand of files like this :)

My proposed solution is to cut of the filename by 32 chars more and append a md5 hash of the original filename to overcome this limitation.

This is in sync with the existing test in 574.
