### PR TITLE
Fix DeprecationWarnings from Django 1.9

### DIFF
--- a/docs/releases/1.5.rst
+++ b/docs/releases/1.5.rst
@@ -57,3 +57,37 @@ Should be changed to:
         ]
 
 To ease the burden on third-party modules, adding tuples to ``Page.search_fields`` will still work. But this backwards-compatibility fix will be removed in Wagtail 1.7.
+
+Elasticsearch backend now defaults to verifying SSL certs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously, if you used the Elasticsearch backend, configured with the URLS property like:
+
+
+.. code-block:: python
+
+    WAGTAILSEARCH_BACKENDS = {
+        'default': {
+            'BACKEND': 'wagtail.wagtailsearch.backends.elasticsearch',
+            'URLS': ['https://example.com/'],
+        }
+    }
+
+Elasticsearch would not be configured to verify SSL certificates for HTTPS URLs. This has been changed so that SSL certificates are verified for HTTPS connections by default.
+
+If you need the old behaviour back, where SSL certificates are not verified for your HTTPS connection, you can configure the Elasticsearch backend with the ``HOSTS`` option, like so:
+
+.. code-block:: python
+
+    WAGTAILSEARCH_BACKENDS = {
+        'default': {
+            'BACKEND': 'wagtail.wagtailsearch.backends.elasticsearch',
+            'HOSTS': [{
+                'host': 'example.com'
+                'use_ssl': True,
+                'verify_certs': False,
+            }],
+        }
+    }
+
+See the `Elasticsearch-py documentation <http://elasticsearch-py.readthedocs.org/en/stable/#ssl-and-authentication>`_ for more configuration options.

--- a/runtests.py
+++ b/runtests.py
@@ -4,6 +4,7 @@ import sys
 import os
 import shutil
 import warnings
+import argparse
 
 from django.core.management import execute_from_command_line
 
@@ -11,22 +12,45 @@ from django.core.management import execute_from_command_line
 os.environ['DJANGO_SETTINGS_MODULE'] = 'wagtail.tests.settings'
 
 
+def make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--deprecation', choices=['all', 'pending', 'imminent', 'none'], default='pending')
+    parser.add_argument('--postgres', action='store_true')
+    parser.add_argument('--elasticsearch', action='store_true')
+    parser.add_argument('rest', nargs='*')
+    return parser
+
+
+def parse_args(args=None):
+    return make_parser().parse_args(args)
+
+
 def runtests():
-    # Don't ignore DeprecationWarnings
-    warnings.simplefilter('default', DeprecationWarning)
-    warnings.simplefilter('default', PendingDeprecationWarning)
+    args = parse_args()
 
-    args = sys.argv[1:]
+    only_wagtail = r'^wagtail(\.|$)'
+    if args.deprecation == 'all':
+        # Show all deprecation warnings from all packages
+        warnings.simplefilter('default', DeprecationWarning)
+        warnings.simplefilter('default', PendingDeprecationWarning)
+    elif args.deprecation == 'pending':
+        # Show all deprecation warnings from wagtail
+        warnings.filterwarnings('default', category=DeprecationWarning, module=only_wagtail)
+        warnings.filterwarnings('default', category=PendingDeprecationWarning, module=only_wagtail)
+    elif args.deprecation == 'imminent':
+        # Show only imminent deprecation warnings from wagtail
+        warnings.filterwarnings('default', category=DeprecationWarning, module=only_wagtail)
+    elif args.deprecation == 'none':
+        # Deprecation warnings are ignored by default
+        pass
 
-    if '--postgres' in args:
+    if args.postgres:
         os.environ['DATABASE_ENGINE'] = 'django.db.backends.postgresql_psycopg2'
-        args.remove('--postgres')
 
-    if '--elasticsearch' in args:
+    if args.elasticsearch:
         os.environ.setdefault('ELASTICSEARCH_URL', 'http://localhost:9200')
-        args.remove('--elasticsearch')
 
-    argv = sys.argv[:1] + ['test'] + args
+    argv = [sys.argv[0], 'test'] + args.rest
     try:
         execute_from_command_line(argv)
     finally:

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -8,7 +8,6 @@ from rest_framework import relations, serializers
 from rest_framework.fields import Field, SkipField
 from taggit.managers import _TaggableManager
 
-from wagtail.utils.compat import get_related_model
 from wagtail.wagtailcore import fields as wagtailcore_fields
 
 from .utils import get_full_url, pages_for_site
@@ -363,7 +362,7 @@ class PageSerializer(BaseSerializer):
         if relation_info.to_many:
             model = getattr(self.Meta, 'model')
             child_relations = {
-                child_relation.field.rel.related_name: get_related_model(child_relation)
+                child_relation.field.rel.related_name: child_relation.related_model
                 for child_relation in get_all_child_relations(model)
             }
 

