### PR TITLE
Enforce slug uniqueness at the model level

### DIFF
--- a/wagtail/contrib/wagtailsitemaps/tests.py
+++ b/wagtail/contrib/wagtailsitemaps/tests.py
@@ -14,18 +14,21 @@ class TestSitemapGenerator(TestCase):
         self.child_page = self.home_page.add_child(instance=SimplePage(
             title="Hello world!",
             slug='hello-world',
+            content="hello",
             live=True,
         ))
 
         self.unpublished_child_page = self.home_page.add_child(instance=SimplePage(
             title="Unpublished",
             slug='unpublished',
+            content="hello",
             live=False,
         ))
 
         self.protected_child_page = self.home_page.add_child(instance=SimplePage(
             title="Protected",
             slug='protected',
+            content="hello",
             live=True,
         ))
         PageViewRestriction.objects.create(page=self.protected_child_page, password='hello')

--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -286,13 +286,9 @@ class WagtailAdminPageForm(WagtailAdminModelForm):
     def clean(self):
         cleaned_data = super(WagtailAdminPageForm, self).clean()
         if 'slug' in self.cleaned_data:
-            # Get siblings for the page
-            siblings = self.parent_page.get_children()
-            if self.instance and self.instance.id:
-                siblings = siblings.exclude(id=self.instance.id)
-
-            # Make sure the slug isn't being used by a sibling
-            if siblings.filter(slug=cleaned_data['slug']).exists():
+            if not Page._slug_is_available(
+                cleaned_data['slug'], self.parent_page, self.instance
+            ):
                 self.add_error('slug', forms.ValidationError(_("This slug is already in use")))
 
         # Check scheduled publishing fields

--- a/wagtail/wagtailadmin/tests/test_page_chooser.py
+++ b/wagtail/wagtailadmin/tests/test_page_chooser.py
@@ -11,9 +11,7 @@ class TestChooserBrowse(TestCase, WagtailTestUtils):
         self.root_page = Page.objects.get(id=2)
 
         # Add child page
-        self.child_page = SimplePage()
-        self.child_page.title = "foobarbaz"
-        self.child_page.slug = "foobarbaz"
+        self.child_page = SimplePage(title="foobarbaz", slug="foobarbaz", content="hello")
         self.root_page.add_child(instance=self.child_page)
 
         self.login()
@@ -48,9 +46,7 @@ class TestChooserBrowseChild(TestCase, WagtailTestUtils):
         self.root_page = Page.objects.get(id=2)
 
         # Add child page
-        self.child_page = SimplePage()
-        self.child_page.title = "foobarbaz"
-        self.child_page.slug = "foobarbaz"
+        self.child_page = SimplePage(title="foobarbaz", slug="foobarbaz", content="hello")
         self.root_page.add_child(instance=self.child_page)
 
         self.login()
@@ -76,6 +72,8 @@ class TestChooserBrowseChild(TestCase, WagtailTestUtils):
         event_page = EventPage(
             title="event",
             slug="event",
+            location='the moon', audience='public',
+            cost='free', date_from='2001-01-01',
         )
         self.root_page.add_child(instance=event_page)
 
@@ -88,6 +86,8 @@ class TestChooserBrowseChild(TestCase, WagtailTestUtils):
         event_index_page.add_child(instance=EventPage(
             title="other event",
             slug="other-event",
+            location='the moon', audience='public',
+            cost='free', date_from='2001-01-01',
         ))
 
         # Send request
@@ -129,6 +129,8 @@ class TestChooserBrowseChild(TestCase, WagtailTestUtils):
         event_page = EventPage(
             title="event",
             slug="event",
+            location='the moon', audience='public',
+            cost='free', date_from='2001-01-01',
         )
         self.root_page.add_child(instance=event_page)
 
@@ -169,6 +171,7 @@ class TestChooserBrowseChild(TestCase, WagtailTestUtils):
             new_page = SimplePage(
                 title="foobarbaz",
                 slug="foobarbaz",
+                content="hello",
             )
             self.root_page.add_child(instance=new_page)
 
@@ -203,9 +206,7 @@ class TestChooserSearch(TestCase, WagtailTestUtils):
         self.root_page = Page.objects.get(id=2)
 
         # Add child page
-        self.child_page = SimplePage()
-        self.child_page.title = "foobarbaz"
-        self.child_page.slug = "foobarbaz"
+        self.child_page = SimplePage(title="foobarbaz", slug="foobarbaz", content="hello")
         self.root_page.add_child(instance=self.child_page)
 
         self.login()
