### PR TITLE
Page privacy, more possibilities

### DIFF
--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -1,12 +1,16 @@
 from django import forms
+from django.conf import settings
 from django.core import validators
 from django.forms.widgets import TextInput
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import AuthenticationForm, PasswordResetForm
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext, ugettext_lazy
+from django.forms import CheckboxSelectMultiple
+from django.contrib.auth.models import User, Group
+
 from wagtail.wagtailadmin.widgets import AdminPageChooser
-from wagtail.wagtailcore.models import Page
+from wagtail.wagtailcore.models import Page, PageViewRestriction
 
 
 class URLOrAbsolutePathValidator(validators.URLValidator):
@@ -173,18 +177,41 @@ class CopyForm(forms.Form):
         return cleaned_data
 
 
-class PageViewRestrictionForm(forms.Form):
-    restriction_type = forms.ChoiceField(label="Visibility", choices=[
-        ('none', ugettext_lazy("Public")),
-        ('password', ugettext_lazy("Private, accessible with the following password")),
-    ], widget=forms.RadioSelect)
-    password = forms.CharField(required=False)
+class PageViewRestrictionForm(forms.ModelForm):
+    restriction_type = forms.ChoiceField(
+        label="Visibility", choices=PageViewRestriction.RESTRICTION_CHOICES,
+        widget=forms.RadioSelect)
+
+    def clean_password(self):
+        password = self.cleaned_data.get('password')
+        if self.cleaned_data.get('restriction_type') == PageViewRestriction.PASSWORD and not password:
+            raise forms.ValidationError(_('This field is required.'), code='invalid')
+        return password
 
     def clean(self):
         cleaned_data = super(PageViewRestrictionForm, self).clean()
+        users = cleaned_data.get('users')
+        groups = cleaned_data.get('groups')
 
-        if cleaned_data.get('restriction_type') == 'password' and not cleaned_data.get('password'):
-            self._errors["password"] = self.error_class([_('This field is required.')])
-            del cleaned_data['password']
+        if self.cleaned_data.get('restriction_type') == PageViewRestriction.USERS_GROUPS:
+            if not users and not groups:
+                self.add_error('groups', _("Please, select at least one group or user."))
+                raise forms.ValidationError(
+                    _('This field is required.'),
+                    code='invalid'
+                )
 
-        return cleaned_data
+    class Meta:
+        model = PageViewRestriction
+        fields = ('restriction_type', 'password', 'users', 'groups')
+
+    def __init__(self, *args, **kwargs):
+
+        super(PageViewRestrictionForm, self).__init__(*args, **kwargs)
+
+        self.fields["users"].widget = CheckboxSelectMultiple()
+        self.fields["users"].queryset = User.objects.all()
+
+        self.fields["groups"].widget = CheckboxSelectMultiple()
+        self.fields["groups"].queryset = Group.objects.all()
+

--- a/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy.html
@@ -10,6 +10,10 @@
             {% include "wagtailadmin/shared/field_as_li.html" with field=form.restriction_type %}
             {% include "wagtailadmin/shared/field_as_li.html" with field=form.password li_classes="password-field" %}
         </ul>
+        <ul class="fields" id="users-groups-fields">
+            {% include "wagtailadmin/shared/field_as_li.html" with field=form.users %}
+            {% include "wagtailadmin/shared/field_as_li.html" with field=form.groups %}
+        </ul>
         <input type="submit" value="Save" />
     </form>
     

--- a/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy.js
@@ -4,13 +4,21 @@ function(modal) {
         return false;
     });
 
-    var restrictionTypePasswordField = $("input[name='restriction_type'][value='password']", modal.body);
-    var passwordField = $("#id_password", modal.body);
+    var restrictionTypePasswordField = $("input[name='restriction_type'][value='password']", modal.body),
+        restrictionTypeUsersGroups = $("input[name='restriction_type'][value='users_groups']", modal.body),
+        passwordField = $(".password-field", modal.body),
+        usersGroupsFields = $('#users-groups-fields', modal.body);
+
     function refreshFormFields() {
         if (restrictionTypePasswordField.is(':checked')) {
-            passwordField.removeAttr('disabled');
+            passwordField.show();
+            usersGroupsFields.hide();
+        } else if (restrictionTypeUsersGroups.is(':checked')){
+            passwordField.hide();
+            usersGroupsFields.show();
         } else {
-            passwordField.attr('disabled', true);
+            passwordField.hide();
+            usersGroupsFields.hide();
         }
     }
     refreshFormFields();

--- a/wagtail/wagtailadmin/views/page_privacy.py
+++ b/wagtail/wagtailadmin/views/page_privacy.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
 
-from wagtail.wagtailcore.models import Page, PageViewRestriction
+from wagtail.wagtailcore.models import Page
 from wagtail.wagtailadmin.forms import PageViewRestrictionForm
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 
@@ -22,20 +22,16 @@ def set_privacy(request, page_id):
         restriction_exists_on_ancestor = False
 
     if request.POST:
-        form = PageViewRestrictionForm(request.POST)
+        form = PageViewRestrictionForm(request.POST, instance=restriction)
         if form.is_valid() and not restriction_exists_on_ancestor:
             if form.cleaned_data['restriction_type'] == 'none':
                 # remove any existing restriction
                 if restriction:
                     restriction.delete()
