### PR TITLE
Improvements to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE *.rst *.txt
-recursive-include wagtail *
-recursive-exclude * __pycache__
-recursive-exclude * *.py[co]
+graft wagtail
+prune wagtail/wagtailadmin/static_src
+global-exclude __pycache__
+global-exclude *.py[co]


### PR DESCRIPTION
Reduces size of wheel files to 5.7MB from 9.3MB (wagtailadmin static was being archived twice).

The change that made the above improvement was this line ``prune wagtail/wagtailadmin/static_src``. I've also made changes to simplify it a bit as well.