### PR TITLE
Only enforce W001 on Page inheritor

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -466,7 +466,7 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
                             for field in model._meta.parents.values() if field]
 
         for field in cls._meta.fields:
-            if isinstance(field, models.ForeignKey) and field.name not in field_exceptions:
+            if isinstance(field, models.ForeignKey) and issubclass(field.rel.to, Page) and field.name not in field_exceptions:
                 if field.rel.on_delete == models.CASCADE:
                     errors.append(
                         checks.Warning(


### PR DESCRIPTION
If your `Page` inheritor has a `ForeignKey` to a model that does not relate to the Wagtail page tree, then having `on_delete=models.CASCADE` should be fine.

E.g. this:

```python
class Survey(Page):
    organization = models.ForeignKey(
        'Organization',
        verbose_name=_('Which organization owns this survey'),
        on_delete=models.CASCADE,
    )
```

Raises:

```
Performing system checks...

System check identified some issues:

WARNINGS:
my_app.Survey.organization: (wagtailcore.W001) Field hasn't specified on_delete action
	HINT: Set on_delete=models.SET_NULL and make sure the field is nullable.
```