--- a/wagtail/api/v2/tests/test_documents.py
+++ b/wagtail/api/v2/tests/test_documents.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 
 import mock

--- a/wagtail/api/v2/tests/test_images.py
+++ b/wagtail/api/v2/tests/test_images.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 
 import mock

--- a/wagtail/contrib/wagtailapi/tests/test_documents.py
+++ b/wagtail/contrib/wagtailapi/tests/test_documents.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 
 import mock

--- a/wagtail/contrib/wagtailapi/tests/test_images.py
+++ b/wagtail/contrib/wagtailapi/tests/test_images.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 
 import mock

--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -478,7 +478,7 @@ class BaseChooserPanel(BaseFieldPanel):
 
     def get_chosen_item(self):
         field = self.instance._meta.get_field(self.field_name)
-        related_model = field.related.model
+        related_model = field.rel.model
         try:
             return getattr(self.instance, self.field_name)
         except related_model.DoesNotExist:

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+import datetime
 
 import django
 import mock
@@ -33,6 +33,11 @@ def submittable_timestamp(timestamp):
     return str(timezone.localtime(timestamp)).split('.')[0]
 
 
+def local_datetime(*args):
+    dt = datetime.datetime(*args)
+    return timezone.make_aware(dt)
+
+
 class TestPageExplorer(TestCase, WagtailTestUtils):
     def setUp(self):
         # Find root page
@@ -50,7 +55,7 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
         self.old_page = StandardIndex(
             title="Old page",
             slug="old-page",
-            latest_revision_created_at=datetime(2010, 1, 1)
+            latest_revision_created_at=local_datetime(2010, 1, 1)
         )
         self.root_page.add_child(instance=self.old_page)
 
@@ -58,7 +63,7 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
             title="New page",
             slug="new-page",
             content="hello",
-            latest_revision_created_at=datetime(2016, 1, 1)
+            latest_revision_created_at=local_datetime(2016, 1, 1)
         )
         self.root_page.add_child(instance=self.new_page)
 
@@ -213,7 +218,7 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
             title="New event",
             location='the moon', audience='public',
             cost='free', date_from='2001-01-01',
-            latest_revision_created_at=datetime(2016, 1, 1)
+            latest_revision_created_at=local_datetime(2016, 1, 1)
         )
         self.root_page.add_child(instance=self.new_event)
 
@@ -498,8 +503,8 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         self.assertFalse(any(Page.find_problems()), 'treebeard found consistency problems')
 
     def test_create_simplepage_scheduled(self):
-        go_live_at = timezone.now() + timedelta(days=1)
-        expire_at = timezone.now() + timedelta(days=2)
+        go_live_at = timezone.now() + datetime.timedelta(days=1)
+        expire_at = timezone.now() + datetime.timedelta(days=2)
         post_data = {
             'title': "New page!",
             'content': "Some content",
@@ -529,8 +534,8 @@ class TestPageCreation(TestCase, WagtailTestUtils):
             'title': "New page!",
             'content': "Some content",
             'slug': 'hello-world',
-            'go_live_at': submittable_timestamp(timezone.now() + timedelta(days=2)),
-            'expire_at': submittable_timestamp(timezone.now() + timedelta(days=1)),
+            'go_live_at': submittable_timestamp(timezone.now() + datetime.timedelta(days=2)),
+            'expire_at': submittable_timestamp(timezone.now() + datetime.timedelta(days=1)),
         }
         response = self.client.post(
             reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)), post_data
@@ -547,7 +552,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
             'title': "New page!",
             'content': "Some content",
             'slug': 'hello-world',
-            'expire_at': submittable_timestamp(timezone.now() + timedelta(days=-1)),
+            'expire_at': submittable_timestamp(timezone.now() + datetime.timedelta(days=-1)),
         }
         response = self.client.post(
             reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)), post_data
@@ -597,8 +602,8 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         self.assertFalse(any(Page.find_problems()), 'treebeard found consistency problems')
 
     def test_create_simplepage_post_publish_scheduled(self):
