### PR TITLE
Remove final references to django-compressor

### DIFF
--- a/docs/advanced_topics/performance.rst
+++ b/docs/advanced_topics/performance.rst
@@ -25,8 +25,6 @@ We recommend `Redis <http://redis.io/>`_ as a fast, persistent cache. Install Re
 	    }
 	}
 
-Without a persistent cache, Wagtail will recreate all compressible assets at each server start, e.g. when any files change under ``./manage.py runserver``.
-
 
 Search
 ------

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -228,7 +228,7 @@ The available hooks are:
 .. _insert_editor_js:
 
 ``insert_editor_js``
-  Add additional Javascript files or code snippets to the page editor. Output must be compatible with ``compress``, as local static includes or string.
+  Add additional Javascript files or code snippets to the page editor.
 
   .. code-block:: python
 
@@ -257,7 +257,7 @@ The available hooks are:
 .. _insert_editor_css:
 
 ``insert_editor_css``
-  Add additional CSS or SCSS files or snippets to the page editor. Output must be compatible with ``compress``, as local static includes or string.
+  Add additional CSS or SCSS files or snippets to the page editor.
 
   .. code-block:: python
 

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -135,8 +135,6 @@ PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.MD5PasswordHasher',  # don't use the intentionally slow default password hasher
 )
 
-COMPRESS_ENABLED = False  # disable compression so that we can run tests on the content of the compress tag
-
 
 WAGTAILSEARCH_BACKENDS = {
     'default': {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
@@ -1,11 +1,12 @@
 // paths 
 
 // We can't use absolute paths here, because those are dependent on Django's
-// STATIC_URL setting. However, django-compressor consistently places the compiled
-// CSS into $ {STATIC_URL}/CACHE/css/ regardless of compilation mode, so we can
-// reliably use relative paths to get back to STATIC_URL. */
+// STATIC_URL setting. Instead, relative paths from the final location of the
+// compiled CSS files are used.
+// */
 
-$static-root: '../../wagtailadmin/images/';
+$static-root: '../../';
+$images-root: $static-root + 'wagtailadmin/images/';
 $font-root: '../../wagtailadmin/fonts/';
 
 // grid settings

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_formatters.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_formatters.scss
@@ -118,7 +118,7 @@
     -webkit-font-smoothing: auto;
     font-size: 0.8em;
     margin: 0 0.5em 0.5em;
-    background: #fff url('#{$static-root}bg-dark-diag.svg');
+    background: #fff url('#{$images-root}bg-dark-diag.svg');
 
     &.primary {
         color: $color-grey-2;
@@ -253,7 +253,7 @@ img {
 
 // Show a transparency grid in background
 .show-transparency {
-    background: url('#{$static-root}transparency.svg');
+    background: url('#{$images-root}transparency.svg');
 }
 
 // make a block-level element inline


### PR DESCRIPTION
* Remove references from docs
* Fix comment in SCSS files, and fix related variable names
* Remove COMPRESS_ENABLED setting from tests

See #2132
Fixes #2197