@@ -230,6 +231,8 @@ class TestChooserSearch(TestCase, WagtailTestUtils):
         event_page = EventPage(
             title="foo",
             slug="foo",
+            location='the moon', audience='public',
+            cost='free', date_from='2001-01-01',
         )
         self.root_page.add_child(instance=event_page)
 
@@ -263,6 +266,8 @@ class TestChooserSearch(TestCase, WagtailTestUtils):
         event_page = EventPage(
             title="foo",
             slug="foo",
+            location='the moon', audience='public',
+            cost='free', date_from='2001-01-01',
         )
         self.root_page.add_child(instance=event_page)
 

--- a/wagtail/wagtailadmin/tests/test_page_chooser.py
+++ b/wagtail/wagtailadmin/tests/test_page_chooser.py
@@ -170,7 +170,7 @@ class TestChooserBrowseChild(TestCase, WagtailTestUtils):
         for i in range(100):
             new_page = SimplePage(
                 title="foobarbaz",
-                slug="foobarbaz",
+                slug="foobarbaz-%d" % i,
                 content="hello",
             )
             self.root_page.add_child(instance=new_page)

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -42,6 +42,7 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
         self.child_page = SimplePage(
             title="Hello world!",
             slug="hello-world",
+            content="hello",
         )
         self.root_page.add_child(instance=self.child_page)
 
@@ -56,6 +57,7 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
         self.new_page = SimplePage(
             title="New page",
             slug="new-page",
+            content="hello",
             latest_revision_created_at=datetime(2016, 1, 1)
         )
         self.root_page.add_child(instance=self.new_page)
@@ -164,6 +166,7 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
             self.root_page.add_child(instance=SimplePage(
                 title="Page " + str(i),
                 slug="page-" + str(i),
+                content="hello",
             ))
 
     def test_pagination(self):
@@ -217,6 +220,7 @@ class TestPageExplorerSignposting(TestCase, WagtailTestUtils):
         self.no_site_page = SimplePage(
             title="Hello world!",
             slug="hello-world",
+            content="hello",
         )
         self.root_page.add_child(instance=self.no_site_page)
 
@@ -644,9 +648,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         # This tests the existing slug checking on page save
 
         # Create a page
-        self.child_page = SimplePage()
-        self.child_page.title = "Hello world!"
-        self.child_page.slug = "hello-world"
+        self.child_page = SimplePage(title="Hello world!", slug="hello-world", content="hello")
         self.root_page.add_child(instance=self.child_page)
 
         # Attempt to create a new one with the same slug
@@ -792,6 +794,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         child_page = SimplePage(
             title="Hello world!",
             slug="hello-world",
+            content="hello",
         )
         self.root_page.add_child(instance=child_page)
         child_page.save_revision().publish()
@@ -810,9 +813,11 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         self.file_page = FilePage.objects.get(id=file_page.id)
 
         # Add event page (to test edit handlers)
-        self.event_page = EventPage()
-        self.event_page.title = "Event page"
-        self.event_page.slug = "event-page"
+        self.event_page = EventPage(
+            title="Event page", slug="event-page",
+            location='the moon', audience='public',
+            cost='free', date_from='2001-01-01',
+        )
         self.root_page.add_child(instance=self.event_page)
 
         # Login
@@ -1123,9 +1128,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         # This tests the existing slug checking on page edit
 
         # Create a page
-        self.child_page = SimplePage()
-        self.child_page.title = "Hello world 2"
-        self.child_page.slug = "hello-world2"
+        self.child_page = SimplePage(title="Hello world 2", slug="hello-world2", content="hello")
         self.root_page.add_child(instance=self.child_page)
 
         # Attempt to change the slug to one thats already in use
@@ -1210,9 +1213,11 @@ class TestPageEditReordering(TestCase, WagtailTestUtils):
         self.root_page = Page.objects.get(id=2)
 
         # Add event page
