### PR TITLE
Support of custom user model

### DIFF
--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -216,7 +216,7 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
                         messages.button(reverse('wagtailadmin_pages:edit', args=(page.id,)), _('Edit'))
                     ]
                 )
-                send_notification(page.get_latest_revision().id, 'submitted', request.user.id)
+                send_notification(page.get_latest_revision().id, 'submitted', request.user.pk)
             else:
                 messages.success(request, _("Page '{0}' created.").format(page.title))
 
@@ -368,7 +368,7 @@ def edit(request, page_id):
                     )
                 ])
 
-                send_notification(page.get_latest_revision().id, 'submitted', request.user.id)
+                send_notification(page.get_latest_revision().id, 'submitted', request.user.pk)
 
             else:  # Saving
 
@@ -802,7 +802,7 @@ def approve_moderation(request, revision_id):
             messages.button(revision.page.url, _('View live')),
             messages.button(reverse('wagtailadmin_pages:edit', args=(revision.page.id,)), _('Edit'))
         ])
-        send_notification(revision.id, 'approved', request.user.id)
+        send_notification(revision.id, 'approved', request.user.pk)
 
     return redirect('wagtailadmin_home')
 
@@ -821,7 +821,7 @@ def reject_moderation(request, revision_id):
         messages.success(request, _("Page '{0}' rejected for publication.").format(revision.page.title), buttons=[
             messages.button(reverse('wagtailadmin_pages:edit', args=(revision.page.id,)), _('Edit'))
         ])
-        send_notification(revision.id, 'rejected', request.user.id)
+        send_notification(revision.id, 'rejected', request.user.pk)
 
     return redirect('wagtailadmin_home')
 

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1673,7 +1673,7 @@ class PagePermissionTester(object):
         return (
             self.user.is_superuser or
             ('edit' in self.permissions) or
-            ('add' in self.permissions and self.page.owner_id == self.user.id)
+            ('add' in self.permissions and self.page.owner_id == self.user.pk)
         )
 
     def can_delete(self):
@@ -1694,7 +1694,7 @@ class PagePermissionTester(object):
             # user can only delete if all pages in this subtree are unpublished and owned by this user
             return (
                 (not self.page.live) and
-                (self.page.owner_id == self.user.id) and
+                (self.page.owner_id == self.user.pk) and
                 (not self.page.get_descendants().exclude(live=False, owner=self.user).exists())
             )
 

--- a/wagtail/wagtailusers/forms.py
+++ b/wagtail/wagtailusers/forms.py
@@ -159,7 +159,7 @@ class UserEditForm(UsernameForm):
         username = self.cleaned_data["username"]
         username_field = User.USERNAME_FIELD
         try:
