### PR TITLE
Handling for server errors when uploading images and documents via a modal dialog

### DIFF
--- a/wagtail/wagtaildocs/templates/wagtaildocs/chooser/chooser.js
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/chooser/chooser.js
@@ -1,3 +1,4 @@
+{% load i18n %}
 function(modal) {
     function ajaxifyLinks (context) {
         $('a.document-choice', context).click(function() {
@@ -57,6 +58,14 @@ function(modal) {
             dataType: 'text',
             success: function(response){
                 modal.loadResponseText(response);
+            },
+            error: function(response, textStatus, errorThrown) {
+                {% trans "Server Error" as error_label %}
+                {% trans "Report this error to your webmaster with the following information:" as error_message %}
+                message = '{{ error_message|escapejs }}<br />' + errorThrown + ' - ' + response.status;
+                $('#upload').append(
+                    '<div class="help-block help-critical">' +
+                    '<strong>{{ error_label|escapejs }}: </strong>' + message + '</div>');
             }
         });
 

--- a/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.js
+++ b/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.js
@@ -1,3 +1,4 @@
+{% load i18n %}
 function(modal) {
     var searchUrl = $('form.image-search', modal.body).attr('action');
 
@@ -63,6 +64,14 @@ function(modal) {
             dataType: 'text',
             success: function(response){
                 modal.loadResponseText(response);
+            },
+            error: function(response, textStatus, errorThrown) {
+                {% trans "Server Error" as error_label %}
+                {% trans "Report this error to your webmaster with the following information:" as error_message %}
+                message = '{{ error_message|escapejs }}<br />' + errorThrown + ' - ' + response.status;
+                $('#upload').append(
+                    '<div class="help-block help-critical">' +
+                    '<strong>{{ error_label|escapejs }}: </strong>' + message + '</div>');
             }
         });
 


### PR DESCRIPTION
Change to catch and display server errors when uploading images & documents using the modal chooser.

Addresses #2093 and the remaining fix required to clear #616

![selection_077](https://cloud.githubusercontent.com/assets/1591068/12651385/9a5d5ef4-c5a3-11e5-90c5-e5323dd477c6.png)
