### PR TITLE
Improve userbar styles

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/userbar.scss
@@ -101,7 +101,9 @@ $positions: (
 }
 
     .#{$namespace}-userbar-trigger {
-        display: block;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         width: $size-home-button;
         height: $size-home-button;
         margin: 0 !important;
@@ -115,17 +117,24 @@ $positions: (
         transition: all 0.2s ease-in-out;
         font-size: 16px;
         text-decoration: none !important;
+        position: relative;
 
         .#{$namespace}-userbar.touch.is-active &,
         .#{$namespace}-userbar.no-touch &:hover {
             box-shadow: $box-shadow-props, 0 3px 15px 0 rgba(107, 214, 230, .95);
         }
 
+        .#{$namespace}-userbar-help-text {
+            position: absolute;
+            top: 100%;
+            left: 0;
+        }
+
         &.#{$namespace}-icon:before {
             transition: color .2s ease;
             font-size: 32px;
-            margin: .4em .15em .4em .375em;
-            display: block;
+            width: auto;
+            margin: 0;
         }
     }
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/userbar/base.html
@@ -4,7 +4,9 @@
     <div class="wagtail-userbar wagtail-userbar--{{ position|default:'bottom-right' }}" data-wagtail-userbar>
         <link rel="stylesheet" href="{% static 'wagtailadmin/css/userbar.css' %}" type="text/css" />
         <div class="wagtail-userbar-nav">
-            <div class="wagtail-icon wagtail-icon-wagtail wagtail-userbar-trigger" data-wagtail-userbar-trigger>{% trans 'Go to Wagtail admin interface' %}</div>
+            <div class="wagtail-icon wagtail-icon-wagtail wagtail-userbar-trigger" data-wagtail-userbar-trigger>
+                <span class="wagtail-userbar-help-text">{% trans 'Go to Wagtail admin interface' %}</span>
+            </div>
             <div class='wagtail-userbar-items'>
                 {% for item in items %}
                     {{ item|safe }}


### PR DESCRIPTION
I was wanting to customize the userbar for my site and running into trouble with it. The way the CSS works currently is not ideal. Here's the way the icon is being centered:

![screenshot from 2016-03-18 19 51 53](https://cloud.githubusercontent.com/assets/3639540/13894894/466bf734-ed43-11e5-9dcb-693abdd0ef5b.png)

Since it uses a margin to center the bird, it's difficult to customize. You can't increase the icon's size or rotate it without manually adjusting the margin. Here's what happens when you increase the icon size:

![screenshot from 2016-03-18 19 52 43](https://cloud.githubusercontent.com/assets/3639540/13894897/52080448-ed43-11e5-92d4-59a38621dd03.png)

The bird goes out of the circle.

So I changed it to be like this instead:

![screenshot from 2016-03-18 19 53 29](https://cloud.githubusercontent.com/assets/3639540/13894916/8b53dee8-ed43-11e5-94c7-06ab8df6bc0d.png)

It uses flexbox, which is [widely supported](http://caniuse.com/#feat=flexbox) now. I tested it in BrowserStack and it does indeed look pristine in IE11, and even IE10. It's not centered in IE9, but Microsoft has ended support for it and less than 1% of the world is using it.

This is my new code with the size increased:

![screenshot from 2016-03-18 19 53 53](https://cloud.githubusercontent.com/assets/3639540/13894934/ba54ab3c-ed43-11e5-92ee-3790652915eb.png)

Now instead of keeping track of the icon size, container size, _and_ margins, you just need to set the icon size and container size.

The other problem was this thing:

![screenshot from 2016-03-18 19 52 05](https://cloud.githubusercontent.com/assets/3639540/13895028/e6f7ec7a-ed44-11e5-9e4f-203f5fe6aaca.png)

Not having a class meant I couldn't target it. So I added one:

![screenshot from 2016-03-18 19 54 04](https://cloud.githubusercontent.com/assets/3639540/13895029/effb1324-ed44-11e5-926f-02f1191c851f.png)

Now it can be styled.

That's all. I'm not changing the look at all here; just updating the way the CSS works to make it a bit more extensible. At the very least I need that span. Without it I can't even apply these as custom styles on my own build. I'm forced to fork the userbar or resort to javascript if I want to change it.