### PR TITLE
Define explorer menu media with property instead of class

### DIFF
--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -1,8 +1,8 @@
+from django import forms
 from django.contrib.auth.models import Permission
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
-from django import forms
 
 from wagtail.wagtailadmin.menu import MenuItem, SubmenuMenuItem, settings_menu
 from wagtail.wagtailadmin.search import SearchArea

--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import Permission
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
+from django import forms
 
 from wagtail.wagtailadmin.menu import MenuItem, SubmenuMenuItem, settings_menu
 from wagtail.wagtailadmin.search import SearchArea
@@ -11,8 +12,9 @@ from wagtail.wagtailcore.permissions import collection_permission_policy
 
 
 class ExplorerMenuItem(MenuItem):
-    class Media:
-        js = [static('wagtailadmin/js/explorer-menu.js')]
+    @property
+    def media(self):
+        return forms.Media(js=[static('wagtailadmin/js/explorer-menu.js')])
 
 
 @hooks.register('register_admin_menu_item')


### PR DESCRIPTION
Fixes #2369

The static() function was being called during app load which caused a crash when the user is using STATICFILES_STORAGE=ManifestStaticFilesStorage, DEBUG=False and haven't yet collected static files.

I've moved it into a property and it's now only called when a view is being rendered.

I haven't yet come up with a reliable way to test this. I don't think it's worth holding this fix for that though.