### PR TITLE
Admin PageChooser - external link window targeting and follow nofollow rel options

### DIFF
--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -52,11 +52,23 @@ class SearchForm(forms.Form):
 
 class ExternalLinkChooserForm(forms.Form):
     url = URLOrAbsolutePathField(required=True, label=ugettext_lazy("URL"))
+    target = forms.ChoiceField(choices=( \
+            ('_blank', 'new window/tab'), ('_self', 'same window') \
+        ), required=True)
+    rel = forms.ChoiceField(choices=(   \
+            ('follow', 'follow'), ('nofollow', 'nofollow'), ('follow noindex', 'follow noindex') \
+        ), required=True)
 
 
 class ExternalLinkChooserWithLinkTextForm(forms.Form):
     url = URLOrAbsolutePathField(required=True, label=ugettext_lazy("URL"))
     link_text = forms.CharField(required=True)
+    target = forms.ChoiceField(choices=( \
+            ('_blank', 'new window/tab'), ('_self', 'same window') \
+        ), required=True)
+    rel = forms.ChoiceField(choices=(   \
+            ('follow', 'follow'), ('nofollow', 'nofollow'), ('follow noindex', 'follow noindex') \
+        ), required=True)
 
 
 class EmailLinkChooserForm(forms.Form):

--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -55,8 +55,7 @@ class ExternalLinkChooserForm(forms.Form):
     target = forms.ChoiceField(choices=(
         ('_blank', 'new window/tab'), ('_self', 'same window')), required=True)
     rel = forms.ChoiceField(choices=(
-        ('follow', 'follow'), ('nofollow', 'nofollow'), ('follow noindex', 'follow noindex')
-    ), required=True)
+        ('follow', 'follow'), ('nofollow', 'nofollow')), required=True)
 
 
 class ExternalLinkChooserWithLinkTextForm(forms.Form):
@@ -65,8 +64,7 @@ class ExternalLinkChooserWithLinkTextForm(forms.Form):
     target = forms.ChoiceField(choices=(
         ('_blank', 'new window/tab'), ('_self', 'same window')), required=True)
     rel = forms.ChoiceField(choices=(
-        ('follow', 'follow'), ('nofollow', 'nofollow'), ('follow noindex', 'follow noindex')
-    ), required=True)
+        ('follow', 'follow'), ('nofollow', 'nofollow')), required=True)
 
 
 class EmailLinkChooserForm(forms.Form):

--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -52,23 +52,21 @@ class SearchForm(forms.Form):
 
 class ExternalLinkChooserForm(forms.Form):
     url = URLOrAbsolutePathField(required=True, label=ugettext_lazy("URL"))
-    target = forms.ChoiceField(choices=( \
-            ('_blank', 'new window/tab'), ('_self', 'same window') \
-        ), required=True)
-    rel = forms.ChoiceField(choices=(   \
-            ('follow', 'follow'), ('nofollow', 'nofollow'), ('follow noindex', 'follow noindex') \
-        ), required=True)
+    target = forms.ChoiceField(choices=(
+        ('_blank', 'new window/tab'), ('_self', 'same window')), required=True)
+    rel = forms.ChoiceField(choices=(
+        ('follow', 'follow'), ('nofollow', 'nofollow'), ('follow noindex', 'follow noindex')
+    ), required=True)
 
 
 class ExternalLinkChooserWithLinkTextForm(forms.Form):
     url = URLOrAbsolutePathField(required=True, label=ugettext_lazy("URL"))
     link_text = forms.CharField(required=True)
-    target = forms.ChoiceField(choices=( \
-            ('_blank', 'new window/tab'), ('_self', 'same window') \
-        ), required=True)
-    rel = forms.ChoiceField(choices=(   \
-            ('follow', 'follow'), ('nofollow', 'nofollow'), ('follow noindex', 'follow noindex') \
-        ), required=True)
+    target = forms.ChoiceField(choices=(
+        ('_blank', 'new window/tab'), ('_self', 'same window')), required=True)
+    rel = forms.ChoiceField(choices=(
+        ('follow', 'follow'), ('nofollow', 'nofollow'), ('follow noindex', 'follow noindex')
+    ), required=True)
 
 
 class EmailLinkChooserForm(forms.Form):

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
@@ -54,6 +54,16 @@
 
                                     a = document.createElement('a');
                                     a.setAttribute('href', pageData.url);
+
+                                    if (pageData.rel) {
+                                        a.setAttribute('rel', pageData.rel);
+                                    }
+
+                                    if (pageData.target) {
+                                        a.setAttribute('target', pageData.target);
+                                    }
+                                
+                                    
                                     if (pageData.id) {
                                         a.setAttribute('data-id', pageData.id);
                                         a.setAttribute('data-linktype', 'page');

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
@@ -63,7 +63,6 @@
                                         a.setAttribute('target', pageData.target);
                                     }
                                 
