### PR TITLE
Update home stats summary CSS

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/home.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/home.scss
@@ -33,7 +33,6 @@ header {
     background-color: $color-grey-5;
     margin-bottom: 2em;
     padding-top: 2em;
-    padding-bottom: 2em;
 
     ul.stats {
         @include clearfix();
@@ -42,6 +41,7 @@ header {
 
         li {
             @include column(4);
+            margin-bottom: 2em;
 
             &:before {
                 opacity: 0.2;


### PR DESCRIPTION
The construct_homepage_summary_items hook allows to add items, but if
you use exactly the same markup as wagtail you end up with a bad layout
because the items form rows with no whitespace between them.

This commit changes the padding-bottom of the section into a margin-bottom
of it's li items, meaning that they form rows with enough whitespace
in between them, and the whitespace at the bottom is preserved.