### PR TITLE
construct_explorer_page_queryset hook for customising explorer page listings

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -340,6 +340,29 @@ Hooks for customising the way users are directed through the process of creating
       return items.append( UserbarPuppyLinkItem() )
 
 
+Page explorer
+------------
+
+.. _construct_explorer_page_queryset:
+
+``construct_explorer_page_queryset``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  Called when rendering the page explorer view, to allow the page listing queryset to be customised. The callable passed into the hook will receive the parent page object, the current page queryset, and the request object, and must return a Page queryset (either the original one, or a new one).
+
+  .. code-block:: python
+
+    from wagtail.wagtailcore import hooks
+
+    @hooks.register('construct_explorer_page_queryset')
+    def show_my_profile_only(parent_page, pages, request):
+      # If we're in the 'user-profiles' section, only show the user's own profile
+      if parent_page.slug == 'user-profiles':
+        pages = pages.filter(owner=request.user)
+
+      return pages
+
+
 Page serving
 ------------
 

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -65,3 +65,13 @@ def register_custom_search_area():
         classnames='icon icon-custom',
         attrs={'is-custom': 'true'},
         order=10000)
+
+
+@hooks.register('construct_explorer_page_queryset')
+def polite_pages_only(parent_page, pages, request):
+    # if the URL parameter polite_pages_only is set,
+    # only return pages with a slug that starts with 'hello'
+    if request.GET.get('polite_pages_only'):
+        pages = pages.filter(slug__startswith='hello')
+
+    return pages

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -146,6 +146,19 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
         # Pages must not be paginated
         self.assertNotIsInstance(response.context['pages'], paginator.Page)
 
+    def test_construct_explorer_page_queryset_hook(self):
+        # testapp implements a construct_explorer_page_queryset hook
+        # that only returns pages with a slug starting with 'hello'
+        # when the 'polite_pages_only' URL parameter is set
+        response = self.client.get(
+            reverse('wagtailadmin_explore', args=(self.root_page.id, )),
+            {'polite_pages_only': 'yes_please'}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/pages/index.html')
+        page_ids = [page.id for page in response.context['pages']]
+        self.assertEqual(page_ids, [self.child_page.id])
+
     def make_pages(self):
         for i in range(150):
             self.root_page.add_child(instance=SimplePage(

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -68,10 +68,15 @@ def index(request, parent_page_id=None):
     else:
         pages = pages.order_by(ordering)
 
-    # Pagination
     # Don't paginate if sorting by page order - all pages must be shown to
     # allow drag-and-drop reordering
     do_paginate = ordering != 'ord'
+
+    # allow hooks to modify the queryset
+    for hook in hooks.get_hooks('construct_explorer_page_queryset'):
+        pages = hook(parent_page, pages, request)
+
+    # Pagination
     if do_paginate:
         paginator, pages = paginate(request, pages, per_page=50)
 


### PR DESCRIPTION
Implements #2196.

~~(Incorporates #2215 and #2216)~~