### PR TITLE
Enable the admin to search over any searchable fields

### DIFF
--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -20,6 +20,7 @@ from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailcore.models import GroupPagePermission, Page, PageRevision, Site
 from wagtail.wagtailcore.signals import page_published, page_unpublished
 from wagtail.wagtailusers.models import UserProfile
+from wagtail.wagtailsearch.index import SearchField
 
 
 def submittable_timestamp(timestamp):
@@ -1473,6 +1474,29 @@ class TestPageSearch(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/pages/search.html')
         self.assertEqual(response.context['query_string'], "Hello")
+
+    def test_search_searchable_fields(self):
+        # Find root page
+        root_page = Page.objects.get(id=2)
+
+        # Create a page
+        root_page.add_child(instance=SimplePage(
+            title="Hi there!",
+            slug='hello-world',
+            live=True,
+            has_unpublished_changes=False,
+        ))
+
+        # Confirm the slug is not being searched
+        response = self.get({'q': "hello"})
+        self.assertNotContains(response, "There is one matching page")
+
+        # Add slug to the search_fields
+        Page.search_fields = Page.search_fields + (SearchField('slug', partial_match=True),)
+
+        # Confirm the slug is being searched
+        response = self.get({'q': "hello"})
+        self.assertContains(response, "There is one matching page")
 
     def test_ajax(self):
         response = self.get({'q': "Hello"}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -1490,6 +1490,7 @@ class TestPageSearch(TestCase, WagtailTestUtils):
         # Confirm the slug is not being searched
         response = self.get({'q': "hello"})
         self.assertNotContains(response, "There is one matching page")
+        search_fields = Page.search_fields
 
         # Add slug to the search_fields
         Page.search_fields = Page.search_fields + (SearchField('slug', partial_match=True),)
@@ -1497,6 +1498,9 @@ class TestPageSearch(TestCase, WagtailTestUtils):
         # Confirm the slug is being searched
         response = self.get({'q': "hello"})
         self.assertContains(response, "There is one matching page")
+
+        # Reset the search fields
+        Page.search_fields = search_fields
 
     def test_ajax(self):
         response = self.get({'q': "Hello"}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -669,7 +669,7 @@ def search(request):
         if form.is_valid():
             q = form.cleaned_data['q']
 
-            pages = Page.objects.all().prefetch_related('content_type').search(q, fields=['title'])
+            pages = Page.objects.all().prefetch_related('content_type').search(q)
             paginator, pages = paginate(request, pages)
     else:
         form = SearchForm()


### PR DESCRIPTION
Enables admin searches to return pages that contain the search query in any of their fields that have been made searchable (by adding the field to the models search_fields variable). Previously only pages that contained the search query in their title field were returned.