-            User._default_manager.exclude(id=self.instance.id).get(**{
+            User._default_manager.exclude(pk=self.instance.pk).get(**{
                 username_field: username})
         except User.DoesNotExist:
             return username
@@ -216,7 +216,7 @@ class GroupForm(forms.ModelForm):
         # but it sets a nicer error message than the ORM. See #13147.
         name = self.cleaned_data["name"]
         try:
-            Group._default_manager.exclude(id=self.instance.id).get(name=name)
+            Group._default_manager.exclude(pk=self.instance.pk).get(name=name)
         except Group.DoesNotExist:
             return name
         raise forms.ValidationError(self.error_messages['duplicate_name'])
@@ -323,9 +323,9 @@ class BaseGroupPagePermissionFormSet(forms.BaseFormSet):
             if (pp.page, pp.permission_type) in final_permission_records:
                 permission_records_to_keep.add((pp.page, pp.permission_type))
             else:
-                permission_ids_to_delete.append(pp.id)
+                permission_ids_to_delete.append(pp.pk)
 
-        self.instance.page_permissions.filter(id__in=permission_ids_to_delete).delete()
+        self.instance.page_permissions.filter(pk__in=permission_ids_to_delete).delete()
 
         permissions_to_add = final_permission_records - permission_records_to_keep
         GroupPagePermission.objects.bulk_create([

--- a/wagtail/wagtailusers/templates/wagtailusers/users/edit.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/edit.html
@@ -12,7 +12,7 @@
         <li><a href="#roles">{% trans "Roles" %}</a></li>
     </ul>   
 
-    <form action="{% url 'wagtailusers_users:edit' user.id %}" method="POST">
+    <form action="{% url 'wagtailusers_users:edit' user.pk %}" method="POST">
         <div class="tab-content">
             {% csrf_token %}
 

--- a/wagtail/wagtailusers/templates/wagtailusers/users/list.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/list.html
@@ -29,7 +29,7 @@
                 <td class="title">
                     <h2>
                         <span class="avatar small icon icon-user"><img src="{% gravatar_url user.email 25 %}" /></span>
-                        <a href="{% url 'wagtailusers_users:edit' user.id %}">{{ user.get_full_name|default:user.get_username }}</a>
+                        <a href="{% url 'wagtailusers_users:edit' user.pk %}">{{ user.get_full_name|default:user.get_username }}</a>
                     </h2>
                 </td>
                 <td class="username">{{ user.get_username }}</td>

--- a/wagtail/wagtailusers/tests.py
+++ b/wagtail/wagtailusers/tests.py
@@ -34,7 +34,7 @@ class TestUserIndexView(TestCase, WagtailTestUtils):
 
     def test_allows_negative_ids(self):
         # see https://github.com/torchbox/wagtail/issues/565
-        get_user_model().objects.create_user('guardian', 'guardian@example.com', 'gu@rd14n', id=-1)
+        get_user_model().objects.create_user('guardian', 'guardian@example.com', 'gu@rd14n', pk=-1)
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'testuser')
@@ -119,10 +119,10 @@ class TestUserEditView(TestCase, WagtailTestUtils):
         self.login()
 
     def get(self, params={}, user_id=None):
-        return self.client.get(reverse('wagtailusers_users:edit', args=(user_id or self.test_user.id, )), params)
+        return self.client.get(reverse('wagtailusers_users:edit', args=(user_id or self.test_user.pk, )), params)
 
     def post(self, post_data={}, user_id=None):
-        return self.client.post(reverse('wagtailusers_users:edit', args=(user_id or self.test_user.id, )), post_data)
+        return self.client.post(reverse('wagtailusers_users:edit', args=(user_id or self.test_user.pk, )), post_data)
 
     def test_simple(self):
         response = self.get()
@@ -146,7 +146,7 @@ class TestUserEditView(TestCase, WagtailTestUtils):
         self.assertRedirects(response, reverse('wagtailusers_users:index'))
 
         # Check that the user was edited
-        user = get_user_model().objects.get(id=self.test_user.id)
+        user = get_user_model().objects.get(pk=self.test_user.pk)
         self.assertEqual(user.first_name, 'Edited')
 
     def test_edit_validation_error(self):
@@ -258,8 +258,8 @@ class TestGroupCreateView(TestCase, WagtailTestUtils):
             'page_permissions-0-page': ['1'],
             'page_permissions-0-permission_types': ['edit', 'publish'],
             'page_permissions-TOTAL_FORMS': ['1'],
-            'document_permissions-0-collection': [Collection.get_first_root_node().id],
-            'document_permissions-0-permissions': [self.add_doc_permission.id],
+            'document_permissions-0-collection': [Collection.get_first_root_node().pk],
+            'document_permissions-0-permissions': [self.add_doc_permission.pk],
             'document_permissions-TOTAL_FORMS': ['1'],
         })
 
@@ -293,10 +293,10 @@ class TestGroupCreateView(TestCase, WagtailTestUtils):
         root_collection = Collection.get_first_root_node()
         response = self.post({
             'name': "test group",
-            'document_permissions-0-collection': [root_collection.id],
-            'document_permissions-0-permissions': [self.add_doc_permission.id],
-            'document_permissions-1-collection': [root_collection.id],
-            'document_permissions-1-permissions': [self.change_doc_permission.id],
+            'document_permissions-0-collection': [root_collection.pk],
+            'document_permissions-0-permissions': [self.add_doc_permission.pk],
+            'document_permissions-1-collection': [root_collection.pk],
+            'document_permissions-1-permissions': [self.change_doc_permission.pk],
             'document_permissions-TOTAL_FORMS': ['2'],
         })
 
@@ -316,11 +316,11 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
     def setUp(self):
         # Create a group to edit
         self.test_group = Group.objects.create(name='test group')
-        self.root_page = Page.objects.get(id=1)
+        self.root_page = Page.objects.get(pk=1)
         self.root_add_permission = GroupPagePermission.objects.create(page=self.root_page,
                                                                       permission_type='add',
                                                                       group=self.test_group)
-        self.home_page = Page.objects.get(id=2)
+        self.home_page = Page.objects.get(pk=2)
 
         # Get the hook-registered permissions, and add one to this group
         self.registered_permissions = Permission.objects.none()
@@ -350,22 +350,22 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         self.login()
 
     def get(self, params={}, group_id=None):
-        return self.client.get(reverse('wagtailusers_groups:edit', args=(group_id or self.test_group.id, )), params)
+        return self.client.get(reverse('wagtailusers_groups:edit', args=(group_id or self.test_group.pk, )), params)
 
     def post(self, post_data={}, group_id=None):
         post_defaults = {
             'name': 'test group',
-            'permissions': [self.existing_permission.id],
+            'permissions': [self.existing_permission.pk],
             'page_permissions-TOTAL_FORMS': ['1'],
             'page_permissions-MAX_NUM_FORMS': ['1000'],
             'page_permissions-INITIAL_FORMS': ['1'],
-            'page_permissions-0-page': [self.root_page.id],
+            'page_permissions-0-page': [self.root_page.pk],
             'page_permissions-0-permission_types': ['add'],
             'document_permissions-TOTAL_FORMS': ['1'],
             'document_permissions-MAX_NUM_FORMS': ['1000'],
             'document_permissions-INITIAL_FORMS': ['1'],
-            'document_permissions-0-collection': [self.evil_plans_collection.id],
-            'document_permissions-0-permissions': [self.add_doc_permission.id],
+            'document_permissions-0-collection': [self.evil_plans_collection.pk],
+            'document_permissions-0-permissions': [self.add_doc_permission.pk],
             'image_permissions-TOTAL_FORMS': ['0'],
             'image_permissions-MAX_NUM_FORMS': ['1000'],
             'image_permissions-INITIAL_FORMS': ['0'],
@@ -373,7 +373,7 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         for k, v in six.iteritems(post_defaults):
             post_data[k] = post_data.get(k, v)
         return self.client.post(reverse(
-            'wagtailusers_groups:edit', args=(group_id or self.test_group.id, )), post_data)
+            'wagtailusers_groups:edit', args=(group_id or self.test_group.pk, )), post_data)
 
     def add_non_registered_perm(self):
         # Some groups may have django permissions assigned that are not
