### PR TITLE
Documentation - Fix parameter name on signal handler

### DIFF
--- a/docs/reference/signals.rst
+++ b/docs/reference/signals.rst
@@ -66,7 +66,7 @@ wish to do something when a new blog post is published:
     from mysite.models import BlogPostPage
 
     # Do something clever for each model type
-    def receiver(model, **kwargs):
+    def receiver(sender, **kwargs):
         # Do something with blog posts
         pass
 


### PR DESCRIPTION
Replacement for PR #2154 that I messed up.

The sample code breaks because the signal handler is invoked with a named parameter of `sender` (at `wagtailcore/models.py` line 1421). The other nearby sample functions are already correct.