### PR TITLE
Add distinct icons to blocks

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -93,7 +93,7 @@ Contributors
 * Rich Atkinson
 * jnns
 * Eugene MechanisM
-* benjaoming
+* Benjamin Bach
 * Alexander Bogushov
 * Aarni Koskela
 * alexpilot11

--- a/wagtail/tests/testapp/blocks.py
+++ b/wagtail/tests/testapp/blocks.py
@@ -22,4 +22,3 @@ class SectionBlock(blocks.StructBlock):
     class Meta:
         icon = "form"
         template = 'tests/blocks/section_block.html'
-

--- a/wagtail/tests/testapp/blocks.py
+++ b/wagtail/tests/testapp/blocks.py
@@ -11,6 +11,7 @@ class LinkBlock(blocks.StructBlock):
         return context
 
     class Meta:
+        icon = "site"
         template = 'tests/blocks/link_block.html'
 
 
@@ -19,4 +20,6 @@ class SectionBlock(blocks.StructBlock):
     body = blocks.RichTextBlock()
 
     class Meta:
+        icon = "form"
         template = 'tests/blocks/section_block.html'
+

--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -19,8 +19,6 @@ from .base import Block
 
 class FieldBlock(Block):
     """A block that wraps a Django form field"""
-    class Meta:
-        default = None
 
     def id_for_label(self, prefix):
         return self.field.widget.id_for_label(prefix)
@@ -76,8 +74,13 @@ class FieldBlock(Block):
         # the one this block works with natively
         return self.value_from_form(self.field.clean(self.value_for_form(value)))
 
+    class Meta:
+        icon = "edit"
+        default = None
+
 
 class CharBlock(FieldBlock):
+
     def __init__(self, required=True, help_text=None, max_length=None, min_length=None, **kwargs):
         # CharField's 'label' and 'initial' parameters are not exposed, as Block handles that functionality natively
         # (via 'label' and 'default')
@@ -94,6 +97,7 @@ class CharBlock(FieldBlock):
 
 
 class TextBlock(FieldBlock):
