### PR TITLE
Removed arrow-up after selector issue #2365

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables-icons.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables-icons.scss
@@ -76,7 +76,6 @@ $icons: (
 );
 
 $icons-after: (
-    'arrow-up': 'e',
     'arrow-down-after': 'q',
     'arrow-right-after': 'n'
 );


### PR DESCRIPTION
The icon arrow-up was placed with a :after selector. While viewing the style guide icon overview, it was obvious the icon was placed twice because of the :after selector.