@@ -381,7 +381,7 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         # that these permissions are not overwritten by our views.
         # Tests that use this method are testing the aforementioned
         # functionality.
-        self.non_registered_perms = Permission.objects.exclude(id__in=self.registered_permissions)
+        self.non_registered_perms = Permission.objects.exclude(pk__in=self.registered_permissions)
         self.non_registered_perm = self.non_registered_perms[0]
         self.test_group.permissions.add(self.non_registered_perm)
 
@@ -400,7 +400,7 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         self.assertRedirects(response, reverse('wagtailusers_groups:index'))
 
         # Check that the group was edited
-        group = Group.objects.get(id=self.test_group.id)
+        group = Group.objects.get(pk=self.test_group.pk)
         self.assertEqual(group.name, 'test group edited')
 
     def test_group_edit_validation_error(self):
@@ -434,7 +434,7 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         )
         response = self.post({
             'document_permissions-0-permissions': [
-                self.add_doc_permission.id, self.change_doc_permission.id
+                self.add_doc_permission.pk, self.change_doc_permission.pk
             ],
         })
 
@@ -459,9 +459,9 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         )
         response = self.post({
             'document_permissions-TOTAL_FORMS': ['2'],
-            'document_permissions-1-collection': [self.root_collection.id],
+            'document_permissions-1-collection': [self.root_collection.pk],
             'document_permissions-1-permissions': [
-                self.add_doc_permission.id, self.change_doc_permission.id
+                self.add_doc_permission.pk, self.change_doc_permission.pk
             ],
         })
 
