### PR TITLE
Use specific page models on explorer page listing

### DIFF
--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -254,6 +254,23 @@ class SingleEventPage(EventPage):
         help_text="Short text to describe what is this action about"
     )
 
+    # Give this page model a custom URL routing scheme
+    def get_url_parts(self):
+        url_parts = super(SingleEventPage, self).get_url_parts()
+        if url_parts is None:
+            return None
+        else:
+            site_id, root_url, page_path = url_parts
+            return (site_id, root_url, page_path + 'pointless-suffix/')
+
+    def route(self, request, path_components):
+        if path_components == ['pointless-suffix']:
+            # treat this as equivalent to a request for this page
+            return super(SingleEventPage, self).route(request, [])
+        else:
+            # fall back to default routing rules
+            return super(SingleEventPage, self).route(request, path_components)
+
 SingleEventPage.content_panels = [FieldPanel('excerpt')] + EventPage.content_panels
 
 

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -13,7 +13,7 @@ from django.utils import timezone
 
 from wagtail.tests.testapp.models import (
     SimplePage, FilePage, EventPage, EventPageCarouselItem,
-    StandardIndex, StandardChild,
+    SingleEventPage, StandardIndex, StandardChild,
     BusinessIndex, BusinessChild, BusinessSubIndex,
     TaggedPage, Advert, AdvertPlacement)
 from wagtail.tests.utils import WagtailTestUtils
@@ -205,6 +205,23 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
 
         # Check that we got the last page
         self.assertEqual(response.context['pages'].number, response.context['pages'].paginator.num_pages)
+
+    def test_listing_uses_specific_models(self):
+        # SingleEventPage has custom URL routing; the 'live' link in the listing
+        # should show the custom URL, which requires us to use the specific version
+        # of the class
+        self.new_event = SingleEventPage(
+            title="New event",
+            location='the moon', audience='public',
+            cost='free', date_from='2001-01-01',
+            latest_revision_created_at=datetime(2016, 1, 1)
+        )
+        self.root_page.add_child(instance=self.new_event)
+
+        response = self.client.get(reverse('wagtailadmin_explore', args=(self.root_page.id, )))
+        self.assertEqual(response.status_code, 200)
+
+        self.assertContains(response, '/new-event/pointless-suffix/')
 
 
 class TestPageExplorerSignposting(TestCase, WagtailTestUtils):

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -72,6 +72,12 @@ def index(request, parent_page_id=None):
     # allow drag-and-drop reordering
     do_paginate = ordering != 'ord'
 
+    if do_paginate:
+        # Retrieve pages in their most specific form.
+        # Only do this for paginated listings, as this could potentially be a
+        # very expensive operation when performed on a large queryset.
+        pages = pages.specific()
+
     # allow hooks to modify the queryset
     for hook in hooks.get_hooks('construct_explorer_page_queryset'):
         pages = hook(parent_page, pages, request)


### PR DESCRIPTION
As per discussion on <https://groups.google.com/d/msg/wagtail/qAmI4HbJfCI/9fxvoCmMEQAJ>, this ensures that any custom URL routes defined on the page model are respected by the 'live' link.

Incorporates #2027 and #2219