### PR TITLE
Ask user for old password when changing password

### DIFF
--- a/wagtail/wagtailadmin/tests/test_account_management.py
+++ b/wagtail/wagtailadmin/tests/test_account_management.py
@@ -190,6 +190,7 @@ class TestAccountSection(TestCase, WagtailTestUtils):
         """
         # Post new password to change password page
         post_data = {
+            'old_password': 'password',
             'new_password1': 'newpassword',
             'new_password2': 'newpassword',
         }

--- a/wagtail/wagtailadmin/views/account.py
+++ b/wagtail/wagtailadmin/views/account.py
@@ -3,7 +3,7 @@ from functools import wraps
 from django.conf import settings
 from django.shortcuts import render, redirect
 from django.contrib import messages
-from django.contrib.auth.forms import SetPasswordForm
+from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth import update_session_auth_hash, views as auth_views
 from django.http import Http404
 from django.utils.translation import ugettext as _
@@ -48,7 +48,7 @@ def change_password(request):
 
     if can_change_password:
         if request.POST:
-            form = SetPasswordForm(request.user, request.POST)
+            form = PasswordChangeForm(request.user, request.POST)
 
             if form.is_valid():
                 form.save()
@@ -57,7 +57,7 @@ def change_password(request):
                 messages.success(request, _("Your password has been changed successfully!"))
                 return redirect('wagtailadmin_account')
         else:
-            form = SetPasswordForm(request.user)
+            form = PasswordChangeForm(request.user)
     else:
         form = None
 


### PR DESCRIPTION
This is accomplished by using SetPasswordForm instead of PasswordChangeForm.

This adds extra security, as without this commit, an attacker that has access to
a user's session at one point in time will be able to change the user's password
and gain permanent access.