+
     def __init__(self, required=True, help_text=None, rows=1, max_length=None, min_length=None, **kwargs):
         self.field_options = {
             'required': required,
@@ -114,8 +118,12 @@ class TextBlock(FieldBlock):
     def get_searchable_content(self, value):
         return [force_text(value)]
 
+    class Meta:
+        icon = "pilcrow"
+
 
 class URLBlock(FieldBlock):
+
     def __init__(self, required=True, help_text=None, max_length=None, min_length=None, **kwargs):
         self.field = forms.URLField(
             required=required,
@@ -125,8 +133,12 @@ class URLBlock(FieldBlock):
         )
         super(URLBlock, self).__init__(**kwargs)
 
+    class Meta:
+        icon = "site"
+
 
 class BooleanBlock(FieldBlock):
+
     def __init__(self, required=True, help_text=None, **kwargs):
         # NOTE: As with forms.BooleanField, the default of required=True means that the checkbox
         # must be ticked to pass validation (i.e. it's equivalent to an "I agree to the terms and
@@ -135,8 +147,12 @@ class BooleanBlock(FieldBlock):
         self.field = forms.BooleanField(required=required, help_text=help_text)
         super(BooleanBlock, self).__init__(**kwargs)
 
+    class Meta:
+        icon = "tick-inverse"
+
 
 class DateBlock(FieldBlock):
+
     def __init__(self, required=True, help_text=None, **kwargs):
         self.field_options = {'required': required, 'help_text': help_text}
         super(DateBlock, self).__init__(**kwargs)
@@ -157,8 +173,12 @@ class DateBlock(FieldBlock):
         else:
             return parse_date(value)
 
+    class Meta:
+        icon = "date"
+
 
 class TimeBlock(FieldBlock):
+
     def __init__(self, required=True, help_text=None, **kwargs):
         self.field_options = {'required': required, 'help_text': help_text}
         super(TimeBlock, self).__init__(**kwargs)
@@ -176,8 +196,12 @@ class TimeBlock(FieldBlock):
         else:
             return parse_time(value)
 
+    class Meta:
+        icon = "time"
+
 
 class DateTimeBlock(FieldBlock):
+
     def __init__(self, required=True, help_text=None, **kwargs):
         self.field_options = {'required': required, 'help_text': help_text}
         super(DateTimeBlock, self).__init__(**kwargs)
@@ -195,8 +219,12 @@ class DateTimeBlock(FieldBlock):
         else:
             return parse_datetime(value)
 
+    class Meta:
+        icon = "date"
+
 
 class ChoiceBlock(FieldBlock):
+
     choices = ()
 
     def __init__(self, choices=None, required=True, help_text=None, **kwargs):
@@ -259,6 +287,9 @@ class ChoiceBlock(FieldBlock):
                     return [v]
         return []  # Value was not found in the list of choices
 
+    class Meta:
+        icon = "list-ol"
+
 
 class RichTextBlock(FieldBlock):
 
@@ -299,8 +330,12 @@ class RichTextBlock(FieldBlock):
     def get_searchable_content(self, value):
         return [force_text(value.source)]
 
+    class Meta:
+        icon = "doc-full"
+
 
 class RawHTMLBlock(FieldBlock):
+
     def __init__(self, required=True, help_text=None, max_length=None, min_length=None, **kwargs):
         self.field = forms.CharField(
             required=required, help_text=help_text, max_length=max_length, min_length=min_length,
@@ -330,6 +365,7 @@ class RawHTMLBlock(FieldBlock):
 
 
 class ChooserBlock(FieldBlock):
+
     def __init__(self, required=True, help_text=None, **kwargs):
         self.required = required
         self.help_text = help_text
@@ -381,8 +417,12 @@ class ChooserBlock(FieldBlock):
             value = value.pk
         return super(ChooserBlock, self).clean(value)
 
+    class Meta:
+        icon = "search"
+
 
 class PageChooserBlock(ChooserBlock):
+
     def __init__(self, can_choose_root=False, **kwargs):
         self.can_choose_root = can_choose_root
         super(PageChooserBlock, self).__init__(**kwargs)
@@ -402,6 +442,9 @@ class PageChooserBlock(ChooserBlock):
             return format_html('<a href="{0}">{1}</a>', value.url, value.title)
         else:
             return ''
+
+    class Meta:
+        icon = "redirect"
 
 
 # Ensure that the blocks defined here get deconstructed as wagtailcore.blocks.FooBlock

--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -288,7 +288,10 @@ class ChoiceBlock(FieldBlock):
         return []  # Value was not found in the list of choices
 
     class Meta:
-        icon = "list-ol"
+        # No suitable icon as of now, feel encouraged to swap this in your
+        # decendant block type or contribute a better generic icon to
+        # Wagtail's icon set
+        icon = "placeholder"
 
 
 class RichTextBlock(FieldBlock):

--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -75,7 +75,10 @@ class FieldBlock(Block):
         return self.value_from_form(self.field.clean(self.value_for_form(value)))
 
     class Meta:
-        icon = "edit"
+        # No icon specified here, because that depends on the purpose that the
+        # block is being used for. Feel encouraged to specify an icon in your
+        # descendant block type
+        icon = "placeholder"
         default = None
 
 
@@ -421,7 +424,10 @@ class ChooserBlock(FieldBlock):
         return super(ChooserBlock, self).clean(value)
 
     class Meta:
-        icon = "search"
+        # No icon specified here, because that depends on the purpose that the
+        # block is being used for. Feel encouraged to specify an icon in your
+        # descendant block type
+        icon = "placeholder"
 
 
 class PageChooserBlock(ChooserBlock):

--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -288,9 +288,9 @@ class ChoiceBlock(FieldBlock):
         return []  # Value was not found in the list of choices
 
     class Meta:
-        # No suitable icon as of now, feel encouraged to swap this in your
-        # decendant block type or contribute a better generic icon to
-        # Wagtail's icon set
+        # No icon specified here, because that depends on the purpose that the
+        # block is being used for. Feel encouraged to specify an icon in your
+        # descendant block type
         icon = "placeholder"
 
 

--- a/wagtail/wagtailcore/blocks/list_block.py
+++ b/wagtail/wagtailcore/blocks/list_block.py
@@ -18,6 +18,7 @@ __all__ = ['ListBlock']
 
 
 class ListBlock(Block):
+
     def __init__(self, child_block, **kwargs):
         super(ListBlock, self).__init__(**kwargs)
 
@@ -159,6 +160,10 @@ class ListBlock(Block):
         errors = super(ListBlock, self).check(**kwargs)
         errors.extend(self.child_block.check(**kwargs))
         return errors
+
+    class Meta:
+        icon = "list-ul"
+
 
 DECONSTRUCT_ALIASES = {
     ListBlock: 'wagtail.wagtailcore.blocks.ListBlock',

--- a/wagtail/wagtailcore/blocks/list_block.py
+++ b/wagtail/wagtailcore/blocks/list_block.py
@@ -162,7 +162,10 @@ class ListBlock(Block):
         return errors
 
     class Meta:
-        icon = "list-ul"
+        # No suitable icon as of now, feel encouraged to swap this in your
+        # decendant block type or contribute a better generic icon to
+        # Wagtail's icon set
+        icon = "placeholder"
 
 
 DECONSTRUCT_ALIASES = {

--- a/wagtail/wagtailcore/blocks/stream_block.py
+++ b/wagtail/wagtailcore/blocks/stream_block.py
@@ -24,9 +24,6 @@ __all__ = ['BaseStreamBlock', 'StreamBlock', 'StreamValue']
 
 
 class BaseStreamBlock(Block):
-    class Meta:
-        icon = "placeholder"
-        default = []
 
     def __init__(self, local_blocks=None, **kwargs):
         self._constructor_kwargs = kwargs
@@ -231,6 +228,13 @@ class BaseStreamBlock(Block):
             errors.extend(child_block._check_name(**kwargs))
 
         return errors
+
+    class Meta:
+        # No suitable icon as of now, feel encouraged to swap this in your
+        # decendant block type or contribute a better generic icon to
+        # Wagtail's icon set
+        icon = "placeholder"
+        default = []
 
 
 class StreamBlock(six.with_metaclass(DeclarativeSubBlocksMetaclass, BaseStreamBlock)):

--- a/wagtail/wagtailcore/blocks/stream_block.py
+++ b/wagtail/wagtailcore/blocks/stream_block.py
@@ -25,6 +25,7 @@ __all__ = ['BaseStreamBlock', 'StreamBlock', 'StreamValue']
 
 class BaseStreamBlock(Block):
     class Meta:
+        icon = "placeholder"
         default = []
 
     def __init__(self, local_blocks=None, **kwargs):

--- a/wagtail/wagtailcore/blocks/struct_block.py
+++ b/wagtail/wagtailcore/blocks/struct_block.py
@@ -162,7 +162,10 @@ class BaseStructBlock(Block):
         template = "wagtailadmin/blocks/struct.html"
         form_classname = 'struct-block'
         form_template = 'wagtailadmin/block_forms/struct.html'
-        icon = "form"
+        # No suitable icon as of now, feel encouraged to swap this in your
+        # decendant block type or contribute a better generic icon to
+        # Wagtail's icon set
+        icon = "placeholder"
 
 
 class StructBlock(six.with_metaclass(DeclarativeSubBlocksMetaclass, BaseStructBlock)):

--- a/wagtail/wagtailcore/blocks/struct_block.py
+++ b/wagtail/wagtailcore/blocks/struct_block.py
@@ -21,11 +21,6 @@ __all__ = ['BaseStructBlock', 'StructBlock', 'StructValue']
 
 
 class BaseStructBlock(Block):
-    class Meta:
-        default = {}
-        template = "wagtailadmin/blocks/struct.html"
-        form_classname = 'struct-block'
-        form_template = 'wagtailadmin/block_forms/struct.html'
 
     def __init__(self, local_blocks=None, **kwargs):
         self._constructor_kwargs = kwargs
@@ -162,6 +157,13 @@ class BaseStructBlock(Block):
 
         return errors
 
+    class Meta:
+        default = {}
+        template = "wagtailadmin/blocks/struct.html"
+        form_classname = 'struct-block'
+        form_template = 'wagtailadmin/block_forms/struct.html'
+        icon = "form"
+
 
 class StructBlock(six.with_metaclass(DeclarativeSubBlocksMetaclass, BaseStructBlock)):
     pass
@@ -182,3 +184,4 @@ class StructValue(collections.OrderedDict):
             (name, block.bind(self.get(name)))
             for name, block in self.block.child_blocks.items()
         ])
+

--- a/wagtail/wagtailcore/blocks/struct_block.py
+++ b/wagtail/wagtailcore/blocks/struct_block.py
@@ -184,4 +184,3 @@ class StructValue(collections.OrderedDict):
             (name, block.bind(self.get(name)))
             for name, block in self.block.child_blocks.items()
         ])
