### PR TITLE
Fix PageQuerySet code overriding code snippet

### DIFF
--- a/docs/topics/pages.rst
+++ b/docs/topics/pages.rst
@@ -474,4 +474,4 @@ Alternately, if you only need to add extra ``QuerySet`` methods, you can inherit
     class EventPage(Page):
         start_date = models.DateField()
 
-        objects = PageManager.from_queryset(EventQuerySet)
+        objects = PageManager.from_queryset(EventPageQuerySet)


### PR DESCRIPTION
Code snippet refered to `EventQuerySet`, however, it was actually (more appropriately) named `EventPageQuerySet`.