@@ -521,7 +521,7 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         )
         self.assertEqual(
             page_permissions_formset.forms[0]['page'].value(),
-            self.root_page.id
+            self.root_page.pk
         )
         self.assertEqual(
             page_permissions_formset.forms[0]['permission_types'].value(),
@@ -543,7 +543,7 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         self.assertEqual(len(page_permissions_formset.forms), 1)
         self.assertEqual(
             page_permissions_formset.forms[0]['page'].value(),
-            self.root_page.id
+            self.root_page.pk
         )
         self.assertEqual(
             page_permissions_formset.forms[0]['permission_types'].value(),
@@ -564,7 +564,7 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         self.assertEqual(page_permissions_formset.management_form['INITIAL_FORMS'].value(), 2)
         self.assertEqual(
             page_permissions_formset.forms[0]['page'].value(),
-            self.root_page.id
+            self.root_page.pk
         )
         self.assertEqual(
             page_permissions_formset.forms[0]['permission_types'].value(),
@@ -572,7 +572,7 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         )
         self.assertEqual(
             page_permissions_formset.forms[1]['page'].value(),
-            self.home_page.id
+            self.home_page.pk
         )
         self.assertEqual(
             page_permissions_formset.forms[1]['permission_types'].value(),
@@ -582,7 +582,7 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
     def test_duplicate_page_permissions_error(self):
         # Try to submit multiple page permission entries for the same page
         response = self.post({
-            'page_permissions-1-page': [self.root_page.id],
+            'page_permissions-1-page': [self.root_page.pk],
             'page_permissions-1-permission_types': ['edit'],
             'page_permissions-TOTAL_FORMS': ['2'],
         })
@@ -594,7 +594,7 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
     def test_duplicate_document_permissions_error(self):
         # Try to submit multiple document permission entries for the same collection
         response = self.post({
-            'document_permissions-1-page': [self.evil_plans_collection.id],
+            'document_permissions-1-page': [self.evil_plans_collection.pk],
             'document_permissions-1-permissions': [self.change_doc_permission],
             'document_permissions-TOTAL_FORMS': ['2'],
         })
@@ -612,7 +612,7 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         # The test group has one django permission to begin with
         self.assertEqual(self.test_group.permissions.count(), 1)
         response = self.post({
-            'permissions': [self.existing_permission.id, self.another_permission.id]
+            'permissions': [self.existing_permission.pk, self.another_permission.pk]
         })
         self.assertRedirects(response, reverse('wagtailusers_groups:index'))
         self.assertEqual(self.test_group.permissions.count(), 2)
@@ -626,7 +626,7 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         # See that the form is set up with the correct initial data
         self.assertEqual(
             response.context['form'].initial.get('permissions'),
-            list(original_permissions.values_list('id', flat=True))
+            list(original_permissions.values_list('pk', flat=True))
         )
 
     def test_group_retains_non_registered_permissions_when_editing(self):
@@ -645,7 +645,7 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         self.add_non_registered_perm()
         # Add a second registered permission
         self.post({
-            'permissions': [self.existing_permission.id, self.another_permission.id]
+            'permissions': [self.existing_permission.pk, self.another_permission.pk]
         })
 
         # See that there are now three permissions in total

--- a/wagtail/wagtailusers/views/users.py
+++ b/wagtail/wagtailusers/views/users.py
@@ -93,7 +93,7 @@ def create(request):
         if form.is_valid():
             user = form.save()
             messages.success(request, _("User '{0}' created.").format(user), buttons=[
-                messages.button(reverse('wagtailusers_users:edit', args=(user.id,)), _('Edit'))
+                messages.button(reverse('wagtailusers_users:edit', args=(user.pk,)), _('Edit'))
             ])
             return redirect('wagtailusers_users:index')
         else:
@@ -108,13 +108,13 @@ def create(request):
 
 @permission_required(change_user_perm)
 def edit(request, user_id):
-    user = get_object_or_404(User, id=user_id)
+    user = get_object_or_404(User, pk=user_id)
     if request.POST:
         form = UserEditForm(request.POST, instance=user)
         if form.is_valid():
             user = form.save()
             messages.success(request, _("User '{0}' updated.").format(user), buttons=[
-                messages.button(reverse('wagtailusers_users:edit', args=(user.id,)), _('Edit'))
+                messages.button(reverse('wagtailusers_users:edit', args=(user.pk,)), _('Edit'))
             ])
             return redirect('wagtailusers_users:index')
         else:


### PR DESCRIPTION
Ref #2347

Some usages of "id" were replaced with "pk", but probably it's not enough to support custom user model.

I checked following:
- [x] Files with get_user_model
- [x] Files with request.user.id
- [x] Files with user.id

Any suggestions?