-

--- a/wagtail/wagtailcore/blocks/struct_block.py
+++ b/wagtail/wagtailcore/blocks/struct_block.py
@@ -162,9 +162,9 @@ class BaseStructBlock(Block):
         template = "wagtailadmin/blocks/struct.html"
         form_classname = 'struct-block'
         form_template = 'wagtailadmin/block_forms/struct.html'
-        # No suitable icon as of now, feel encouraged to swap this in your
-        # decendant block type or contribute a better generic icon to
-        # Wagtail's icon set
+        # No icon specified here, because that depends on the purpose that the
+        # block is being used for. Feel encouraged to specify an icon in your
+        # descendant block type
         icon = "placeholder"
 
 

--- a/wagtail/wagtaildocs/blocks.py
+++ b/wagtail/wagtaildocs/blocks.py
@@ -25,4 +25,3 @@ class DocumentChooserBlock(ChooserBlock):
 
     class Meta:
         icon = "doc-empty"
-

--- a/wagtail/wagtaildocs/blocks.py
+++ b/wagtail/wagtaildocs/blocks.py
@@ -22,3 +22,7 @@ class DocumentChooserBlock(ChooserBlock):
             return format_html('<a href="{0}">{1}</a>', value.url, value.title)
         else:
             return ''
+
+    class Meta:
+        icon = "doc-empty"
+

