### PR TITLE
Show a message to users who do not have permission to access admin 

### DIFF
--- a/wagtail/contrib/settings/tests/test_admin.py
+++ b/wagtail/contrib/settings/tests/test_admin.py
@@ -21,7 +21,7 @@ class TestSettingMenu(TestCase, WagtailTestUtils):
             username='test', email='test@email.com', password='password')
         user.user_permissions.add(Permission.objects.get_by_natural_key(
             codename='access_admin', app_label='wagtailadmin', model='admin'))
-        self.client.login(username='test', password='password')
+        self.assertTrue(self.client.login(username='test', password='password'))
         return user
 
     def test_menu_item_in_admin(self):

--- a/wagtail/tests/utils.py
+++ b/wagtail/tests/utils.py
@@ -18,7 +18,7 @@ class WagtailTestUtils(object):
         user = get_user_model().objects.create_superuser(username='test', email='test@email.com', password='password')
 
         # Login
-        self.client.login(username='test', password='password')
+        self.assertTrue(self.client.login(username='test', password='password'))
 
         return user
 

--- a/wagtail/wagtailadmin/decorators.py
+++ b/wagtail/wagtailadmin/decorators.py
@@ -1,0 +1,26 @@
+from django.contrib.auth.views import \
+    redirect_to_login as auth_redirect_to_login
+from django.core.urlresolvers import reverse
+from django.utils.translation import ugettext as _
+
+from wagtail.wagtailadmin import messages
+
+
+def redirect_to_login(request):
+    return auth_redirect_to_login(
+        request.get_full_path(), login_url=reverse('wagtailadmin_login'))
+
+
+def require_admin_access(view_func):
+    def decorated_view(request, *args, **kwargs):
+        user = request.user
+
+        if user.is_anonymous():
+            return redirect_to_login(request)
+
+        if user.has_perms(['wagtailadmin.access_admin']):
+            return view_func(request, *args, **kwargs)
+
+        messages.error(request, _('You do not have permission to access the admin'))
+        return redirect_to_login(request)
+    return decorated_view

--- a/wagtail/wagtailadmin/templates/wagtailadmin/login.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/login.html
@@ -11,10 +11,15 @@
 
 {% block furniture %}
     <div class="content-wrapper">
-        {% if form.errors %}
+        {% if messages or form.errors %}
             <div class="messages">
                 <ul>
-                    <li class="error">{% blocktrans %}Your {{ username_field }} and password didn't match. Please try again.{% endblocktrans %}</li>
+                    {% if form.errors %}
+                        <li class="error">{% blocktrans %}Your {{ username_field }} and password didn't match. Please try again.{% endblocktrans %}</li>
+                    {% endif %}
+                    {% for message in messages %}
+                        <li class="{{ message.tags }}">{{ message }}</li>
+                    {% endfor %}
                 </ul>
             </div>
         {% endif %}

--- a/wagtail/wagtailadmin/tests/test_account_management.py
+++ b/wagtail/wagtailadmin/tests/test_account_management.py
@@ -76,8 +76,8 @@ class TestAuthentication(TestCase, WagtailTestUtils):
         This tests issue #431
         """
         # Login as unprivileged user
-        get_user_model().objects.create(username='unprivileged', password='123')
-        self.client.login(username='unprivileged', password='123')
+        get_user_model().objects.create_user(username='unprivileged', password='123')
+        self.assertTrue(self.client.login(username='unprivileged', password='123'))
 
         # Get login page
         response = self.client.get(reverse('wagtailadmin_login'))
@@ -268,7 +268,7 @@ class TestAccountManagementForNonModerator(TestCase, WagtailTestUtils):
         self.submitter = get_user_model().objects.create_user('submitter', 'submitter@example.com', 'password')
         self.submitter.groups.add(Group.objects.get(name='Editors'))
 
-        self.client.login(username=self.submitter.username, password='password')
+        self.assertTrue(self.client.login(username=self.submitter.username, password='password'))
 
     def test_notification_preferences_form_is_reduced_for_non_moderators(self):
         """
