### PR TITLE
Enable template debugging on tests, to catch broken includes

### DIFF
--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -50,6 +50,7 @@ TEMPLATES = [
                 'wagtail.tests.context_processors.do_not_use_static_url',
                 'wagtail.contrib.settings.context_processors.settings',
             ],
+            'debug': True,
         },
     },
     {


### PR DESCRIPTION
This threw me for a while just now while merging #1892 - the add_multiple.html template contained the line `{% include "wagtailadmin/shared/tag_field_css.html" %}` which is a file that no longer exists. This caused the view to break, but the tests failed to reveal this, apparently because they were rendering templates in production mode (where missing includes are silently ignored)...