-        go_live_at = timezone.now() + timedelta(days=1)
-        expire_at = timezone.now() + timedelta(days=2)
+        go_live_at = timezone.now() + datetime.timedelta(days=1)
+        expire_at = timezone.now() + datetime.timedelta(days=2)
         post_data = {
             'title': "New page!",
             'content': "Some content",
@@ -915,8 +920,8 @@ class TestPageEdit(TestCase, WagtailTestUtils):
     def test_edit_post_scheduled(self):
         # put go_live_at and expire_at several days away from the current date, to avoid
         # false matches in content_json__contains tests
-        go_live_at = timezone.now() + timedelta(days=10)
-        expire_at = timezone.now() + timedelta(days=20)
+        go_live_at = timezone.now() + datetime.timedelta(days=10)
+        expire_at = timezone.now() + datetime.timedelta(days=20)
         post_data = {
             'title': "I've been edited!",
             'content': "Some content",
@@ -952,8 +957,8 @@ class TestPageEdit(TestCase, WagtailTestUtils):
             'title': "I've been edited!",
             'content': "Some content",
             'slug': 'hello-world',
-            'go_live_at': submittable_timestamp(timezone.now() + timedelta(days=2)),
-            'expire_at': submittable_timestamp(timezone.now() + timedelta(days=1)),
+            'go_live_at': submittable_timestamp(timezone.now() + datetime.timedelta(days=2)),
+            'expire_at': submittable_timestamp(timezone.now() + datetime.timedelta(days=1)),
         }
         response = self.client.post(reverse('wagtailadmin_pages:edit', args=(self.child_page.id, )), post_data)
 
@@ -968,7 +973,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
             'title': "I've been edited!",
             'content': "Some content",
             'slug': 'hello-world',
-            'expire_at': submittable_timestamp(timezone.now() + timedelta(days=-1)),
+            'expire_at': submittable_timestamp(timezone.now() + datetime.timedelta(days=-1)),
         }
         response = self.client.post(reverse('wagtailadmin_pages:edit', args=(self.child_page.id, )), post_data)
 
@@ -1028,8 +1033,8 @@ class TestPageEdit(TestCase, WagtailTestUtils):
             break
 
     def test_edit_post_publish_scheduled(self):
-        go_live_at = timezone.now() + timedelta(days=1)
-        expire_at = timezone.now() + timedelta(days=2)
+        go_live_at = timezone.now() + datetime.timedelta(days=1)
+        expire_at = timezone.now() + datetime.timedelta(days=2)
         post_data = {
             'title': "I've been edited!",
             'content': "Some content",
@@ -1062,8 +1067,8 @@ class TestPageEdit(TestCase, WagtailTestUtils):
 
     def test_edit_post_publish_now_an_already_scheduled(self):
         # First let's publish a page with a go_live_at in the future
-        go_live_at = timezone.now() + timedelta(days=1)
-        expire_at = timezone.now() + timedelta(days=2)
+        go_live_at = timezone.now() + datetime.timedelta(days=1)
+        expire_at = timezone.now() + datetime.timedelta(days=2)
         post_data = {
             'title': "I've been edited!",
             'content': "Some content",
@@ -2800,7 +2805,7 @@ class TestRevisions(TestCase, WagtailTestUtils):
             "but the very next day you gave it away</p>"
         )
         self.last_christmas_revision = self.christmas_event.save_revision()
-        self.last_christmas_revision.created_at = '2013-12-25'
+        self.last_christmas_revision.created_at = local_datetime(2013, 12, 25)
         self.last_christmas_revision.save()
 
         self.christmas_event.title = "This Christmas"
@@ -2810,7 +2815,7 @@ class TestRevisions(TestCase, WagtailTestUtils):
             "I'll give it to someone special</p>"
         )
         self.this_christmas_revision = self.christmas_event.save_revision()
-        self.this_christmas_revision.created_at = '2014-12-25'
+        self.this_christmas_revision.created_at = local_datetime(2014, 12, 25)
         self.this_christmas_revision.save()
 
         self.login()

--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -19,10 +19,8 @@ def get_object_usage(obj):
     pages = Page.objects.none()
 
     # get all the relation objects for obj
-    relations = type(obj)._meta.get_all_related_objects(
-        include_hidden=True,
-        include_proxy_eq=True
-    )
+    relations = [f for f in type(obj)._meta.get_fields(include_hidden=True)
+                 if (f.one_to_many or f.one_to_one) and f.auto_created]
     for relation in relations:
         related_model = relation.related_model
 

--- a/wagtail/wagtailcore/management/commands/fixtree.py
+++ b/wagtail/wagtailcore/management/commands/fixtree.py
@@ -1,6 +1,5 @@
 import functools
 import operator
-from optparse import make_option
 
 from django.core.management.base import BaseCommand
 from django.db import models
@@ -12,13 +11,11 @@ from wagtail.wagtailcore.models import Page
 
 class Command(BaseCommand):
     help = "Checks for data integrity errors on the page tree, and fixes them where possible."
-    base_options = (
-        make_option(
+
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--noinput', action='store_false', dest='interactive', default=True,
-            help='If provided, any fixes requiring user interaction will be skipped.'
-        ),
-    )
-    option_list = BaseCommand.option_list + base_options
+            help='If provided, any fixes requiring user interaction will be skipped.')
 
     def numberlist_to_string(self, numberlist):
         # Converts a list of numbers into a string

--- a/wagtail/wagtailcore/management/commands/publish_scheduled_pages.py
+++ b/wagtail/wagtailcore/management/commands/publish_scheduled_pages.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import json
-from optparse import make_option
 
 from django.core.management.base import BaseCommand
 from django.utils import dateparse, timezone
