### PR TITLE
Prevent email send errors from crashing the admin pages

### DIFF
--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 from django.core.urlresolvers import reverse
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
+from django.contrib.messages import constants as message_constants
 from django.core import mail, paginator
 from django.core.files.base import ContentFile
 from django.db.models.signals import pre_delete, post_delete
@@ -2344,6 +2345,22 @@ class TestNotificationPreferences(TestCase, WagtailTestUtils):
         self.assertIn(self.moderator2.email, email_to)
         self.assertIn(user1.email, email_to)
         self.assertIn(user2.email, email_to)
+
+    @mock.patch('wagtail.wagtailadmin.utils.django_send_mail', side_effect=IOError('Server down'))
+    def test_email_send_error(self, mock_fn):
+        # Approve
+        self.silent_submit()
+        response = self.approve()
+
+        # An email that fails to send should return a message rather than crash the page
+        self.assertEqual(response.status_code, 302)
+        response = self.client.get(reverse('wagtailadmin_home'))
+
+        # There should be one "approved" message and one "failed to send notifications"
+        messages = list(response.context['messages'])
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[0].level, message_constants.SUCCESS)
+        self.assertEqual(messages[1].level, message_constants.ERROR)
 
 
 class TestLocking(TestCase, WagtailTestUtils):

--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -15,7 +15,7 @@ from wagtail.wagtailcore.models import Page, PageRevision, GroupPagePermission
 from wagtail.wagtailusers.models import UserProfile
 
 
-logger = logging.getLogger('wagtail.wagtailadmin')
+logger = logging.getLogger('wagtail.admin')
 
 
 def get_object_usage(obj):

--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -1,3 +1,4 @@
+import logging
 from functools import wraps
 
 from django.template.loader import render_to_string
@@ -12,6 +13,9 @@ from modelcluster.fields import ParentalKey
 
 from wagtail.wagtailcore.models import Page, PageRevision, GroupPagePermission
 from wagtail.wagtailusers.models import UserProfile
+
+
+logger = logging.getLogger('wagtail.wagtailadmin')
 
 
 def get_object_usage(obj):
@@ -169,7 +173,7 @@ def send_notification(page_revision_id, notification, excluded_user_id):
         # Get submitter
         recipients = [revision.user]
     else:
-        return
+        return False
 
     # Get list of email addresses
     email_recipients = [
@@ -182,7 +186,7 @@ def send_notification(page_revision_id, notification, excluded_user_id):
 
     # Return if there are no email addresses
     if not email_recipients:
-        return
+        return True
 
     # Get template
     template = 'wagtailadmin/notifications/' + notification + '.html'
@@ -194,12 +198,22 @@ def send_notification(page_revision_id, notification, excluded_user_id):
     }
 
     # Send emails
+    sent_count = 0
     for recipient in email_recipients:
-        # update context with this recipient
-        context["user"] = recipient
+        try:
+            # update context with this recipient
+            context["user"] = recipient
 
-        # Get email subject and content
-        email_subject, email_content = render_to_string(template, context).split('\n', 1)
+            # Get email subject and content
+            email_subject, email_content = render_to_string(template, context).split('\n', 1)
 
-        # Send email
-        send_mail(email_subject, email_content, [recipient.email])
+            # Send email
+            send_mail(email_subject, email_content, [recipient.email])
+            sent_count += 1
+        except Exception as e:
+            logger.error(
+                "Failed to send notification email '%s' to %s. Error: %s",
+                email_subject, recipient.email, str(e)
+            )
+
+    return sent_count == len(email_recipients)

--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -210,10 +210,10 @@ def send_notification(page_revision_id, notification, excluded_user_id):
             # Send email
             send_mail(email_subject, email_content, [recipient.email])
             sent_count += 1
-        except Exception as e:
-            logger.error(
-                "Failed to send notification email '%s' to %s. Error: %s",
-                email_subject, recipient.email, str(e)
+        except Exception:
+            logger.exception(
+                "Failed to send notification email '%s' to %s",
+                email_subject, recipient.email
             )
 
     return sent_count == len(email_recipients)

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -188,7 +188,8 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
                         messages.button(reverse('wagtailadmin_pages:edit', args=(page.id,)), _('Edit'))
                     ]
                 )
-                send_notification(page.get_latest_revision().id, 'submitted', request.user.id)
+                if not send_notification(page.get_latest_revision().id, 'submitted', request.user.id):
+                    messages.error(request, _("Failed to send notifications to moderators"))
             else:
                 messages.success(request, _("Page '{0}' created.").format(page.title))
 
@@ -277,7 +278,8 @@ def edit(request, page_id):
                     messages.button(reverse('wagtailadmin_pages:view_draft', args=(page_id,)), _('View draft')),
                     messages.button(reverse('wagtailadmin_pages:edit', args=(page_id,)), _('Edit'))
                 ])
-                send_notification(page.get_latest_revision().id, 'submitted', request.user.id)
+                if not send_notification(page.get_latest_revision().id, 'submitted', request.user.id):
+                    messages.error(request, _("Failed to send notifications to moderators"))
             else:
                 messages.success(request, _("Page '{0}' updated.").format(page.title))
 
@@ -680,7 +682,8 @@ def approve_moderation(request, revision_id):
             messages.button(revision.page.url, _('View live')),
             messages.button(reverse('wagtailadmin_pages:edit', args=(revision.page.id,)), _('Edit'))
         ])
-        send_notification(revision.id, 'approved', request.user.id)
+        if not send_notification(revision.id, 'approved', request.user.id):
+            messages.error(request, _("Failed to send approval notifications"))
 
     return redirect('wagtailadmin_home')
 
@@ -699,7 +702,8 @@ def reject_moderation(request, revision_id):
         messages.success(request, _("Page '{0}' rejected for publication.").format(revision.page.title), buttons=[
             messages.button(reverse('wagtailadmin_pages:edit', args=(revision.page.id,)), _('Edit'))
         ])
-        send_notification(revision.id, 'rejected', request.user.id)
+        if not send_notification(revision.id, 'rejected', request.user.id):
+            messages.error(request, _("Failed to send rejection notifications"))
 
     return redirect('wagtailadmin_home')
 


### PR DESCRIPTION
At the moment, failure to send an email (from the publish/approve/reject notifications) throws an unchecked exception and so causes an error 500, even though the main action itself succeeded.  Email servers can be a bit flakey; it seems a shame for some external problem to break Wagtail.

This PR catches email exceptions and returns an error message on-screen instead.