@@ -297,7 +297,7 @@ class TestAccountManagementForAdminOnlyUser(TestCase, WagtailTestUtils):
         )
         self.admin_only_user.groups.add(admin_only_group)
 
-        self.client.login(username=self.admin_only_user.username, password='password')
+        self.assertTrue(self.client.login(username=self.admin_only_user.username, password='password'))
 
     def test_notification_preferences_view_redirects_for_admin_only_users(self):
         """

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -221,7 +221,7 @@ class TestPageExplorerSignposting(TestCase, WagtailTestUtils):
         self.root_page.add_child(instance=self.no_site_page)
 
     def test_admin_at_root(self):
-        self.client.login(username='superuser', password='password')
+        self.assertTrue(self.client.login(username='superuser', password='password'))
         response = self.client.get(reverse('wagtailadmin_explore_root'))
         self.assertEqual(response.status_code, 200)
         # Administrator (or user with add_site permission) should get the full message
@@ -236,7 +236,7 @@ class TestPageExplorerSignposting(TestCase, WagtailTestUtils):
         self.assertContains(response, """<a href="/admin/sites/">Configure a site now.</a>""")
 
     def test_admin_at_non_site_page(self):
-        self.client.login(username='superuser', password='password')
+        self.assertTrue(self.client.login(username='superuser', password='password'))
         response = self.client.get(reverse('wagtailadmin_explore', args=(self.no_site_page.id, )))
         self.assertEqual(response.status_code, 200)
         # Administrator (or user with add_site permission) should get a warning about
@@ -251,14 +251,14 @@ class TestPageExplorerSignposting(TestCase, WagtailTestUtils):
         self.assertContains(response, """<a href="/admin/sites/">Configure a site now.</a>""")
 
     def test_admin_at_site_page(self):
-        self.client.login(username='superuser', password='password')
+        self.assertTrue(self.client.login(username='superuser', password='password'))
         response = self.client.get(reverse('wagtailadmin_explore', args=(self.site_page.id, )))
         self.assertEqual(response.status_code, 200)
         # There should be no warning message here
         self.assertNotContains(response, "Pages created here will not be accessible")
 
     def test_nonadmin_at_root(self):
-        self.client.login(username='siteeditor', password='password')
+        self.assertTrue(self.client.login(username='siteeditor', password='password'))
         response = self.client.get(reverse('wagtailadmin_explore_root'))
         self.assertEqual(response.status_code, 200)
         # Non-admin should get a simple "create pages as children of the homepage" prompt
@@ -269,7 +269,7 @@ class TestPageExplorerSignposting(TestCase, WagtailTestUtils):
         )
 
     def test_nonadmin_at_non_site_page(self):
-        self.client.login(username='siteeditor', password='password')
+        self.assertTrue(self.client.login(username='siteeditor', password='password'))
         response = self.client.get(reverse('wagtailadmin_explore', args=(self.no_site_page.id, )))
         self.assertEqual(response.status_code, 200)
         # Non-admin should get a warning about unroutable pages
@@ -282,7 +282,7 @@ class TestPageExplorerSignposting(TestCase, WagtailTestUtils):
         )
 
     def test_nonadmin_at_site_page(self):
-        self.client.login(username='siteeditor', password='password')
+        self.assertTrue(self.client.login(username='siteeditor', password='password'))
         response = self.client.get(reverse('wagtailadmin_explore', args=(self.site_page.id, )))
         self.assertEqual(response.status_code, 200)
         # There should be no warning message here

--- a/wagtail/wagtailadmin/tests/tests.py
+++ b/wagtail/wagtailadmin/tests/tests.py
@@ -64,7 +64,7 @@ class TestHome(TestCase, WagtailTestUtils):
         # cause a failure when generating Gravatar URLs
         get_user_model().objects.create_superuser(username='snowman', email='☃@thenorthpole.com', password='password')
         # Login
-        self.client.login(username='snowman', password='password')
+        self.assertTrue(self.client.login(username='snowman', password='password'))
         response = self.client.get(reverse('wagtailadmin_home'))
         self.assertEqual(response.status_code, 200)
 
@@ -253,7 +253,7 @@ class TestUserPassesTestPermissionDecorator(TestCase):
     def test_user_passes_test(self):
         # create and log in as a user called Bob
         get_user_model().objects.create_superuser(first_name='Bob', last_name='Mortimer', username='test', email='test@email.com', password='password')
-        self.client.login(username='test', password='password')
+        self.assertTrue(self.client.login(username='test', password='password'))
 
         response = self.client.get(reverse('testapp_bob_only_zone'))
         self.assertEqual(response.status_code, 200)
@@ -261,7 +261,7 @@ class TestUserPassesTestPermissionDecorator(TestCase):
     def test_user_fails_test(self):
         # create and log in as a user not called Bob
         get_user_model().objects.create_superuser(first_name='Vic', last_name='Reeves', username='test', email='test@email.com', password='password')
-        self.client.login(username='test', password='password')
+        self.assertTrue(self.client.login(username='test', password='password'))
 
         response = self.client.get(reverse('testapp_bob_only_zone'))
         self.assertRedirects(response, reverse('wagtailadmin_home'))

--- a/wagtail/wagtailadmin/urls/__init__.py
+++ b/wagtail/wagtailadmin/urls/__init__.py
@@ -1,5 +1,4 @@
 from django.conf.urls import url, include
-from django.contrib.auth.decorators import permission_required
 from django.views.decorators.cache import cache_control
 
 from wagtail.wagtailadmin.urls import pages as wagtailadmin_pages_urls
@@ -7,6 +6,7 @@ from wagtail.wagtailadmin.urls import password_reset as wagtailadmin_password_re
 from wagtail.wagtailadmin.views import account, chooser, home, pages, tags, userbar
 from wagtail.wagtailcore import hooks
 from wagtail.utils.urlpatterns import decorate_urlpatterns
+from wagtail.wagtailadmin.decorators import require_admin_access
 
 
 urlpatterns = [
@@ -50,13 +50,7 @@ for fn in hooks.get_hooks('register_admin_urls'):
 
 
 # Add "wagtailadmin.access_admin" permission check
-urlpatterns = decorate_urlpatterns(
-    urlpatterns,
-    permission_required(
-        'wagtailadmin.access_admin',
-        login_url='wagtailadmin_login'
-    )
-)
+urlpatterns = decorate_urlpatterns(urlpatterns, require_admin_access)
 
 
 # These url patterns do not require an authenticated admin user

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -946,7 +946,7 @@ class TestEditOnlyPermissions(TestCase, WagtailTestUtils):
         change_permission = Permission.objects.get(content_type__app_label='wagtaildocs', codename='change_document')
         admin_permission = Permission.objects.get(content_type__app_label='wagtailadmin', codename='access_admin')
         user.user_permissions.add(change_permission, admin_permission)
-        self.client.login(username='changeonly', password='password')
+        self.assertTrue(self.client.login(username='changeonly', password='password'))
 
     def test_get_index(self):
         response = self.client.get(reverse('wagtaildocs:index'))

--- a/wagtail/wagtailforms/tests.py
+++ b/wagtail/wagtailforms/tests.py
@@ -184,7 +184,7 @@ class TestFormsIndex(TestCase):
     fixtures = ['test.json']
 
     def setUp(self):
-        self.client.login(username='siteeditor', password='password')
+        self.assertTrue(self.client.login(username='siteeditor', password='password'))
         self.form_page = Page.objects.get(url_path='/home/contact-us/')
 
     def make_form_pages(self):
@@ -250,7 +250,7 @@ class TestFormsIndex(TestCase):
 
     def test_cannot_see_forms_without_permission(self):
         # Login with as a user without permission to see forms
-        self.client.login(username='eventeditor', password='password')
+        self.assertTrue(self.client.login(username='eventeditor', password='password'))
 
         response = self.client.get(reverse('wagtailforms:index'))
 
@@ -399,7 +399,7 @@ class TestDeleteFormSubmission(TestCase):
     fixtures = ['test.json']
 
     def setUp(self):
-        self.client.login(username='siteeditor', password='password')
+        self.assertTrue(self.client.login(username='siteeditor', password='password'))
         self.form_page = Page.objects.get(url_path='/home/contact-us/')
 
     def test_delete_submission_show_cofirmation(self):
@@ -426,7 +426,7 @@ class TestDeleteFormSubmission(TestCase):
 
     def test_delete_submission_bad_permissions(self):
         self.form_page = make_form_page()
-        self.client.login(username="eventeditor", password="password")
+        self.assertTrue(self.client.login(username="eventeditor", password="password"))
 
         response = self.client.post(reverse(
             'wagtailforms:delete_submission',
@@ -444,7 +444,7 @@ class TestIssue798(TestCase):
     fixtures = ['test.json']
 
     def setUp(self):
-        self.client.login(username='siteeditor', password='password')
+        self.assertTrue(self.client.login(username='siteeditor', password='password'))
         self.form_page = Page.objects.get(url_path='/home/contact-us/').specific
 
         # Add a number field to the page

--- a/wagtail/wagtailimages/tests/test_admin_views.py
+++ b/wagtail/wagtailimages/tests/test_admin_views.py
@@ -802,7 +802,7 @@ class TestEditOnlyPermissions(TestCase, WagtailTestUtils):
         change_permission = Permission.objects.get(content_type__app_label='wagtailimages', codename='change_image')
         admin_permission = Permission.objects.get(content_type__app_label='wagtailadmin', codename='access_admin')
         user.user_permissions.add(change_permission, admin_permission)
-        self.client.login(username='changeonly', password='password')
+        self.assertTrue(self.client.login(username='changeonly', password='password'))
 
     def test_get_index(self):
         response = self.client.get(reverse('wagtailimages:index'))

--- a/wagtail/wagtailsites/tests.py
+++ b/wagtail/wagtailsites/tests.py
@@ -266,7 +266,7 @@ class TestLimitedPermissions(TestCase, WagtailTestUtils):
         )
 
         # Login
-        self.client.login(username='test', password='password')
+        self.assertTrue(self.client.login(username='test', password='password'))
 
         self.home_page = Page.objects.get(id=2)
         self.localhost = Site.objects.all()[0]

--- a/wagtail/wagtailsnippets/tests.py
+++ b/wagtail/wagtailsnippets/tests.py
@@ -518,7 +518,7 @@ class TestAddOnlyPermissions(TestCase, WagtailTestUtils):
         add_permission = Permission.objects.get(content_type__app_label='tests', codename='add_advert')
         admin_permission = Permission.objects.get(content_type__app_label='wagtailadmin', codename='access_admin')
         user.user_permissions.add(add_permission, admin_permission)
-        self.client.login(username='addonly', password='password')
+        self.assertTrue(self.client.login(username='addonly', password='password'))
 
     def test_get_index(self):
         response = self.client.get(reverse('wagtailsnippets:list',
@@ -562,7 +562,7 @@ class TestEditOnlyPermissions(TestCase, WagtailTestUtils):
         change_permission = Permission.objects.get(content_type__app_label='tests', codename='change_advert')
         admin_permission = Permission.objects.get(content_type__app_label='wagtailadmin', codename='access_admin')
         user.user_permissions.add(change_permission, admin_permission)
-        self.client.login(username='changeonly', password='password')
+        self.assertTrue(self.client.login(username='changeonly', password='password'))
 
     def test_get_index(self):
         response = self.client.get(reverse('wagtailsnippets:list',
@@ -606,7 +606,7 @@ class TestDeleteOnlyPermissions(TestCase, WagtailTestUtils):
         change_permission = Permission.objects.get(content_type__app_label='tests', codename='delete_advert')
         admin_permission = Permission.objects.get(content_type__app_label='wagtailadmin', codename='access_admin')
         user.user_permissions.add(change_permission, admin_permission)
-        self.client.login(username='deleteonly', password='password')
+        self.assertTrue(self.client.login(username='deleteonly', password='password'))
 
     def test_get_index(self):
         response = self.client.get(reverse('wagtailsnippets:list',


### PR DESCRIPTION
Fixes #1486.

As part of doing this, I found a bug in the admin access tests where a user was not logged correctly, but this was not caught by the tests. I have fixed the tests to assert that users are actually logged in.