@@ -21,15 +20,10 @@ def revision_date_expired(r):
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option(
-            '--dryrun',
-            action='store_true',
-            dest='dryrun',
-            default=False,
-            help='Dry run -- don\'t change anything.'
-        ),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dryrun', action='store_true', dest='dryrun', default=False,
+            help="Dry run -- dont't change anything.")
 
     def handle(self, *args, **options):
         dryrun = False

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import datetime
 import json
 

--- a/wagtail/wagtaildocs/views/multiple.py
+++ b/wagtail/wagtaildocs/views/multiple.py
@@ -1,11 +1,11 @@
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, render
+from django.template.loader import render_to_string
 from django.utils.encoding import force_text
 from django.views.decorators.http import require_POST
 from django.views.decorators.vary import vary_on_headers
 
-from wagtail.utils.compat import render_to_string
 from wagtail.wagtailadmin.utils import PermissionPolicyChecker
 from wagtail.wagtailsearch.backends import get_search_backends
 

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -686,6 +686,7 @@ class ElasticSearch(BaseSearch):
                     'port': port,
                     'url_prefix': parsed_url.path,
                     'use_ssl': use_ssl,
+                    'verify_certs': use_ssl,
                     'http_auth': http_auth,
                 })
 

--- a/wagtail/wagtailsearch/management/commands/update_index.py
+++ b/wagtail/wagtailsearch/management/commands/update_index.py
@@ -1,5 +1,3 @@
-from optparse import make_option
-
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction
@@ -57,15 +55,10 @@ class Command(BaseCommand):
         self.stdout.write(backend_name + ": Finishing rebuild")
         rebuilder.finish()
 
-    option_list = BaseCommand.option_list + (
-        make_option(
-            '--backend',
-            action='store',
-            dest='backend_name',
-            default=None,
-            help="Specify a backend to update",
-        ),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--backend', action='store', dest='backend_name', default=None,
+            help="Specify a backend to update")
 
     def handle(self, **options):
         # Get object list

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -911,6 +911,7 @@ class TestBackendConfiguration(TestCase):
                     'host': '127.0.0.1',
                     'port': 9300,
                     'use_ssl': True,
+                    'verify_certs': True,
                 }
             ]
         })

--- a/wagtail/wagtailsnippets/edit_handlers.py
+++ b/wagtail/wagtailsnippets/edit_handlers.py
@@ -41,7 +41,7 @@ class BaseSnippetChooserPanel(BaseChooserPanel):
                         .format(cls.__name__, cls.snippet_type)
                     )
             else:
-                cls._target_model = cls.model._meta.get_field(cls.field_name).rel.to
+                cls._target_model = cls.model._meta.get_field(cls.field_name).rel.model
 
         return cls._target_model
 


### PR DESCRIPTION
The output of `./runtests.py` was so full of DeprecationWarnings, RuntimeWarnings, and so on that it was near useless. This PR aims to clean the output up some what.

The console output is full of deprecation warnings produced by Wagtail that need fixing. It is also full of deprecation warnings from third party packages such as django-taggit. I've made the test suite only print deprecation warnings produced by Wagtail by default, so the warnings are easier to deal with. There is a `--full-warnings` flag that can be passed to `./runtests.py` to enable all deprecation warnings again,  if we want to try and fix warnings in third party modules.

Wagtail was still using some of its own deprecated internal methods, despite having a documented alternative available. I've fixed these warnings as well.

There were two places still using `field.related` instead of `field.rel`, and `rel.to` over `rel.model`. These have been fixed. Django 1.9 renamed `field.rel` to `field.remote_model`, deprecating the old `field.rel`, so this will need to happen again in the future.

`Model._meta.get_fields()` should be used, instead of the old `Model._meta.get_all_related_objects()`. [Django has instructions on migrating this code](https://docs.djangoproject.com/en/1.9/ref/models/meta/#migrating-from-the-old-api).

All management commands now use argparse/`add_arguments()` over optparse/`options_list`.

Some tests used naive datetimes, which was causing needless RuntimeWarnings.

Elasticsearch was complaining about not verifying SSL certificates for HTTPS connections. This change is mildly backwards incompatible, as SSL certificates are now verified by default. People will have to change their configurations if they are using Elasticsearch over HTTPS, with an invalid SSL certificate, through the automatic URLS parameter. A release note has been added, with further discussion in the relevant commit.

Some tests were missing `from __future__ import unicode_literals`, which was causing a RuntimeWarning from unidecode via django-taggit. `unicode_literals` have been enabled in the relevant tests. I will create a different PR which adds `unicode_literals` to all files in the repo, as this is a larger and slightly unrelated change.

The end result of all this is that the output of `./runtests.py` on Django 1.8 is now free of warnings!