### PR TITLE
Fixed syntax of jQuery selector

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -340,7 +340,7 @@ function initErrorDetection() {
 
     // now identify them on each tab
     for (var index in errorSections) {
-        $('.tab-nav a[href=#' + index + ']').addClass('errors').attr('data-count', errorSections[index]);
+        $('.tab-nav a[href="#' + index + '"]').addClass('errors').attr('data-count', errorSections[index]);
     }
 }
 


### PR DESCRIPTION
We recently updated to jQuery 2.x and this requires quotes around attribute values.

Fixes #2380
Fixes #2381