### PR TITLE
Fixed styleguide text to use correct classname

### DIFF
--- a/wagtail/contrib/wagtailstyleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/wagtailstyleguide/templates/wagtailstyleguide/base.html
@@ -570,7 +570,7 @@
                 <li class="icon icon-order-up">order-up</li>
                 <li class="icon icon-bin">bin</li>
                 <li class="spinner"><div class="icon icon-spinner">spinner</div> spinner</li>
-                <li class="icon icon-pick">promotion</li>
+                <li class="icon icon-pick">pick</li>
                 <li class="icon icon-redirect">redirect</li>
                 <li class="icon icon-view">view</li>
                 <li class="icon icon-no-view">no-view</li>


### PR DESCRIPTION
Made the icon with the class `pick` display the correct classname in the styleguide.