### PR TITLE
Make user confirm before navigating away from changed page editor

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -36,6 +36,47 @@ function initTagField(id, autocompleteUrl) {
     });
 }
 
+/*
+ * Enables a "dirty form check", prompting the user if they are navigating away
+ * from a page with unsaved changes.
+ *
+ * It takes the following parameters:
+ *
+ *  - formSelector - A CSS selector to select the form to apply this check to.
+ *
+ *  - options - An object for passing in options. Possible options are:
+ *    - ignoredButtonsSelector - A CSS selector to find buttons to ignore within
+ *      the form. If the navigation was triggered by one of these buttons, The
+ *      check will be ignored. defaults to: input[type="submit"].
+ *    - confirmationMessage - The message to display in the prompt.
+ *    - alwaysDirty - When set to true the form will always be considered dirty,
+ *      prompting the user even when nothing has been changed.
+*/
+function enableDirtyFormCheck(formSelector, options) {
+    var $form = $(formSelector);
+    var $ignoredButtons = $form.find(options.ignoredButtonsSelector || 'input[type="submit"]');
+    var confirmationMessage = options.confirmationMessage || ' ';
+    var alwaysDirty = options.alwaysDirty || false;
+    var initialData = $form.serialize();
+
+    window.addEventListener('beforeunload', function(event) {
+        // Ignore if the user clicked on an ignored element
+        var triggeredByIgnoredButton = false;
+        var $trigger = $(event.target.activeElement);
+
+        $ignoredButtons.each(function() {
+            if ($(this).is($trigger)) {
+                triggeredByIgnoredButton = true;
+            }
+        });
+
+        if (!triggeredByIgnoredButton && (alwaysDirty || $form.serialize() != initialData)) {
+            event.returnValue = confirmationMessage;
+            return confirmationMessage;
+        }
+    });
+}
+
 $(function() {
     // Add class to the body from which transitions may be hung so they don't appear to transition as the page loads
     $('body').addClass('ready');
@@ -207,4 +248,3 @@ $(function() {
         }, 10);
     });
 });
-

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -33,7 +33,7 @@
                 <li class="actions">
                     <div class="dropdown dropup dropdown-button match-width">
                         <button type="submit" class="action-save button-longrunning" tabindex="3" data-clicked-text="{% trans 'Saving...' %}" {% if page.locked %}disabled {% endif %}><span class="icon icon-spinner"></span><em>{% if page.locked %}{% trans 'Page locked' %}{% else %}{% trans 'Save draft' %}{% endif %}</em></button>
-                        
+
                         {% if not page.locked %}
                             <div class="dropdown-toggle icon icon-arrow-up"></div>
                             <ul role="menu">
@@ -99,4 +99,22 @@
 {% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+
+    <script>
+        $(function() {
+            /* Make user confirm before leaving the editor if there are unsaved changes */
+            {% trans "This page has unsaved changes." as confirmation_message %}
+            enableDirtyFormCheck(
+                '#page-edit-form',
+                {
+                    ignoredButtonsSelector: 'button[type="submit"]',
+                    confirmationMessage: '{{ confirmation_message|escapejs }}',
+
+                    {% if form.errors %}
+                        alwaysDirty: true,
+                    {% endif %}
+                }
+            );
+        });
+    </script>
 {% endblock %}


### PR DESCRIPTION
This PR implements a simple piece of code that detects whether the form has changed and blocks the user from navigating away from the page editor if it has. This should prevent data loss.

~~One thing it doesn't yet solve is that if the user recieves a validation error, they still can navigate away. Not sure what the best way is to solve that.~~ solved