-        self.event_page = EventPage()
-        self.event_page.title = "Event page"
-        self.event_page.slug = "event-page"
+        self.event_page = EventPage(
+            title="Event page", slug="event-page",
+            location='the moon', audience='public',
+            cost='free', date_from='2001-01-01',
+        )
         self.event_page.carousel_items = [
             EventPageCarouselItem(caption='1234567', sort_order=1),
             EventPageCarouselItem(caption='7654321', sort_order=2),
@@ -1319,9 +1324,7 @@ class TestPageDelete(TestCase, WagtailTestUtils):
         self.root_page = Page.objects.get(id=2)
 
         # Add child page
-        self.child_page = SimplePage()
-        self.child_page.title = "Hello world!"
-        self.child_page.slug = "hello-world"
+        self.child_page = SimplePage(title="Hello world!", slug="hello-world", content="hello")
         self.root_page.add_child(instance=self.child_page)
 
         # Add a page with child pages of its own
@@ -1521,20 +1524,14 @@ class TestPageMove(TestCase, WagtailTestUtils):
         self.root_page = Page.objects.get(id=2)
 
         # Create two sections
-        self.section_a = SimplePage()
-        self.section_a.title = "Section A"
-        self.section_a.slug = "section-a"
+        self.section_a = SimplePage(title="Section A", slug="section-a", content="hello")
         self.root_page.add_child(instance=self.section_a)
 
-        self.section_b = SimplePage()
-        self.section_b.title = "Section B"
-        self.section_b.slug = "section-b"
+        self.section_b = SimplePage(title="Section B", slug="section-b", content="hello")
         self.root_page.add_child(instance=self.section_b)
 
         # Add test page into section A
-        self.test_page = SimplePage()
-        self.test_page.title = "Hello world!"
-        self.test_page.slug = "hello-world"
+        self.test_page = SimplePage(title="Hello world!", slug="hello-world", content="hello")
         self.section_a.add_child(instance=self.test_page)
 
         # Login
@@ -1578,6 +1575,7 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         self.test_page = self.root_page.add_child(instance=SimplePage(
             title="Hello world!",
             slug='hello-world',
+            content="hello",
             live=True,
             has_unpublished_changes=False,
         ))
@@ -1586,6 +1584,7 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         self.test_child_page = self.test_page.add_child(instance=SimplePage(
             title="Child page",
             slug='child-page',
+            content="hello",
             live=True,
             has_unpublished_changes=True,
         ))
@@ -1593,6 +1592,7 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         self.test_unpublished_child_page = self.test_page.add_child(instance=SimplePage(
             title="Unpublished Child page",
             slug='unpublished-child-page',
+            content="hello",
             live=False,
             has_unpublished_changes=True,
         ))
@@ -1908,6 +1908,7 @@ class TestPageUnpublish(TestCase, WagtailTestUtils):
         self.page = SimplePage(
             title="Hello world!",
             slug='hello-world',
+            content="hello",
             live=True,
         )
         self.root_page.add_child(instance=self.page)
@@ -1991,6 +1992,7 @@ class TestApproveRejectModeration(TestCase, WagtailTestUtils):
         self.page = SimplePage(
             title="Hello world!",
             slug='hello-world',
+            content="hello",
             live=False,
             has_unpublished_changes=True,
         )
@@ -2279,6 +2281,7 @@ class TestNotificationPreferences(TestCase, WagtailTestUtils):
         self.child_page = SimplePage(
             title="Hello world!",
             slug='hello-world',
+            content="hello",
             live=False,
         )
         self.root_page.add_child(instance=self.child_page)
@@ -2434,6 +2437,7 @@ class TestLocking(TestCase, WagtailTestUtils):
         self.child_page = SimplePage(
             title="Hello world!",
             slug='hello-world',
+            content="hello",
             live=False,
         )
         self.root_page.add_child(instance=self.child_page)

--- a/wagtail/wagtailadmin/tests/test_privacy.py
+++ b/wagtail/wagtailadmin/tests/test_privacy.py
@@ -16,12 +16,14 @@ class TestSetPrivacyView(TestCase, WagtailTestUtils):
         self.public_page = self.homepage.add_child(instance=SimplePage(
             title="Public page",
             slug='public-page',
+            content="hello",
             live=True,
         ))
 
         self.private_page = self.homepage.add_child(instance=SimplePage(
             title="Private page",
             slug='private-page',
+            content="hello",
             live=True,
         ))
         PageViewRestriction.objects.create(page=self.private_page, password='password123')
@@ -29,6 +31,7 @@ class TestSetPrivacyView(TestCase, WagtailTestUtils):
         self.private_child_page = self.private_page.add_child(instance=SimplePage(
             title="Private child page",
             slug='private-child-page',
+            content="hello",
             live=True,
         ))
 
@@ -138,12 +141,14 @@ class TestPrivacyIndicators(TestCase, WagtailTestUtils):
         self.public_page = self.homepage.add_child(instance=SimplePage(
             title="Public page",
             slug='public-page',
+            content="hello",
             live=True,
         ))
 
         self.private_page = self.homepage.add_child(instance=SimplePage(
             title="Private page",
             slug='private-page',
+            content="hello",
             live=True,
         ))
         PageViewRestriction.objects.create(page=self.private_page, password='password123')
@@ -151,6 +156,7 @@ class TestPrivacyIndicators(TestCase, WagtailTestUtils):
         self.private_child_page = self.private_page.add_child(instance=SimplePage(
             title="Private child page",
             slug='private-child-page',
+            content="hello",
             live=True,
         ))
 

--- a/wagtail/wagtailadmin/tests/test_widgets.py
+++ b/wagtail/wagtailadmin/tests/test_widgets.py
@@ -15,6 +15,7 @@ class TestAdminPageChooserWidget(TestCase):
         self.child_page = SimplePage(
             title="foobarbaz",
             slug="foobarbaz",
+            content="hello",
         )
         self.root_page.add_child(instance=self.child_page)
 

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -604,6 +604,8 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
                 raise Http404
 
     def save_revision(self, user=None, submitted_for_moderation=False, approved_go_live_at=None, changed=True):
+        self.full_clean()
+
         # Create revision
         revision = self.revisions.create(
             content_json=self.to_json(),

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -397,6 +397,8 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
     @transaction.atomic
     # ensure that changes are only committed when we have updated all descendant URL paths, to preserve consistency
     def save(self, *args, **kwargs):
+        self.full_clean()
+
         update_descendant_url_paths = False
         is_new = self.id is None
 

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -283,8 +283,6 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         max_length=255,
         help_text=_("The name of the page as it will appear in URLs e.g http://domain.com/blog/[my-slug]/")
     )
-    # TODO: enforce uniqueness on slug field per parent (will have to be done at the Django
-    # level rather than db, since there is no explicit parent relation in the db)
     content_type = models.ForeignKey(
         'contenttypes.ContentType',
         verbose_name=_('content type'),
@@ -393,6 +391,27 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
             self.url_path = '/'
 
         return self.url_path
+
+    @staticmethod
+    def _slug_is_available(slug, parent_page, page=None):
+        """
+        Determine whether the given slug is available for use on a child page of
+        parent_page. If 'page' is passed, the slug is intended for use on that page
+        (and so it will be excluded from the duplicate check).
+        """
+        if parent_page is None:
+            # the root page's slug can be whatever it likes...
+            return True
+
+        siblings = parent_page.get_children()
+        if page:
+            siblings = siblings.not_page(page)
+
+        return not siblings.filter(slug=slug).exists()
+
+    def clean(self):
+        if not Page._slug_is_available(self.slug, self.get_parent(), self):
+            raise ValidationError({'slug': _("This slug is already in use")})
 
     @transaction.atomic
     # ensure that changes are only committed when we have updated all descendant URL paths, to preserve consistency

--- a/wagtail/wagtailcore/tests/test_management_commands.py
+++ b/wagtail/wagtailcore/tests/test_management_commands.py
@@ -175,6 +175,7 @@ class TestPublishScheduledPagesCommand(TestCase):
         page = SimplePage(
             title="Hello world!",
             slug="hello-world",
+            content="hello",
             live=False,
             has_unpublished_changes=True,
             go_live_at=timezone.now() - timedelta(days=1),
@@ -204,6 +205,7 @@ class TestPublishScheduledPagesCommand(TestCase):
         page = SimplePage(
             title="Hello world!",
             slug="hello-world",
+            content="hello",
             live=False,
             has_unpublished_changes=True,
             go_live_at=timezone.now() - timedelta(days=1),
@@ -226,6 +228,7 @@ class TestPublishScheduledPagesCommand(TestCase):
         page = SimplePage(
             title="Hello world!",
             slug="hello-world",
+            content="hello",
             live=False,
             go_live_at=timezone.now() + timedelta(days=1),
         )
@@ -257,6 +260,7 @@ class TestPublishScheduledPagesCommand(TestCase):
         page = SimplePage(
             title="Hello world!",
             slug="hello-world",
+            content="hello",
             live=True,
             has_unpublished_changes=False,
             expire_at=timezone.now() - timedelta(days=1),
@@ -282,6 +286,7 @@ class TestPublishScheduledPagesCommand(TestCase):
         page = SimplePage(
             title="Hello world!",
             slug="hello-world",
+            content="hello",
             live=True,
             expire_at=timezone.now() + timedelta(days=1),
         )
@@ -300,6 +305,7 @@ class TestPublishScheduledPagesCommand(TestCase):
         page = SimplePage(
             title="Hello world!",
             slug="hello-world",
+            content="hello",
             live=False,
             expire_at=timezone.now() - timedelta(days=1),
         )

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -322,14 +322,24 @@ class TestStaticSitePaths(TestCase):
         self.root_page = Page.objects.get(id=1)
 
         # For simple tests
-        self.home_page = self.root_page.add_child(instance=SimplePage(title="Homepage", slug="home"))
-        self.about_page = self.home_page.add_child(instance=SimplePage(title="About us", slug="about"))
-        self.contact_page = self.home_page.add_child(instance=SimplePage(title="Contact", slug="contact"))
+        self.home_page = self.root_page.add_child(
+            instance=SimplePage(title="Homepage", slug="home", content="hello")
+        )
+        self.about_page = self.home_page.add_child(
+            instance=SimplePage(title="About us", slug="about", content="hello")
+        )
+        self.contact_page = self.home_page.add_child(
+            instance=SimplePage(title="Contact", slug="contact", content="hello")
+        )
 
         # For custom tests
         self.event_index = self.root_page.add_child(instance=EventIndex(title="Events", slug="events"))
         for i in range(20):
-            self.event_index.add_child(instance=EventPage(title="Event " + str(i), slug="event" + str(i)))
+            self.event_index.add_child(instance=EventPage(
+                title="Event " + str(i), slug="event" + str(i),
+                location='the moon', audience='public',
+                cost='free', date_from='2001-01-01',
+            ))
 
     def test_local_static_site_paths(self):
         paths = list(self.about_page.get_static_site_paths())
@@ -611,7 +621,7 @@ class TestCopyPage(TestCase):
 
     def test_copy_page_copies_recursively_with_revisions(self):
         events_index = EventIndex.objects.get(url_path='/home/events/')
-        old_christmas_event = events_index.get_children().filter(slug='christmas').first()
+        old_christmas_event = events_index.get_children().filter(slug='christmas').first().specific
         old_christmas_event.save_revision()
 
         # Copy it

--- a/wagtail/wagtailcore/tests/test_tests.py
+++ b/wagtail/wagtailcore/tests/test_tests.py
@@ -53,7 +53,7 @@ class TestWagtailPageTests(WagtailPageTests):
             ])})
 
     def test_assert_can_create_subpage_rules(self):
-        simple_page = SimplePage(title='Simple Page', slug='simple')
+        simple_page = SimplePage(title='Simple Page', slug='simple', content="hello")
         self.root.add_child(instance=simple_page)
         # This should raise an error, as a BusinessChild can not be created under a SimplePage
         with self.assertRaisesRegex(AssertionError, r'Can not create a tests.businesschild under a tests.simplepage'):

--- a/wagtail/wagtailcore/tests/tests.py
+++ b/wagtail/wagtailcore/tests/tests.py
@@ -97,7 +97,7 @@ class TestSiteRootPathsCache(TestCase):
         default_site = Site.objects.get(is_default_site=True)
 
         # Create a new homepage under current homepage
-        new_homepage = SimplePage(title="New Homepage", slug="new-homepage")
+        new_homepage = SimplePage(title="New Homepage", slug="new-homepage", content="hello")
         homepage.add_child(instance=new_homepage)
 
         # Set new homepage as the site root page

--- a/wagtail/wagtailforms/tests.py
+++ b/wagtail/wagtailforms/tests.py
@@ -425,7 +425,6 @@ class TestDeleteFormSubmission(TestCase):
         self.assertRedirects(response, reverse("wagtailforms:list_submissions", args=(self.form_page.id, )))
 
     def test_delete_submission_bad_permissions(self):
-        self.form_page = make_form_page()
         self.client.login(username="eventeditor", password="password")
 
         response = self.client.post(reverse(

--- a/wagtail/wagtailsearch/tests/test_frontend.py
+++ b/wagtail/wagtailsearch/tests/test_frontend.py
@@ -47,6 +47,8 @@ class TestSearchView(TestCase):
                 event = EventPage(
                     title="Event " + str(i),
                     slug='event-' + str(i),
+                    location='the moon', audience='public',
+                    cost='free', date_from='2001-01-01',
                     live=True,
                 )
                 event_index.add_child(instance=event)


### PR DESCRIPTION
Fixes #1518.

Added model-level validation on save, save_revision and preview (and fixed all tests that created invalid page instances), and moved slug uniqueness checking so that it happens both in WagtailAdminPageForm and on the Page model.