### PR TITLE
Tweaked repr of search results to diffrentiate them from QuerySets and lists

### DIFF
--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -183,7 +183,7 @@ class BaseSearchResults(object):
         data = list(self[:21])
         if len(data) > 20:
             data[-1] = "...(remaining elements truncated)..."
-        return repr(data)
+        return '<SearchResults %r>' % data
 
 
 class BaseSearch(object):


### PR DESCRIPTION
Search results sets are now wrapped with ``<SearchResults >``. This should make debugging through the console slightly easier as the developer can now easily see the type of sequence they are working with.