### PR TITLE
Updated to include TEMPLATE requirement for Django 1.9+

### DIFF
--- a/docs/advanced_topics/customisation/branding.rst
+++ b/docs/advanced_topics/customisation/branding.rst
@@ -18,6 +18,21 @@ Install ``django-overextends`` with ``pip install django-overextends`` (or add `
       
       # ...
     )
+    
+    #For Django 1.9+ you must also add overextends to the builtins key of your TEMPLATES setting:
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'APP_DIRS': True,
+            'OPTIONS': {
+                # ...
+                'builtins': ['overextends.templatetags.overextends_tags'],
+            }
+        },
+]
+
+
+
 
 The template blocks that are available to be overridden are as follows:
 

--- a/docs/advanced_topics/customisation/branding.rst
+++ b/docs/advanced_topics/customisation/branding.rst
@@ -29,7 +29,7 @@ Install ``django-overextends`` with ``pip install django-overextends`` (or add `
                 'builtins': ['overextends.templatetags.overextends_tags'],
             }
         },
-]
+    ]
 
 
 

--- a/docs/advanced_topics/customisation/branding.rst
+++ b/docs/advanced_topics/customisation/branding.rst
@@ -19,7 +19,7 @@ Install ``django-overextends`` with ``pip install django-overextends`` (or add `
       # ...
     )
     
-    #For Django 1.9+ you must also add overextends to the builtins key of your TEMPLATES setting:
+    # For Django 1.9+ you must also add overextends to the builtins key of your TEMPLATES setting:
     TEMPLATES = [
         {
             'BACKEND': 'django.template.backends.django.DjangoTemplates',


### PR DESCRIPTION
In Django 1.9+ if you do not add: 'builtins': ['overextends.templatetags.overextends_tags'], to your TEMPLATES section you will receive a TemplateSyntaxError when the overextends template files are rendered: "Invalid block tag on line".  Including 'builtins': ['overextends.templatetags.overextends_tags'], per the overextends docs (and experience) resolves this error.

https://github.com/stephenmcd/django-overextends