### PR TITLE
Tagging snippets documentation fix

### DIFF
--- a/docs/topics/snippets.rst
+++ b/docs/topics/snippets.rst
@@ -218,7 +218,7 @@ Adding tags to snippets is very similar to adding tags to pages. The only differ
     @register_snippet
     class Advert(models.Model):
         ...
-        tags = TaggableManager(through=BlogPageTag, blank=True)
+        tags = TaggableManager(through=AdvertTag, blank=True)
 
         panels = [
             ...


### PR DESCRIPTION
I'm not sure i'm right but i think there is a typo in this example. I guess there should be a AdvertTag use in TaggableManager instead BlogPageTag