### PR TITLE
Remove unused private method in BaseSearchQuery

### DIFF
--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -25,15 +25,6 @@ class BaseSearchQuery(object):
         self.operator = operator or self.DEFAULT_OPERATOR
         self.order_by_relevance = order_by_relevance
 
-    def _get_searchable_field(self, field_attname):
-        # Get field
-        field = dict(
-            (field.get_attname(self.queryset.model), field)
-            for field in self.queryset.model.get_searchable_search_fields()
-        ).get(field_attname, None)
-
-        return field
-
     def _get_filterable_field(self, field_attname):
         # Get field
         field = dict(


### PR DESCRIPTION
Hey. I need to implement a tweak (more like subclass!) of the existing ``elasticsearch.SearchBackend`` and noticed that this method is unused while I was perusing the code base. Since it's private I think it's safe to remove it.