### PR TITLE
Add revisions button to page list

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changelog
  * Fix: Streamfields no longer break on validation error
  * Fix: Number of validation errors in each tab in the editor is now correctly reported again
  * Fix: Userbar now opens on devices with both touch and mouse (Josh Barr)
+ * Added revisions button to pages list. (Roel Bruggink)
 
 
 1.4.1 (17.03.2016)

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -38,4 +38,6 @@
     {% if page_perms.can_add_subpage and 'add_subpage' not in hide_actions|default:'' %}
         <li><a href="{% url 'wagtailadmin_pages:add_subpage' page.id %}" class="button button-small button-secondary">{% trans 'Add child page' %}</a></li>
     {% endif %}
+
+    <li><a href="{% url 'wagtailadmin_pages:revisions_index' page.id %}" class="button button-small button-secondary">{% trans 'Revisions' %}</a></li>
 </ul>


### PR DESCRIPTION
This skips editing the page to get to the revisions.