-            else:  # restriction_type = 'password'
-                if restriction:
-                    restriction.password = form.cleaned_data['password']
-                    restriction.save()
-                else:
-                    # create a new restriction object
-                    PageViewRestriction.objects.create(
-                        page=page, password=form.cleaned_data['password'])
+            else:
+                restriction = form.save(commit=False)
+                restriction.page = page
+                form.save()
 
             return render_modal_workflow(
                 request, None, 'wagtailadmin/page_privacy/set_privacy_done.js', {
@@ -46,9 +42,7 @@ def set_privacy(request, page_id):
     else:  # request is a GET
         if not restriction_exists_on_ancestor:
             if restriction:
-                form = PageViewRestrictionForm(initial={
-                    'restriction_type': 'password', 'password': restriction.password
-                })
+                form = PageViewRestrictionForm(instance=restriction)
             else:
                 # no current view restrictions on this page
                 form = PageViewRestrictionForm(initial={

--- a/wagtail/wagtailcore/migrations/0024_auto_20160303_1848.py
+++ b/wagtail/wagtailcore/migrations/0024_auto_20160303_1848.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0006_require_contenttypes_0002'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('wagtailcore', '0023_alter_page_revision_on_delete_behaviour'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='pageviewrestriction',
+            name='groups',
+            field=models.ManyToManyField(to='auth.Group', blank=True),
+        ),
+        migrations.AddField(
+            model_name='pageviewrestriction',
+            name='restriction_type',
+            field=models.CharField(default='none', max_length=20, choices=[('none', 'Public'), ('password', 'Private, accessible with the following password'), ('users_groups', 'Private, visible to specific users and groups')]),
+        ),
+        migrations.AddField(
+            model_name='pageviewrestriction',
+            name='users',
+            field=models.ManyToManyField(to=settings.AUTH_USER_MODEL, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='pageviewrestriction',
+            name='password',
+            field=models.CharField(max_length=255, verbose_name='password', blank=True),
+        ),
+    ]

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -18,7 +18,7 @@ from django.core.handlers.wsgi import WSGIRequest
 from django.core.handlers.base import BaseHandler
 from django.core.urlresolvers import reverse
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import User, Group
 from django.conf import settings
 from django.template.response import TemplateResponse
 from django.utils import timezone
@@ -1246,6 +1246,7 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         return PageViewRestriction.objects.filter(page__in=self.get_ancestors(inclusive=True))
 
     password_required_template = getattr(settings, 'PASSWORD_REQUIRED_TEMPLATE', 'wagtailcore/password_required.html')
+    access_denied_template = getattr(settings, 'ACCESS_DENIED_TEMPLATE', 'wagtailcore/access_denied.html')
 
     def serve_password_required_response(self, request, form, action_url):
         """
@@ -1259,6 +1260,10 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         context['form'] = form
         context['action_url'] = action_url
         return TemplateResponse(request, self.password_required_template, context)
+
+    def serve_access_denied_response(self, request):
+        context = self.get_context(request)
+        return TemplateResponse(request, self.access_denied_template, context)
 
     class Meta:
         verbose_name = _('page')
@@ -1710,8 +1715,23 @@ class PagePermissionTester(object):
 
 
 class PageViewRestriction(models.Model):
+    NONE = 'none'
+    PASSWORD = 'password'
+    USERS_GROUPS = 'users_groups'
+    LOGIN = 'login'
+
+    RESTRICTION_CHOICES = (
+        (NONE, _("Public")),
+        (LOGIN, _("Private, visible if logged in")),
+        (PASSWORD, _("Private, accessible with the following password")),
+        (USERS_GROUPS, _("Private, visible to specific users and groups"))
+    )
+    restriction_type = models.CharField(
+        max_length=20, default=NONE, choices=RESTRICTION_CHOICES)
     page = models.ForeignKey('Page', verbose_name=_('page'), related_name='view_restrictions')
-    password = models.CharField(verbose_name=_('password'), max_length=255)
+    password = models.CharField(verbose_name=_('password'), max_length=255, blank=True)
+    users = models.ManyToManyField(User, blank=True)
+    groups = models.ManyToManyField(Group, blank=True)
 
     class Meta:
         verbose_name = _('page view restriction')

--- a/wagtail/wagtailcore/query.py
+++ b/wagtail/wagtailcore/query.py
@@ -209,6 +209,21 @@ class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
         """
         return self.exclude(self.exact_type_q(model))
 
+    def user_can_view_q(self, request):
+        from wagtail.wagtailcore.utils import check_user_can_view_page
+
+        ids_to_exclude = []
+        for page in self:
+            if not check_user_can_view_page(page, request):
+                ids_to_exclude.append(page.id)
+        return Q(id__in=ids_to_exclude)
+
+    def user_can_view(self, request):
+        """
+        This filters the QuerySet to only contain pages visible by the user in request
+        """
+        return self.exclude(self.user_can_view_q(request))
+
     def public_q(self):
         from wagtail.wagtailcore.models import PageViewRestriction
 

--- a/wagtail/wagtailcore/templates/wagtailcore/access_denied.html
+++ b/wagtail/wagtailcore/templates/wagtailcore/access_denied.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <title>Access denied</title>
+    </head>
+    <body>
+        <h1>Access Denied</h1>
+        <p>You can not view this page.</p>
+    </body>
+</html>


### PR DESCRIPTION
Now you can choose the privacy of a pages between these options:
1 - Public
2 - Private, visible with a required password
3 - Private, visible if logged in
4 - Private, visible if you are a specific user or in a specific user group

Implemented a new QuerySet method that allows you to retrieve only the pages visible by the currently logged user. It can be useful, for example, when drawing the menu of the main site.

_Example:_
```python
def top_menu(context, parent, calling_page=None):
    menuitems = parent.get_children().live().in_menu().user_can_view(context['request'])
```