### PR TITLE
Fixes notification errors when there are multiple moderation groups

### DIFF
--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -56,7 +56,7 @@ def users_with_page_permission(page, permission_type, include_superusers=True):
     # Find GroupPagePermission records of the given type that apply to this page or an ancestor
     ancestors_and_self = list(page.get_ancestors()) + [page]
     perm = GroupPagePermission.objects.filter(permission_type=permission_type, page__in=ancestors_and_self)
-    q = Q(groups__page_permissions=perm)
+    q = Q(groups__page_permissions__in=perm)
 
     # Include superusers
     if include_superusers:


### PR DESCRIPTION
My site has multiple moderation groups - one that can moderate anything, and a few others that only allow moderation of parts of the site tree.  Whenever submitting a page for approval I was getting this error from Postgres:
```
Internal Server Error: /admin/pages/add/bulletin_core/submission/6/
Traceback (most recent call last):
  File "/Users/matt/Dev/Thomas/Bulletin/lib/python3.4/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
psycopg2.ProgrammingError: more than one row returned by a subquery used as an expression
```
On SQLite there was no error but not all relevant users received the notification.
This PR fixes the problem, plus a new unit test.