### PR TITLE
Changed button class for saving settings

### DIFF
--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -32,7 +32,7 @@
 
         <footer>
             <ul>
-                <li class="actions">
+                <li class="actions dropdown dropup match-width">
                     <input type="submit" value="{% trans 'Save' %}" class="button" />
                 </li>
             </ul>


### PR DESCRIPTION
Changed the 'Save' button class in settings to be full width, making it easier to click, and also the same as the snippets save button.