### PR TITLE
Dependency update: Support django-treebeard 3.0 and 4.0 releases

### DIFF
--- a/docs/releases/1.4.rst
+++ b/docs/releases/1.4.rst
@@ -64,6 +64,7 @@ Minor features
  * Upgraded jQuery to 2.2.1 (Charlie Choiniere)
  * Multiple homepage summary items (`construct_homepage_summary_items` hook) now better vertically spaced (Nicolas Kuttler)
  * Email notifications can now be sent in HTML format. See :ref:`email_notifications_format` (Mike Dingjan)
+ * Dependency update: Support django-treebeard 3.0 and 4.0 releases
 
 
 Bug fixes

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = [
     "Django>=1.8.1,<1.10",
     "django-modelcluster>=1.1,<1.2",
     "django-taggit>=0.17.5",
-    "django-treebeard==3.0",
+    "django-treebeard>=3.0,<5.0",
     "djangorestframework>=3.1.3",
     "Pillow>=2.6.1",
     "beautifulsoup4>=4.3.2",


### PR DESCRIPTION
The admin extensions in django treebeard 3.0 are not compatible with
Django 1.9. Although these are not used by Wagtail they are used in
other projects (e.g. Oscar), so we should allow treebeard 4.0 which
is compatible with Django 1.9.