### PR TITLE
Correcting typo in The Dashboard doc

### DIFF
--- a/docs/editor_manual/finding_your_way_around/the_dashboard.rst
+++ b/docs/editor_manual/finding_your_way_around/the_dashboard.rst
@@ -9,7 +9,7 @@ The Dashboard provides information on:
 * Any pages currently awaiting moderation (if you have these privileges)
 * Your most recently edited pages
 
-You can return to the Dashboard at any time by clicking the Wagtail log in the top-left of the screen.
+You can return to the Dashboard at any time by clicking the Wagtail logo in the top-left of the screen.
 
 .. image:: ../../_static/images/screen02_dashboard_editor.png
 


### PR DESCRIPTION
Simple typo, documentation says "click on the *log* to return to dashboard" instead of "logo"