### PR TITLE
Datetimepicker improvements

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -71,23 +71,43 @@ function insertRichTextDeleteControl(elem) {
     });
 }
 
+// Compare two date objects. Ignore minutes and seconds.
+function dateEqual(x, y) {
+    return x.getDate() === y.getDate() &&
+           x.getMonth() === y.getMonth() &&
+           x.getYear() === y.getYear()
+}
+
+/*
+Remove the xdsoft_current css class from markup unless the selected date is currently in view.
+Keep the normal behaviour if the home button is clicked.
+ */
+function hideCurrent(current, input) {
+    var selected = new Date(input[0].value);
+    if (!dateEqual(selected, current)) {
+        $(this).find('.xdsoft_datepicker .xdsoft_current:not(.xdsoft_today)').removeClass('xdsoft_current');
+    }
+}
+
 function initDateChooser(id, opts) {
     if (window.dateTimePickerTranslations) {
         $('#' + id).datetimepicker($.extend({
             closeOnDateSelect: true,
             timepicker: false,
-            scrollInput:false,
+            scrollInput: false,
             format: 'Y-m-d',
             i18n: {
                 lang: window.dateTimePickerTranslations
             },
-            lang: 'lang'
+            lang: 'lang',
+            onGenerate: hideCurrent
         }, opts || {}));
     } else {
         $('#' + id).datetimepicker($.extend({
             timepicker: false,
-            scrollInput:false,
-            format: 'Y-m-d'
+            scrollInput: false,
+            format: 'Y-m-d',
+            onGenerate: hideCurrent
         }, opts || {}));
     }
 }
@@ -97,7 +117,7 @@ function initTimeChooser(id) {
         $('#' + id).datetimepicker({
             closeOnDateSelect: true,
             datepicker: false,
-            scrollInput:false,
+            scrollInput: false,
             format: 'H:i',
             i18n: {
                 lang: window.dateTimePickerTranslations
@@ -117,15 +137,17 @@ function initDateTimeChooser(id, opts) {
         $('#' + id).datetimepicker($.extend({
             closeOnDateSelect: true,
             format: 'Y-m-d H:i',
-            scrollInput:false,
+            scrollInput: false,
             i18n: {
                 lang: window.dateTimePickerTranslations
             },
-            language: 'lang'
+            language: 'lang',
+            onGenerate: hideCurrent
         }, opts || {}));
     } else {
         $('#' + id).datetimepicker($.extend({
-            format: 'Y-m-d H:i'
+            format: 'Y-m-d H:i',
+            onGenerate: hideCurrent
         }, opts || {}));
     }
 }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_datetimepicker.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_datetimepicker.scss
@@ -281,6 +281,10 @@
         color: $color-white;
         background: $color-teal;
     }
+
+    .xdsoft_calendar td.xdsoft_today {
+        font-weight: 700;
+    }
 }
 
 .xdsoft_noselect {


### PR DESCRIPTION
Fixes for #2239 

Current date is now highlighted if it is not selected.

I also incorporated changes that remove the highlighting of the same day as was previously selected when switching months. This works for both the datepicker and datetimepicker. However in order to change both date and time with the datetimepicker one still has to open the modal twice (or use the text input).