### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/advanced_topics/third_party_tutorials.rst
+++ b/docs/advanced_topics/third_party_tutorials.rst
@@ -22,7 +22,6 @@ Third-party tutorials
 * `Wagtail notes: dynamic templates per page <http://www.coactivate.org/projects/ejucovy/blog/2014/05/10/wagtail-notes-dynamic-templates-per-page/>`_ (10 May 2014)
 * `Wagtail notes: type-constrained PageChooserPanel <http://www.coactivate.org/projects/ejucovy/blog/2014/05/09/wagtail-notes-type-constrained-pagechooserpanel/>`_ (9 May 2014)
 * `How to Run the Wagtail CMS on Gondor <https://gondor.io/blog/2014/02/14/how-run-wagtail-cms-gondor/>`_ (14 February 2014)
-* `The first Wagtail tutorial <http://spapas.github.io/2014/02/13/wagtail-tutorial/>`_ (13 February 2014)
 
 .. tip::
 

--- a/docs/getting_started/tutorial.rst
+++ b/docs/getting_started/tutorial.rst
@@ -110,8 +110,7 @@ home\_page.html). Edit
 Wagtail template tags
 ~~~~~~~~~~~~~~~~~~~~~
 
-Wagtail provides a number of
-`template tags & filters <../topics/writing_templates#template-tags-filters>`__
+Wagtail provides a number of :ref:`template tags & filters <template-tags-and-filters>`
 which can be loaded by including ``{% load wagtailcore_tags %}`` at the top of
 your template file.
 

--- a/docs/reference/pages/model_reference.rst
+++ b/docs/reference/pages/model_reference.rst
@@ -6,6 +6,8 @@ Model Reference
 
 This document contains reference information for the model classes inside the ``wagtailcore`` module.
 
+.. _page-model-ref:
+
 ``Page``
 ========
 
@@ -239,6 +241,8 @@ Methods and properties
          - Everything else will use the ``http://`` scheme and the port will be appended to the end of the hostname (eg. ``http://mysite.com:8000/``)
 
     .. automethod:: get_site_root_paths
+
+.. _page-revision-model-ref:
 
 ``PageRevision``
 ================

--- a/docs/reference/signals.rst
+++ b/docs/reference/signals.rst
@@ -3,8 +3,7 @@
 Signals
 =======
 
-Wagtail's `PageRevision <./pages/model_reference#pagerevision>`__  and
-`Page <./pages/model_reference#page>`__  implement
+Wagtail's :ref:`page-revision-model-ref` and :ref:`page-model-ref` implement
 `Signals <https://docs.djangoproject.com/en/1.8/topics/signals/>`__ from ``django.dispatch``.
 Signals are useful for creating side-effects from page publish/unpublish events.
 

--- a/docs/reference/signals.rst
+++ b/docs/reference/signals.rst
@@ -7,8 +7,8 @@ Wagtail's :ref:`page-revision-model-ref` and :ref:`page-model-ref` implement
 `Signals <https://docs.djangoproject.com/en/1.8/topics/signals/>`__ from ``django.dispatch``.
 Signals are useful for creating side-effects from page publish/unpublish events.
 
-Primarily, these are used by the `Frontend Cache <./contrib/frontendcache>`__ contrib module
-and the `Wagtail API <./contrib/api/index>`__. You could also use signals to send
+Primarily, these are used by the :doc:`Frontend Cache <./contrib/frontendcache>` contrib module
+and the :doc:`./contrib/api/index`. You could also use signals to send
 publish notifications to a messaging service, or ``POST`` messages to another
 app that's consuming the API, such as a static site generator.
 

--- a/docs/topics/writing_templates.rst
+++ b/docs/topics/writing_templates.rst
@@ -72,6 +72,7 @@ Images from the library must be requested using this syntax, but a developer's s
 
 Read more about the image manipulation syntax here :ref:`image_tag`.
 
+.. _template-tags-and-filters:
 
 Template tags & filters
 =======================


### PR DESCRIPTION
While going through the [Getting Started tutorial](http://docs.wagtail.io/en/v1.3.1/getting_started/tutorial.html), I stumbled upon a few broken links.

I used [Dead Link Checker](http://www.deadlinkchecker.com/) to catch as many as possible. However, there will still be some broken links:
 - Documentation of older versions will not be affected.
 - The `Read the Docs` widget (on the lower left corner) links to the same page for previous version of the documentation, even if  it does not exist for that said version.

I was able to successfully generate the `html` and `epub` documentation to check everything was alright. However, I could not verify the `pdf` version as I was unable to install `pdflatex` properly.