--- a/wagtail/wagtailembeds/blocks.py
+++ b/wagtail/wagtailembeds/blocks.py
@@ -63,4 +63,3 @@ class EmbedBlock(blocks.URLBlock):
 
     class Meta:
         icon = "media"
-

--- a/wagtail/wagtailembeds/blocks.py
+++ b/wagtail/wagtailembeds/blocks.py
@@ -60,3 +60,7 @@ class EmbedBlock(blocks.URLBlock):
             return None
         else:
             return EmbedValue(value)
+
+    class Meta:
+        icon = "media"
+

--- a/wagtail/wagtailimages/blocks.py
+++ b/wagtail/wagtailimages/blocks.py
@@ -23,4 +23,3 @@ class ImageChooserBlock(ChooserBlock):
 
     class Meta:
         icon = "image"
-

--- a/wagtail/wagtailimages/blocks.py
+++ b/wagtail/wagtailimages/blocks.py
@@ -20,3 +20,7 @@ class ImageChooserBlock(ChooserBlock):
             return get_rendition_or_not_found(value, 'original').img_tag()
         else:
             return ''
+
+    class Meta:
+        icon = "image"
+

--- a/wagtail/wagtailsnippets/blocks.py
+++ b/wagtail/wagtailsnippets/blocks.py
@@ -14,3 +14,7 @@ class SnippetChooserBlock(ChooserBlock):
     def widget(self):
         from wagtail.wagtailsnippets.widgets import AdminSnippetChooser
         return AdminSnippetChooser(self.target_model)
+
+    class Meta:
+        icon = "snippet"
+

--- a/wagtail/wagtailsnippets/blocks.py
+++ b/wagtail/wagtailsnippets/blocks.py
@@ -17,4 +17,3 @@ class SnippetChooserBlock(ChooserBlock):
 
     class Meta:
         icon = "snippet"
-


### PR DESCRIPTION
It's pretty hard to navigate the many different block types in a StreamField that permits lots of different blocks. So I used the icons from the current style guide. Some of the icon names and semantic intentions might be a little besides the way they're used, but in case the icon changes, I don't think it'll cause a major disaster :)

I moved a couple of subclass `class Meta` to the end of the class definition because it's easier to always know where to look for them.