-                                    
                                     if (pageData.id) {
                                         a.setAttribute('data-id', pageData.id);
                                         a.setAttribute('data-linktype', 'page');

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
@@ -62,7 +62,7 @@
                                     if (pageData.target) {
                                         a.setAttribute('target', pageData.target);
                                     }
-                                
+
                                     if (pageData.id) {
                                         a.setAttribute('data-id', pageData.id);
                                         a.setAttribute('data-linktype', 'page');

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link_chosen.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link_chosen.js
@@ -1,7 +1,9 @@
 function(modal) {
     modal.respond('pageChosen', {
         'url': '{{ url|escapejs }}',
-        'title': '{{ link_text|escapejs }}'
+        'title': '{{ link_text|escapejs }}',
+        'rel': '{{ rel|escapejs }}',
+        'target': '{{ target|escapejs }}'
     });
     modal.close();
 }

--- a/wagtail/wagtailadmin/tests/test_page_chooser.py
+++ b/wagtail/wagtailadmin/tests/test_page_chooser.py
@@ -323,7 +323,6 @@ class TestChooserExternalLink(TestCase, WagtailTestUtils):
         self.assertContains(response, "'rel': 'nofollow'")
         self.assertContains(response, "'target': '_blank'")
 
-
     def test_invalid_url(self):
         response = self.post({'url': 'ntp://www.example.com', 'target': '_blank', 'rel': 'nofollow'})
         self.assertEqual(response.status_code, 200)

--- a/wagtail/wagtailadmin/tests/test_page_chooser.py
+++ b/wagtail/wagtailadmin/tests/test_page_chooser.py
@@ -315,24 +315,29 @@ class TestChooserExternalLink(TestCase, WagtailTestUtils):
         self.assertEqual(self.get({'prompt_for_link_text': 'foo'}).status_code, 200)
 
     def test_create_link(self):
-        response = self.post({'url': 'http://www.example.com/'})
+        response = self.post({'url': 'http://www.example.com/', 'target': '_blank', 'rel': 'nofollow'})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "'onload'")  # indicates success / post back to calling page
         self.assertContains(response, "'url': 'http://www.example.com/',")
         self.assertContains(response, "'title': 'http://www.example.com/'")
+        self.assertContains(response, "'rel': 'nofollow'")
+        self.assertContains(response, "'target': '_blank'")
+
 
     def test_invalid_url(self):
-        response = self.post({'url': 'ntp://www.example.com'})
+        response = self.post({'url': 'ntp://www.example.com', 'target': '_blank', 'rel': 'nofollow'})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "'html'")  # indicates failure / show error message
         self.assertContains(response, "Enter a valid URL.")
 
     def test_allow_local_url(self):
-        response = self.post({'url': '/admin/'})
+        response = self.post({'url': '/admin/', 'target': '_self', 'rel': 'follow'})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "'onload'")  # indicates success / post back to calling page
         self.assertContains(response, "'url': '/admin/',")
         self.assertContains(response, "'title': '/admin/'")
+        self.assertContains(response, "'rel': 'follow'")
+        self.assertContains(response, "'target': '_self'")
 
 
 class TestChooserEmailLink(TestCase, WagtailTestUtils):

--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -158,7 +158,9 @@ def external_link(request):
                 None, 'wagtailadmin/chooser/external_link_chosen.js',
                 {
                     'url': form.cleaned_data['url'],
-                    'link_text': form.cleaned_data['link_text'] if prompt_for_link_text else form.cleaned_data['url']
+                    'link_text': form.cleaned_data['link_text'] if prompt_for_link_text else form.cleaned_data['url'], 
+                    'rel': form.cleaned_data['rel'],
+                    'target': form.cleaned_data['target']
                 }
             )
     else:

--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -158,7 +158,7 @@ def external_link(request):
                 None, 'wagtailadmin/chooser/external_link_chosen.js',
                 {
                     'url': form.cleaned_data['url'],
-                    'link_text': form.cleaned_data['link_text'] if prompt_for_link_text else form.cleaned_data['url'], 
+                    'link_text': form.cleaned_data['link_text'] if prompt_for_link_text else form.cleaned_data['url'],
                     'rel': form.cleaned_data['rel'],
                     'target': form.cleaned_data['target']
                 }

--- a/wagtail/wagtailcore/tests/test_dbwhitelister.py
+++ b/wagtail/wagtailcore/tests/test_dbwhitelister.py
@@ -102,7 +102,7 @@ class TestDbWhitelister(TestCase):
         output_html = Whitelister.clean(input_html)
         expected = (
             'I would put a tax on all people who'
-            ' <a href="https://twitter.com/DMReporter/status/432914941201223680/photo/1">'
+            ' <a href="https://twitter.com/DMReporter/status/432914941201223680/photo/1" target="_blank">'
             'stand in water</a>.<p>- Gumby</p>'
         )
         self.assertHtmlEqual(expected, output_html)

--- a/wagtail/wagtailcore/whitelist.py
+++ b/wagtail/wagtailcore/whitelist.py
@@ -65,7 +65,7 @@ allow_without_attributes = attribute_rule({})
 class Whitelister(object):
     element_rules = {
         '[document]': allow_without_attributes,
-        'a': attribute_rule({'href': check_url}),
+        'a': attribute_rule({'href': check_url, 'target': True, 'rel': True}),
         'b': allow_without_attributes,
         'br': allow_without_attributes,
         'div': allow_without_attributes,


### PR DESCRIPTION
Added the ability for user to select blank window (new tab) or self, as well as follow no follow options for external links added through hallo-js link button modal window.