### PR TITLE
Import absolute_import, unicode_literals in all files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,5 @@ universal = 1
 [isort]
 line_length=100
 multi_line_output=4
+skip=migrations
+add_imports=from __future__ import absolute_import,from __future__ import unicode_literals

--- a/wagtail/api/apps.py
+++ b/wagtail/api/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig, apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured

--- a/wagtail/api/v2/endpoints.py
+++ b/wagtail/api/v2/endpoints.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from collections import OrderedDict
 

--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf import settings
 from rest_framework.filters import BaseFilterBackend
 from taggit.managers import _TaggableManager

--- a/wagtail/api/v2/pagination.py
+++ b/wagtail/api/v2/pagination.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from collections import OrderedDict
 
 from django.conf import settings

--- a/wagtail/api/v2/router.py
+++ b/wagtail/api/v2/router.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import functools
 
 from django.conf.urls import include, url

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -393,7 +393,7 @@ def get_serializer_class(model_, fields_, meta_fields=None, base=BaseSerializer)
         model = model_
         fields = base.default_fields + list(fields_)
 
-    return type(model_.__name__ + 'Serializer', (base, ), {
+    return type(str(model_.__name__ + 'Serializer'), (base, ), {
         'Meta': Meta,
         'meta_fields': base.meta_fields + list(meta_fields or []),
     })

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from collections import OrderedDict
 

--- a/wagtail/api/v2/signal_handlers.py
+++ b/wagtail/api/v2/signal_handlers.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.urlresolvers import reverse
 from django.db.models.signals import post_delete, post_save
 

--- a/wagtail/api/v2/tests/test_documents.py
+++ b/wagtail/api/v2/tests/test_documents.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import json
 

--- a/wagtail/api/v2/tests/test_images.py
+++ b/wagtail/api/v2/tests/test_images.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import json
 

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import collections
 import json
 

--- a/wagtail/api/v2/urls.py
+++ b/wagtail/api/v2/urls.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import url
 

--- a/wagtail/api/v2/utils.py
+++ b/wagtail/api/v2/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf import settings
 from django.utils.six.moves.urllib.parse import urlparse
 

--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 from optparse import OptionParser

--- a/wagtail/contrib/settings/apps.py
+++ b/wagtail/contrib/settings/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/contrib/settings/context_processors.py
+++ b/wagtail/contrib/settings/context_processors.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.utils.encoding import python_2_unicode_compatible
 
 from .registry import registry

--- a/wagtail/contrib/settings/models.py
+++ b/wagtail/contrib/settings/models.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.db import models
 
 from .registry import register_setting

--- a/wagtail/contrib/settings/permissions.py
+++ b/wagtail/contrib/settings/permissions.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import, unicode_literals
+
+
 def user_can_edit_setting_type(user, model):
     """ Check if a user has permission to edit this setting type """
     return user.has_perm("{}.change_{}".format(

--- a/wagtail/contrib/settings/registry.py
+++ b/wagtail/contrib/settings/registry.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import apps
 from django.contrib.auth.models import Permission
 from django.core.urlresolvers import reverse

--- a/wagtail/contrib/settings/templatetags/wagtailsettings_tags.py
+++ b/wagtail/contrib/settings/templatetags/wagtailsettings_tags.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.template import Library
 
 from wagtail.wagtailcore.models import Site

--- a/wagtail/contrib/settings/tests/test_register.py
+++ b/wagtail/contrib/settings/tests/test_register.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 

--- a/wagtail/contrib/settings/tests/test_templates.py
+++ b/wagtail/contrib/settings/tests/test_templates.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.template import Context, RequestContext, Template
 from django.test import TestCase
 

--- a/wagtail/contrib/settings/urls.py
+++ b/wagtail/contrib/settings/urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from . import views

--- a/wagtail/contrib/settings/views.py
+++ b/wagtail/contrib/settings/views.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render

--- a/wagtail/contrib/settings/wagtail_hooks.py
+++ b/wagtail/contrib/settings/wagtail_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import include, url
 
 from wagtail.wagtailcore import hooks

--- a/wagtail/contrib/wagtailapi/apps.py
+++ b/wagtail/contrib/wagtailapi/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig, apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured

--- a/wagtail/contrib/wagtailapi/endpoints.py
+++ b/wagtail/contrib/wagtailapi/endpoints.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from collections import OrderedDict
 

--- a/wagtail/contrib/wagtailapi/filters.py
+++ b/wagtail/contrib/wagtailapi/filters.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf import settings
 from rest_framework.filters import BaseFilterBackend
 from taggit.managers import _TaggableManager

--- a/wagtail/contrib/wagtailapi/pagination.py
+++ b/wagtail/contrib/wagtailapi/pagination.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from collections import OrderedDict
 
 from django.conf import settings

--- a/wagtail/contrib/wagtailapi/router.py
+++ b/wagtail/contrib/wagtailapi/router.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import functools
 
 from django.conf.urls import include, url

--- a/wagtail/contrib/wagtailapi/serializers.py
+++ b/wagtail/contrib/wagtailapi/serializers.py
@@ -284,6 +284,6 @@ def get_serializer_class(model_, fields_, base=BaseSerializer):
         model = model_
         fields = fields_
 
-    return type(model_.__name__ + 'Serializer', (base, ), {
+    return type(str(model_.__name__ + 'Serializer'), (base, ), {
         'Meta': Meta
     })

--- a/wagtail/contrib/wagtailapi/serializers.py
+++ b/wagtail/contrib/wagtailapi/serializers.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from collections import OrderedDict
 

--- a/wagtail/contrib/wagtailapi/signal_handlers.py
+++ b/wagtail/contrib/wagtailapi/signal_handlers.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.urlresolvers import reverse
 from django.db.models.signals import post_delete, post_save
 

--- a/wagtail/contrib/wagtailapi/tests/test_documents.py
+++ b/wagtail/contrib/wagtailapi/tests/test_documents.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import json
 

--- a/wagtail/contrib/wagtailapi/tests/test_images.py
+++ b/wagtail/contrib/wagtailapi/tests/test_images.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import json
 

--- a/wagtail/contrib/wagtailapi/tests/test_pages.py
+++ b/wagtail/contrib/wagtailapi/tests/test_pages.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import collections
 import json
 

--- a/wagtail/contrib/wagtailapi/urls.py
+++ b/wagtail/contrib/wagtailapi/urls.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import url
 

--- a/wagtail/contrib/wagtailapi/utils.py
+++ b/wagtail/contrib/wagtailapi/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf import settings
 from django.utils.six.moves.urllib.parse import urlparse
 

--- a/wagtail/contrib/wagtailfrontendcache/apps.py
+++ b/wagtail/contrib/wagtailfrontendcache/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 from wagtail.contrib.wagtailfrontendcache.signal_handlers import register_signal_handlers

--- a/wagtail/contrib/wagtailfrontendcache/backends.py
+++ b/wagtail/contrib/wagtailfrontendcache/backends.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import json
 import logging
 

--- a/wagtail/contrib/wagtailfrontendcache/signal_handlers.py
+++ b/wagtail/contrib/wagtailfrontendcache/signal_handlers.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import apps
 
 from wagtail.contrib.wagtailfrontendcache.utils import purge_page_from_cache

--- a/wagtail/contrib/wagtailfrontendcache/tests.py
+++ b/wagtail/contrib/wagtailfrontendcache/tests.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.test import TestCase
 from django.test.utils import override_settings
 

--- a/wagtail/contrib/wagtailfrontendcache/utils.py
+++ b/wagtail/contrib/wagtailfrontendcache/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import logging
 
 from django.conf import settings

--- a/wagtail/contrib/wagtailmedusa/apps.py
+++ b/wagtail/contrib/wagtailmedusa/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/contrib/wagtailmedusa/renderers.py
+++ b/wagtail/contrib/wagtailmedusa/renderers.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django_medusa.renderers import StaticSiteRenderer
 from wagtail.wagtailcore.models import Site
 from wagtail.wagtaildocs.models import Document

--- a/wagtail/contrib/wagtailroutablepage/apps.py
+++ b/wagtail/contrib/wagtailroutablepage/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/contrib/wagtailroutablepage/models.py
+++ b/wagtail/contrib/wagtailroutablepage/models.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import url
 from django.core.urlresolvers import RegexURLResolver

--- a/wagtail/contrib/wagtailroutablepage/templatetags/wagtailroutablepage_tags.py
+++ b/wagtail/contrib/wagtailroutablepage/templatetags/wagtailroutablepage_tags.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import template
 
 register = template.Library()

--- a/wagtail/contrib/wagtailroutablepage/tests.py
+++ b/wagtail/contrib/wagtailroutablepage/tests.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.urlresolvers import NoReverseMatch
 from django.test import RequestFactory, TestCase
 

--- a/wagtail/contrib/wagtailsearchpromotions/admin_urls.py
+++ b/wagtail/contrib/wagtailsearchpromotions/admin_urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.contrib.wagtailsearchpromotions import views

--- a/wagtail/contrib/wagtailsearchpromotions/apps.py
+++ b/wagtail/contrib/wagtailsearchpromotions/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/contrib/wagtailsearchpromotions/forms.py
+++ b/wagtail/contrib/wagtailsearchpromotions/forms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import forms
 from django.forms.models import inlineformset_factory
 from django.utils.translation import ugettext_lazy as _

--- a/wagtail/contrib/wagtailsearchpromotions/models.py
+++ b/wagtail/contrib/wagtailsearchpromotions/models.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 

--- a/wagtail/contrib/wagtailsearchpromotions/templatetags/wagtailsearchpromotions_tags.py
+++ b/wagtail/contrib/wagtailsearchpromotions/templatetags/wagtailsearchpromotions_tags.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import template
 
 from wagtail.contrib.wagtailsearchpromotions.models import SearchPromotion

--- a/wagtail/contrib/wagtailsearchpromotions/tests.py
+++ b/wagtail/contrib/wagtailsearchpromotions/tests.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 

--- a/wagtail/contrib/wagtailsearchpromotions/views.py
+++ b/wagtail/contrib/wagtailsearchpromotions/views.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import ugettext as _

--- a/wagtail/contrib/wagtailsearchpromotions/wagtail_hooks.py
+++ b/wagtail/contrib/wagtailsearchpromotions/wagtail_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import include, url
 from django.contrib.auth.models import Permission
 from django.core import urlresolvers

--- a/wagtail/contrib/wagtailsitemaps/apps.py
+++ b/wagtail/contrib/wagtailsitemaps/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/contrib/wagtailsitemaps/sitemap_generator.py
+++ b/wagtail/contrib/wagtailsitemaps/sitemap_generator.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.template.loader import render_to_string
 
 

--- a/wagtail/contrib/wagtailsitemaps/tests.py
+++ b/wagtail/contrib/wagtailsitemaps/tests.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.cache import cache
 from django.test import TestCase
 

--- a/wagtail/contrib/wagtailsitemaps/views.py
+++ b/wagtail/contrib/wagtailsitemaps/views.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf import settings
 from django.core.cache import cache
 from django.http import HttpResponse

--- a/wagtail/contrib/wagtailstyleguide/apps.py
+++ b/wagtail/contrib/wagtailstyleguide/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/contrib/wagtailstyleguide/tests.py
+++ b/wagtail/contrib/wagtailstyleguide/tests.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 

--- a/wagtail/contrib/wagtailstyleguide/views.py
+++ b/wagtail/contrib/wagtailstyleguide/views.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import forms
 from django.core.paginator import Paginator
 from django.shortcuts import render

--- a/wagtail/contrib/wagtailstyleguide/wagtail_hooks.py
+++ b/wagtail/contrib/wagtailstyleguide/wagtail_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 from django.core import urlresolvers
 from django.utils.translation import ugettext_lazy as _

--- a/wagtail/project_template/home/models.py
+++ b/wagtail/project_template/home/models.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.db import models
 

--- a/wagtail/project_template/manage.py
+++ b/wagtail/project_template/manage.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import absolute_import, unicode_literals
+
 import os
 import sys
 

--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -10,6 +10,8 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/
 """
 
+from __future__ import absolute_import, unicode_literals
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 

--- a/wagtail/project_template/project_name/settings/dev.py
+++ b/wagtail/project_template/project_name/settings/dev.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from .base import *
 
 # SECURITY WARNING: don't run with debug turned on in production!

--- a/wagtail/project_template/project_name/settings/production.py
+++ b/wagtail/project_template/project_name/settings/production.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from .base import *
 
 DEBUG = False

--- a/wagtail/project_template/project_name/urls.py
+++ b/wagtail/project_template/project_name/urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin

--- a/wagtail/project_template/project_name/wsgi.py
+++ b/wagtail/project_template/project_name/wsgi.py
@@ -7,6 +7,8 @@ For more information on this file, see
 https://docs.djangoproject.com/en/{{ docs_version }}/howto/deployment/wsgi/
 """
 
+from __future__ import absolute_import, unicode_literals
+
 import os
 
 from django.core.wsgi import get_wsgi_application

--- a/wagtail/project_template/search/views.py
+++ b/wagtail/project_template/search/views.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.shortcuts import render
 

--- a/wagtail/tests/context_processors.py
+++ b/wagtail/tests/context_processors.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import, unicode_literals
+
+
 def do_not_use_static_url(request):
     def exception():
         raise Exception("Do not use STATIC_URL in templates. Use the {% static %} templatetag instead.")

--- a/wagtail/tests/customuser/models.py
+++ b/wagtail/tests/customuser/models.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import sys
 
 from django.contrib.auth.models import (

--- a/wagtail/tests/demosite/models.py
+++ b/wagtail/tests/demosite/models.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from datetime import date
 
 from django.db import models

--- a/wagtail/tests/dummy_external_storage.py
+++ b/wagtail/tests/dummy_external_storage.py
@@ -5,6 +5,8 @@
 #  - Calling .path on the storage or image file raises NotImplementedError
 #  - File.open() after the file has been closed raises an error
 
+from __future__ import absolute_import, unicode_literals
+
 from django.core.files.base import File
 from django.core.files.storage import FileSystemStorage, Storage
 from django.utils.deconstruct import deconstructible

--- a/wagtail/tests/non_root_urls.py
+++ b/wagtail/tests/non_root_urls.py
@@ -1,6 +1,8 @@
 """An alternative urlconf module where Wagtail front-end URLs
 are rooted at '/site/' rather than '/'"""
 
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import include, url
 
 from wagtail.wagtailadmin import urls as wagtailadmin_urls

--- a/wagtail/tests/routablepage/apps.py
+++ b/wagtail/tests/routablepage/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/tests/routablepage/models.py
+++ b/wagtail/tests/routablepage/models.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.http import HttpResponse
 
 from wagtail.contrib.wagtailroutablepage.models import RoutablePage, route

--- a/wagtail/tests/search/apps.py
+++ b/wagtail/tests/search/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/tests/search/models.py
+++ b/wagtail/tests/search/models.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.db import models
 from taggit.managers import TaggableManager
 

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import os
 
 WAGTAIL_ROOT = os.path.dirname(__file__)

--- a/wagtail/tests/snippets/apps.py
+++ b/wagtail/tests/snippets/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/tests/snippets/forms.py
+++ b/wagtail/tests/snippets/forms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from wagtail.wagtailadmin.forms import WagtailAdminModelForm
 
 

--- a/wagtail/tests/snippets/models.py
+++ b/wagtail/tests/snippets/models.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 

--- a/wagtail/tests/test_utils.py
+++ b/wagtail/tests/test_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import warnings
 

--- a/wagtail/tests/testapp/apps.py
+++ b/wagtail/tests/testapp/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/tests/testapp/blocks.py
+++ b/wagtail/tests/testapp/blocks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from wagtail.wagtailcore import blocks
 
 

--- a/wagtail/tests/testapp/forms.py
+++ b/wagtail/tests/testapp/forms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import forms
 
 from wagtail.wagtailadmin.forms import WagtailAdminPageForm

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import hashlib
 import os

--- a/wagtail/tests/testapp/urls.py
+++ b/wagtail/tests/testapp/urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.tests.testapp.views import bob_only_zone

--- a/wagtail/tests/testapp/views.py
+++ b/wagtail/tests/testapp/views.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.http import HttpResponse
 
 from wagtail.wagtailadmin.utils import user_passes_test

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.http import HttpResponse
 
 from wagtail.wagtailadmin.menu import MenuItem

--- a/wagtail/tests/urls.py
+++ b/wagtail/tests/urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import include, url
 
 from wagtail.api.v2 import urls as wagtailapi2_urls

--- a/wagtail/utils/apps.py
+++ b/wagtail/utils/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from importlib import import_module
 
 from django.apps import apps

--- a/wagtail/utils/compat.py
+++ b/wagtail/utils/compat.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import warnings
 
 from django.template import loader

--- a/wagtail/utils/deprecation.py
+++ b/wagtail/utils/deprecation.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import warnings
 
 

--- a/wagtail/utils/pagination.py
+++ b/wagtail/utils/pagination.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 
 DEFAULT_PAGE_KEY = 'p'

--- a/wagtail/utils/sendfile.py
+++ b/wagtail/utils/sendfile.py
@@ -1,6 +1,8 @@
 # Copied from django-sendfile 0.3.6 and tweaked to allow a backend to be passed
 # to sendfile()
 # See: https://github.com/johnsensible/django-sendfile/pull/33
+from __future__ import absolute_import, unicode_literals
+
 import os.path
 from mimetypes import guess_type
 

--- a/wagtail/utils/sendfile_streaming_backend.py
+++ b/wagtail/utils/sendfile_streaming_backend.py
@@ -1,6 +1,8 @@
 # Sendfile "streaming" backend
 # This is based on sendfiles builtin "simple" backend but uses a StreamingHttpResponse
 
+from __future__ import absolute_import, unicode_literals
+
 import os
 import re
 import stat

--- a/wagtail/utils/urlpatterns.py
+++ b/wagtail/utils/urlpatterns.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import, unicode_literals
+
+
 def decorate_urlpatterns(urlpatterns, decorator):
     for pattern in urlpatterns:
         if hasattr(pattern, 'url_patterns'):

--- a/wagtail/wagtailadmin/apps.py
+++ b/wagtail/wagtailadmin/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 from . import checks  # NOQA

--- a/wagtail/wagtailadmin/blocks.py
+++ b/wagtail/wagtailadmin/blocks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import warnings
 
 from wagtail.wagtailcore.blocks import *  # noqa

--- a/wagtail/wagtailadmin/checks.py
+++ b/wagtail/wagtailadmin/checks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import os
 
 from django.core.checks import Warning, register

--- a/wagtail/wagtailadmin/decorators.py
+++ b/wagtail/wagtailadmin/decorators.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib.auth.views import redirect_to_login as auth_redirect_to_login
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _

--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import django
 from django import forms

--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import copy
 from itertools import groupby

--- a/wagtail/wagtailadmin/jinja2tags.py
+++ b/wagtail/wagtailadmin/jinja2tags.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import jinja2
 from jinja2.ext import Extension

--- a/wagtail/wagtailadmin/menu.py
+++ b/wagtail/wagtailadmin/menu.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.forms import Media, MediaDefiningClass

--- a/wagtail/wagtailadmin/messages.py
+++ b/wagtail/wagtailadmin/messages.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib import messages
 from django.template.loader import render_to_string
 

--- a/wagtail/wagtailadmin/modal_workflow.py
+++ b/wagtail/wagtailadmin/modal_workflow.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import json
 
 from django.http import HttpResponse

--- a/wagtail/wagtailadmin/models.py
+++ b/wagtail/wagtailadmin/models.py
@@ -1,3 +1,3 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 # Create your models here.

--- a/wagtail/wagtailadmin/search.py
+++ b/wagtail/wagtailadmin/search.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.forms import Media, MediaDefiningClass
 from django.forms.utils import flatatt

--- a/wagtail/wagtailadmin/signals.py
+++ b/wagtail/wagtailadmin/signals.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.dispatch import Signal
 
 init_new_page = Signal(providing_args=['page', 'parent'])

--- a/wagtail/wagtailadmin/site_summary.py
+++ b/wagtail/wagtailadmin/site_summary.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.template.loader import render_to_string
 
 from wagtail.wagtailcore import hooks

--- a/wagtail/wagtailadmin/taggable.py
+++ b/wagtail/wagtailadmin/taggable.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count
 from taggit.models import Tag

--- a/wagtail/wagtailadmin/templatetags/gravatar.py
+++ b/wagtail/wagtailadmin/templatetags/gravatar.py
@@ -7,6 +7,8 @@
 # <img src="{% gravatar_url sometemplatevariable %}">
 # just make sure to update the "default" image path below
 
+from __future__ import absolute_import, unicode_literals
+
 import hashlib
 
 from django import template

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import itertools
 

--- a/wagtail/wagtailadmin/templatetags/wagtailuserbar.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailuserbar.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import template
 from django.template.loader import render_to_string
 

--- a/wagtail/wagtailadmin/tests/test_account_management.py
+++ b/wagtail/wagtailadmin/tests/test_account_management.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission

--- a/wagtail/wagtailadmin/tests/test_buttons_hooks.py
+++ b/wagtail/wagtailadmin/tests/test_buttons_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 

--- a/wagtail/wagtailadmin/tests/test_collections_views.py
+++ b/wagtail/wagtailadmin/tests/test_collections_views.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.core.urlresolvers import reverse
 from django.test import TestCase

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from datetime import date
 
 import mock

--- a/wagtail/wagtailadmin/tests/test_page_chooser.py
+++ b/wagtail/wagtailadmin/tests/test_page_chooser.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import datetime
 
 import django

--- a/wagtail/wagtailadmin/tests/test_password_reset.py
+++ b/wagtail/wagtailadmin/tests/test_password_reset.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core import mail
 from django.core.urlresolvers import reverse
 from django.test import TestCase, override_settings

--- a/wagtail/wagtailadmin/tests/test_privacy.py
+++ b/wagtail/wagtailadmin/tests/test_privacy.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 

--- a/wagtail/wagtailadmin/tests/test_userbar.py
+++ b/wagtail/wagtailadmin/tests/test_userbar.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.core.urlresolvers import reverse

--- a/wagtail/wagtailadmin/tests/test_widgets.py
+++ b/wagtail/wagtailadmin/tests/test_widgets.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 

--- a/wagtail/wagtailadmin/tests/tests.py
+++ b/wagtail/wagtailadmin/tests/tests.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import json
 

--- a/wagtail/wagtailadmin/urls/collections.py
+++ b/wagtail/wagtailadmin/urls/collections.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.wagtailadmin.views import collections

--- a/wagtail/wagtailadmin/urls/pages.py
+++ b/wagtail/wagtailadmin/urls/pages.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.wagtailadmin.views import page_privacy, pages

--- a/wagtail/wagtailadmin/urls/password_reset.py
+++ b/wagtail/wagtailadmin/urls/password_reset.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.wagtailadmin.forms import PasswordResetForm

--- a/wagtail/wagtailadmin/userbar.py
+++ b/wagtail/wagtailadmin/userbar.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.template.loader import render_to_string
 
 

--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from functools import wraps
 
 from django.conf import settings

--- a/wagtail/wagtailadmin/views/account.py
+++ b/wagtail/wagtailadmin/views/account.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from functools import wraps
 
 from django.conf import settings

--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.http import Http404
 from django.shortcuts import get_object_or_404, render
 

--- a/wagtail/wagtailadmin/views/collections.py
+++ b/wagtail/wagtailadmin/views/collections.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.translation import ugettext_lazy as __

--- a/wagtail/wagtailadmin/views/generic.py
+++ b/wagtail/wagtailadmin/views/generic.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import ugettext as _

--- a/wagtail/wagtailadmin/views/home.py
+++ b/wagtail/wagtailadmin/views/home.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf import settings
 from django.db.models import F
 from django.shortcuts import render

--- a/wagtail/wagtailadmin/views/page_privacy.py
+++ b/wagtail/wagtailadmin/views/page_privacy.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
 

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse

--- a/wagtail/wagtailadmin/views/tags.py
+++ b/wagtail/wagtailadmin/views/tags.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.http import JsonResponse
 from taggit.models import Tag
 

--- a/wagtail/wagtailadmin/views/userbar.py
+++ b/wagtail/wagtailadmin/views/userbar.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib.auth.decorators import permission_required
 from django.shortcuts import render
 

--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import forms
 from django.contrib.auth.models import Permission
 from django.contrib.staticfiles.templatetags.staticfiles import static

--- a/wagtail/wagtailcore/admin.py
+++ b/wagtail/wagtailcore/admin.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib import admin
 from django.contrib.auth.admin import GroupAdmin
 from django.contrib.auth.models import Group

--- a/wagtail/wagtailcore/apps.py
+++ b/wagtail/wagtailcore/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/wagtailcore/blocks/utils.py
+++ b/wagtail/wagtailcore/blocks/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import re
 
 

--- a/wagtail/wagtailcore/compat.py
+++ b/wagtail/wagtailcore/compat.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 

--- a/wagtail/wagtailcore/forms.py
+++ b/wagtail/wagtailcore/forms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import forms
 
 

--- a/wagtail/wagtailcore/hooks.py
+++ b/wagtail/wagtailcore/hooks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from wagtail.utils.apps import get_app_submodules
 
 _hooks = {}

--- a/wagtail/wagtailcore/jinja2tags.py
+++ b/wagtail/wagtailcore/jinja2tags.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import jinja2
 from jinja2.ext import Extension

--- a/wagtail/wagtailcore/management/commands/fixtree.py
+++ b/wagtail/wagtailcore/management/commands/fixtree.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import functools
 import operator
 

--- a/wagtail/wagtailcore/management/commands/move_pages.py
+++ b/wagtail/wagtailcore/management/commands/move_pages.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.management.base import BaseCommand
 
 from wagtail.wagtailcore.models import Page

--- a/wagtail/wagtailcore/management/commands/publish_scheduled_pages.py
+++ b/wagtail/wagtailcore/management/commands/publish_scheduled_pages.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import json
 

--- a/wagtail/wagtailcore/management/commands/replace_text.py
+++ b/wagtail/wagtailcore/management/commands/replace_text.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.management.base import BaseCommand
 from django.db import models
 from modelcluster.models import get_all_child_relations

--- a/wagtail/wagtailcore/management/commands/set_url_paths.py
+++ b/wagtail/wagtailcore/management/commands/set_url_paths.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.management.base import NoArgsCommand
 
 from wagtail.wagtailcore.models import Page

--- a/wagtail/wagtailcore/middleware.py
+++ b/wagtail/wagtailcore/middleware.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from wagtail.wagtailcore.models import Site
 
 

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import json
 import logging

--- a/wagtail/wagtailcore/permission_policies/base.py
+++ b/wagtail/wagtailcore/permission_policies/base.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType

--- a/wagtail/wagtailcore/permission_policies/collections.py
+++ b/wagtail/wagtailcore/permission_policies/collections.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured

--- a/wagtail/wagtailcore/permissions.py
+++ b/wagtail/wagtailcore/permissions.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from wagtail.wagtailcore.models import Collection, Site
 from wagtail.wagtailcore.permission_policies import ModelPermissionPolicy
 

--- a/wagtail/wagtailcore/query.py
+++ b/wagtail/wagtailcore/query.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from collections import defaultdict
 
 from django import VERSION as DJANGO_VERSION

--- a/wagtail/wagtailcore/rich_text.py
+++ b/wagtail/wagtailcore/rich_text.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals  # ensure that RichText.__str__ returns unicode
+from __future__ import absolute_import, unicode_literals
 
 import re  # parsing HTML with regexes LIKE A BOSS.
 

--- a/wagtail/wagtailcore/signals.py
+++ b/wagtail/wagtailcore/signals.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.dispatch import Signal
 
 page_published = Signal(providing_args=['instance', 'revision'])

--- a/wagtail/wagtailcore/templatetags/wagtailcore_tags.py
+++ b/wagtail/wagtailcore/templatetags/wagtailcore_tags.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import template
 from django.utils.safestring import mark_safe
 

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import base64
 import unittest

--- a/wagtail/wagtailcore/tests/test_collection_model.py
+++ b/wagtail/wagtailcore/tests/test_collection_model.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.test import TestCase
 
 from wagtail.wagtailcore.models import Collection

--- a/wagtail/wagtailcore/tests/test_collection_permission_policies.py
+++ b/wagtail/wagtailcore/tests/test_collection_permission_policies.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser, Group, Permission
 from django.contrib.contenttypes.models import ContentType

--- a/wagtail/wagtailcore/tests/test_dbwhitelister.py
+++ b/wagtail/wagtailcore/tests/test_dbwhitelister.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from bs4 import BeautifulSoup
 from django.test import TestCase
 

--- a/wagtail/wagtailcore/tests/test_management_commands.py
+++ b/wagtail/wagtailcore/tests/test_management_commands.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from datetime import timedelta
 
 from django.core import management

--- a/wagtail/wagtailcore/tests/test_migrations.py
+++ b/wagtail/wagtailcore/tests/test_migrations.py
@@ -3,6 +3,8 @@ Check that all changes to Wagtail models have had migrations created. If there
 are outstanding model changes that need migrations, fail the tests.
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import apps
 from django.db.migrations.autodetector import MigrationAutodetector
 from django.db.migrations.loader import MigrationLoader

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import datetime
 import json

--- a/wagtail/wagtailcore/tests/test_page_permissions.py
+++ b/wagtail/wagtailcore/tests/test_page_permissions.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 

--- a/wagtail/wagtailcore/tests/test_page_privacy.py
+++ b/wagtail/wagtailcore/tests/test_page_privacy.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.test import TestCase
 
 from wagtail.wagtailcore.models import Page, PageViewRestriction

--- a/wagtail/wagtailcore/tests/test_page_queryset.py
+++ b/wagtail/wagtailcore/tests/test_page_queryset.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.test import TestCase
 
 from wagtail.tests.testapp.models import EventPage, SingleEventPage

--- a/wagtail/wagtailcore/tests/test_permission_policies.py
+++ b/wagtail/wagtailcore/tests/test_permission_policies.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser, Group, Permission
 from django.contrib.contenttypes.models import ContentType

--- a/wagtail/wagtailcore/tests/test_rich_text.py
+++ b/wagtail/wagtailcore/tests/test_rich_text.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from bs4 import BeautifulSoup
 from django.test import TestCase
 from mock import patch

--- a/wagtail/wagtailcore/tests/test_sites.py
+++ b/wagtail/wagtailcore/tests/test_sites.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.exceptions import ValidationError
 from django.http.request import HttpRequest
 from django.test import TestCase

--- a/wagtail/wagtailcore/tests/test_streamfield.py
+++ b/wagtail/wagtailcore/tests/test_streamfield.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import json
 

--- a/wagtail/wagtailcore/tests/test_utils.py
+++ b/wagtail/wagtailcore/tests/test_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.test import TestCase
 from django.utils.text import slugify

--- a/wagtail/wagtailcore/tests/test_whitelist.py
+++ b/wagtail/wagtailcore/tests/test_whitelist.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from bs4 import BeautifulSoup
 from django.test import TestCase
 

--- a/wagtail/wagtailcore/tests/tests.py
+++ b/wagtail/wagtailcore/tests/tests.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.cache import cache
 from django.test import TestCase
 from django.utils.safestring import SafeString

--- a/wagtail/wagtailcore/tests/tests.py
+++ b/wagtail/wagtailcore/tests/tests.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.core.cache import cache
 from django.test import TestCase
-from django.utils.safestring import SafeString
+from django.utils.safestring import SafeText
 
 from wagtail.tests.testapp.models import SimplePage
 from wagtail.wagtailcore.models import Page, Site
@@ -196,7 +196,7 @@ class TestRichtextTag(TestCase):
     def test_call_with_text(self):
         result = richtext("Hello world!")
         self.assertEqual(result, '<div class="rich-text">Hello world!</div>')
-        self.assertIsInstance(result, SafeString)
+        self.assertIsInstance(result, SafeText)
 
     def test_call_with_none(self):
         result = richtext(None)

--- a/wagtail/wagtailcore/url_routing.py
+++ b/wagtail/wagtailcore/url_routing.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import, unicode_literals
+
+
 class RouteResult(object):
     """
     An object to be returned from Page.route, which encapsulates

--- a/wagtail/wagtailcore/urls.py
+++ b/wagtail/wagtailcore/urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.wagtailcore import views

--- a/wagtail/wagtailcore/utils.py
+++ b/wagtail/wagtailcore/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import re
 import unicodedata
 

--- a/wagtail/wagtailcore/views.py
+++ b/wagtail/wagtailcore/views.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponse

--- a/wagtail/wagtailcore/wagtail_hooks.py
+++ b/wagtail/wagtailcore/wagtail_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.urlresolvers import reverse
 
 from wagtail.wagtailcore import hooks

--- a/wagtail/wagtailcore/whitelist.py
+++ b/wagtail/wagtailcore/whitelist.py
@@ -2,6 +2,8 @@
 A generic HTML whitelisting engine, designed to accommodate subclassing to override
 specific rules.
 """
+from __future__ import absolute_import, unicode_literals
+
 import re
 
 from bs4 import BeautifulSoup, Comment, NavigableString, Tag

--- a/wagtail/wagtaildocs/admin.py
+++ b/wagtail/wagtaildocs/admin.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf import settings
 from django.contrib import admin
 

--- a/wagtail/wagtaildocs/admin_urls.py
+++ b/wagtail/wagtaildocs/admin_urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.wagtaildocs.views import chooser, documents, multiple

--- a/wagtail/wagtaildocs/apps.py
+++ b/wagtail/wagtaildocs/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/wagtaildocs/blocks.py
+++ b/wagtail/wagtaildocs/blocks.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.utils.functional import cached_property
 from django.utils.html import format_html

--- a/wagtail/wagtaildocs/forms.py
+++ b/wagtail/wagtaildocs/forms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import forms
 from django.forms.models import modelform_factory
 from django.utils.translation import ugettext_lazy as _

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import os.path
 

--- a/wagtail/wagtaildocs/permissions.py
+++ b/wagtail/wagtaildocs/permissions.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from wagtail.wagtailcore.permission_policies.collections import CollectionOwnershipPermissionPolicy
 from wagtail.wagtaildocs.models import Document, get_document_model
 

--- a/wagtail/wagtaildocs/rich_text.py
+++ b/wagtail/wagtaildocs/rich_text.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.utils.html import escape
 
 from wagtail.wagtaildocs.models import get_document_model

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import json
 import os.path

--- a/wagtail/wagtaildocs/urls.py
+++ b/wagtail/wagtaildocs/urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.wagtaildocs.views import serve

--- a/wagtail/wagtaildocs/views/chooser.py
+++ b/wagtail/wagtaildocs/views/chooser.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import json
 
 from django.core.urlresolvers import reverse

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import ugettext as _

--- a/wagtail/wagtaildocs/views/multiple.py
+++ b/wagtail/wagtaildocs/views/multiple.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, render

--- a/wagtail/wagtaildocs/views/serve.py
+++ b/wagtail/wagtaildocs/views/serve.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from wsgiref.util import FileWrapper
 
 from django.conf import settings

--- a/wagtail/wagtaildocs/wagtail_hooks.py
+++ b/wagtail/wagtaildocs/wagtail_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import include, url
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core import urlresolvers

--- a/wagtail/wagtailembeds/apps.py
+++ b/wagtail/wagtailembeds/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/wagtailembeds/blocks.py
+++ b/wagtail/wagtailembeds/blocks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.utils.encoding import python_2_unicode_compatible
 
 from wagtail.wagtailcore import blocks

--- a/wagtail/wagtailembeds/embeds.py
+++ b/wagtail/wagtailembeds/embeds.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from datetime import datetime
 
 from wagtail.wagtailembeds.finders import get_default_finder

--- a/wagtail/wagtailembeds/exceptions.py
+++ b/wagtail/wagtailembeds/exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import, unicode_literals
+
+
 class EmbedException(Exception):
     pass
 

--- a/wagtail/wagtailembeds/finders/embedly.py
+++ b/wagtail/wagtailembeds/finders/embedly.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
 

--- a/wagtail/wagtailembeds/finders/oembed.py
+++ b/wagtail/wagtailembeds/finders/oembed.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import json
 

--- a/wagtail/wagtailembeds/format.py
+++ b/wagtail/wagtailembeds/format.py
@@ -1,4 +1,5 @@
 from __future__ import division  # Use true division
+from __future__ import absolute_import, unicode_literals
 
 from django.template.loader import render_to_string
 

--- a/wagtail/wagtailembeds/forms.py
+++ b/wagtail/wagtailembeds/forms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import forms
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator

--- a/wagtail/wagtailembeds/models.py
+++ b/wagtail/wagtailembeds/models.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible

--- a/wagtail/wagtailembeds/oembed_providers.py
+++ b/wagtail/wagtailembeds/oembed_providers.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import re
 
 OEMBED_ENDPOINTS = {

--- a/wagtail/wagtailembeds/rich_text.py
+++ b/wagtail/wagtailembeds/rich_text.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from wagtail.wagtailembeds import format
 from wagtail.wagtailembeds.exceptions import EmbedException
 

--- a/wagtail/wagtailembeds/templatetags/wagtailembeds_tags.py
+++ b/wagtail/wagtailembeds/templatetags/wagtailembeds_tags.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import template
 from django.utils.safestring import mark_safe
 

--- a/wagtail/wagtailembeds/tests.py
+++ b/wagtail/wagtailembeds/tests.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import unittest
 
 import django.utils.six.moves.urllib.request

--- a/wagtail/wagtailembeds/urls.py
+++ b/wagtail/wagtailembeds/urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.wagtailembeds.views import chooser

--- a/wagtail/wagtailembeds/views/chooser.py
+++ b/wagtail/wagtailembeds/views/chooser.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.forms.utils import ErrorList
 from django.utils.translation import ugettext as _
 

--- a/wagtail/wagtailembeds/wagtail_hooks.py
+++ b/wagtail/wagtailembeds/wagtail_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import include, url
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core import urlresolvers

--- a/wagtail/wagtailforms/apps.py
+++ b/wagtail/wagtailforms/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/wagtailforms/forms.py
+++ b/wagtail/wagtailforms/forms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from collections import OrderedDict
 
 import django.forms

--- a/wagtail/wagtailforms/forms.py
+++ b/wagtail/wagtailforms/forms.py
@@ -99,7 +99,7 @@ class FormBuilder(object):
         return options
 
     def get_form_class(self):
-        return type('WagtailForm', (BaseForm,), self.formfields)
+        return type(str('WagtailForm'), (BaseForm,), self.formfields)
 
 
 class SelectDateForm(django.forms.Form):

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import json
 import re

--- a/wagtail/wagtailforms/tests.py
+++ b/wagtail/wagtailforms/tests.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import json
 

--- a/wagtail/wagtailforms/urls.py
+++ b/wagtail/wagtailforms/urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.wagtailforms import views

--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import csv
 import datetime
 

--- a/wagtail/wagtailforms/wagtail_hooks.py
+++ b/wagtail/wagtailforms/wagtail_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import include, url
 from django.core import urlresolvers
 from django.utils.translation import ugettext_lazy as _

--- a/wagtail/wagtailimages/admin.py
+++ b/wagtail/wagtailimages/admin.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf import settings
 from django.contrib import admin
 

--- a/wagtail/wagtailimages/admin_urls.py
+++ b/wagtail/wagtailimages/admin_urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.wagtailimages.views import chooser, images, multiple

--- a/wagtail/wagtailimages/apps.py
+++ b/wagtail/wagtailimages/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 from . import checks  # NOQA

--- a/wagtail/wagtailimages/blocks.py
+++ b/wagtail/wagtailimages/blocks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.utils.functional import cached_property
 
 from wagtail.wagtailcore.blocks import ChooserBlock

--- a/wagtail/wagtailimages/checks.py
+++ b/wagtail/wagtailimages/checks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import os
 
 from django.core.checks import Warning, register

--- a/wagtail/wagtailimages/exceptions.py
+++ b/wagtail/wagtailimages/exceptions.py
@@ -1,2 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
+
 class InvalidFilterSpecError(ValueError):
     pass

--- a/wagtail/wagtailimages/fields.py
+++ b/wagtail/wagtailimages/fields.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import os
 
 from django.conf import settings

--- a/wagtail/wagtailimages/formats.py
+++ b/wagtail/wagtailimages/formats.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.utils.html import escape
 
 from wagtail.utils.apps import get_app_submodules

--- a/wagtail/wagtailimages/forms.py
+++ b/wagtail/wagtailimages/forms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import forms
 from django.forms.models import modelform_factory
 from django.utils.translation import ugettext as _

--- a/wagtail/wagtailimages/image_operations.py
+++ b/wagtail/wagtailimages/image_operations.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import absolute_import, division, unicode_literals
 
 import inspect
 

--- a/wagtail/wagtailimages/jinja2tags.py
+++ b/wagtail/wagtailimages/jinja2tags.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from jinja2.ext import Extension
 

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import hashlib
 import os.path

--- a/wagtail/wagtailimages/permissions.py
+++ b/wagtail/wagtailimages/permissions.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from wagtail.wagtailcore.permission_policies.collections import CollectionOwnershipPermissionPolicy
 from wagtail.wagtailimages.models import Image, get_image_model
 

--- a/wagtail/wagtailimages/rect.py
+++ b/wagtail/wagtailimages/rect.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import absolute_import, division, unicode_literals
 
 import math
 

--- a/wagtail/wagtailimages/rich_text.py
+++ b/wagtail/wagtailimages/rich_text.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from wagtail.wagtailimages.formats import get_image_format
 from wagtail.wagtailimages.models import get_image_model
 

--- a/wagtail/wagtailimages/shortcuts.py
+++ b/wagtail/wagtailimages/shortcuts.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, unicode_literals
+
 from wagtail.wagtailimages.models import SourceImageIOError
 
 

--- a/wagtail/wagtailimages/templatetags/wagtailimages_tags.py
+++ b/wagtail/wagtailimages/templatetags/wagtailimages_tags.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import re
 
 from django import template

--- a/wagtail/wagtailimages/tests/test_admin_views.py
+++ b/wagtail/wagtailimages/tests/test_admin_views.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import json
 

--- a/wagtail/wagtailimages/tests/test_blocks.py
+++ b/wagtail/wagtailimages/tests/test_blocks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import os
 

--- a/wagtail/wagtailimages/tests/test_image_operations.py
+++ b/wagtail/wagtailimages/tests/test_image_operations.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.test import TestCase
 from django.utils.six import BytesIO
 from mock import Mock

--- a/wagtail/wagtailimages/tests/test_image_operations.py
+++ b/wagtail/wagtailimages/tests/test_image_operations.py
@@ -57,8 +57,7 @@ class ImageOperationTestCase(TestCase):
             for attr, value in expected_output.items():
                 self.assertEqual(getattr(operation, attr), value)
 
-        test_name = 'test_filter_%s' % filter_spec
-        test_filter_spec.__name__ = test_name
+        test_filter_spec.__name__ = str('test_filter_%s' % filter_spec)
         return test_filter_spec
 
     @classmethod
@@ -66,8 +65,8 @@ class ImageOperationTestCase(TestCase):
         def test_filter_spec_error(self):
             self.assertRaises(InvalidFilterSpecError, self.operation_class, *filter_spec.split('-'))
 
-        test_name = 'test_filter_%s_raises_%s' % (filter_spec, InvalidFilterSpecError.__name__)
-        test_filter_spec_error.__name__ = test_name
+        test_filter_spec_error.__name__ = str('test_filter_%s_raises_%s' % (
+            filter_spec, InvalidFilterSpecError.__name__))
         return test_filter_spec_error
 
     @classmethod
@@ -87,8 +86,7 @@ class ImageOperationTestCase(TestCase):
             # Check
             self.assertEqual(operation_recorder.ran_operations, expected_output)
 
-        test_name = 'test_run_%s' % filter_spec
-        test_run.__name__ = test_name
+        test_run.__name__ = str('test_run_%s' % filter_spec)
         return test_run
 
     @classmethod

--- a/wagtail/wagtailimages/tests/test_models.py
+++ b/wagtail/wagtailimages/tests/test_models.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import unittest
 
 from django.contrib.auth import get_user_model

--- a/wagtail/wagtailimages/tests/test_rich_text.py
+++ b/wagtail/wagtailimages/tests/test_rich_text.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from bs4 import BeautifulSoup
 from django.test import TestCase
 from mock import patch

--- a/wagtail/wagtailimages/tests/test_shortcuts.py
+++ b/wagtail/wagtailimages/tests/test_shortcuts.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, unicode_literals
+
 from django.test import TestCase
 
 from wagtail.wagtailimages.shortcuts import get_rendition_or_not_found

--- a/wagtail/wagtailimages/tests/tests.py
+++ b/wagtail/wagtailimages/tests/tests.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import forms, template
 from django.core.urlresolvers import reverse
 from django.test import TestCase

--- a/wagtail/wagtailimages/tests/utils.py
+++ b/wagtail/wagtailimages/tests/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import PIL.Image
 from django.core.files.images import ImageFile
 from django.utils.six import BytesIO

--- a/wagtail/wagtailimages/urls.py
+++ b/wagtail/wagtailimages/urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.wagtailimages.views import frontend

--- a/wagtail/wagtailimages/utils.py
+++ b/wagtail/wagtailimages/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import base64
 import hashlib
 import hmac

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import json
 
 from django.core.urlresolvers import reverse

--- a/wagtail/wagtailimages/views/frontend.py
+++ b/wagtail/wagtailimages/views/frontend.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import imghdr
 from wsgiref.util import FileWrapper
 

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import os
 
 from django.core.urlresolvers import NoReverseMatch, reverse

--- a/wagtail/wagtailimages/views/multiple.py
+++ b/wagtail/wagtailimages/views/multiple.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, render

--- a/wagtail/wagtailimages/wagtail_hooks.py
+++ b/wagtail/wagtailimages/wagtail_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import include, url
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core import urlresolvers

--- a/wagtail/wagtailredirects/apps.py
+++ b/wagtail/wagtailredirects/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/wagtailredirects/forms.py
+++ b/wagtail/wagtailredirects/forms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 

--- a/wagtail/wagtailredirects/middleware.py
+++ b/wagtail/wagtailredirects/middleware.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import http
 from django.utils.six.moves.urllib.parse import urlparse
 

--- a/wagtail/wagtailredirects/models.py
+++ b/wagtail/wagtailredirects/models.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.db import models
 from django.utils.six.moves.urllib.parse import urlparse

--- a/wagtail/wagtailredirects/permissions.py
+++ b/wagtail/wagtailredirects/permissions.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from wagtail.wagtailcore.permission_policies import ModelPermissionPolicy
 from wagtail.wagtailredirects.models import Redirect
 

--- a/wagtail/wagtailredirects/tests.py
+++ b/wagtail/wagtailredirects/tests.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 

--- a/wagtail/wagtailredirects/urls.py
+++ b/wagtail/wagtailredirects/urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.wagtailredirects import views

--- a/wagtail/wagtailredirects/views.py
+++ b/wagtail/wagtailredirects/views.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import ugettext as _

--- a/wagtail/wagtailredirects/wagtail_hooks.py
+++ b/wagtail/wagtailredirects/wagtail_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import include, url
 from django.contrib.auth.models import Permission
 from django.core import urlresolvers

--- a/wagtail/wagtailsearch/apps.py
+++ b/wagtail/wagtailsearch/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 from wagtail.wagtailsearch.signal_handlers import register_signal_handlers

--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -1,4 +1,6 @@
 
+from __future__ import absolute_import, unicode_literals
+
 from django.db.models.lookups import Lookup
 from django.db.models.query import QuerySet
 from django.db.models.sql.where import SubqueryConstraint, WhereNode

--- a/wagtail/wagtailsearch/backends/db.py
+++ b/wagtail/wagtailsearch/backends/db.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.db import models
 
 from wagtail.wagtailsearch.backends.base import BaseSearch, BaseSearchQuery, BaseSearchResults

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import json
 

--- a/wagtail/wagtailsearch/forms.py
+++ b/wagtail/wagtailsearch/forms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 

--- a/wagtail/wagtailsearch/index.py
+++ b/wagtail/wagtailsearch/index.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import apps
 from django.db import models
 from django.db.models.fields import FieldDoesNotExist

--- a/wagtail/wagtailsearch/management/commands/search_garbage_collect.py
+++ b/wagtail/wagtailsearch/management/commands/search_garbage_collect.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core.management.base import BaseCommand
 
 from wagtail.wagtailsearch import models

--- a/wagtail/wagtailsearch/management/commands/update_index.py
+++ b/wagtail/wagtailsearch/management/commands/update_index.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction

--- a/wagtail/wagtailsearch/models.py
+++ b/wagtail/wagtailsearch/models.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import datetime
 

--- a/wagtail/wagtailsearch/queryset.py
+++ b/wagtail/wagtailsearch/queryset.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from wagtail.wagtailsearch.backends import get_search_backend
 
 

--- a/wagtail/wagtailsearch/signal_handlers.py
+++ b/wagtail/wagtailsearch/signal_handlers.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.db.models.signals import post_delete, post_save
 
 from wagtail.wagtailsearch.backends import get_search_backends

--- a/wagtail/wagtailsearch/tests/test_backends.py
+++ b/wagtail/wagtailsearch/tests/test_backends.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import time
 import unittest
 

--- a/wagtail/wagtailsearch/tests/test_db_backend.py
+++ b/wagtail/wagtailsearch/tests/test_db_backend.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import unittest
 
 from django.test import TestCase

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import datetime
 import json

--- a/wagtail/wagtailsearch/tests/test_frontend.py
+++ b/wagtail/wagtailsearch/tests/test_frontend.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.core import paginator
 from django.core.urlresolvers import reverse
 from django.test import TestCase

--- a/wagtail/wagtailsearch/tests/test_indexed_class.py
+++ b/wagtail/wagtailsearch/tests/test_indexed_class.py
@@ -18,7 +18,7 @@ class TestContentTypeNames(TestCase):
 
 class TestSearchFields(TestCase):
     def make_dummy_type(self, search_fields):
-        return type('DummyType', (index.Indexed, ), dict(search_fields=search_fields))
+        return type(str('DummyType'), (index.Indexed, ), dict(search_fields=search_fields))
 
     def test_basic(self):
         cls = self.make_dummy_type([

--- a/wagtail/wagtailsearch/tests/test_indexed_class.py
+++ b/wagtail/wagtailsearch/tests/test_indexed_class.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.test import TestCase
 
 from wagtail.tests.search import models

--- a/wagtail/wagtailsearch/tests/test_queries.py
+++ b/wagtail/wagtailsearch/tests/test_queries.py
@@ -1,4 +1,6 @@
 
+from __future__ import absolute_import, unicode_literals
+
 from django.core import management
 from django.test import TestCase
 from django.utils.six import StringIO

--- a/wagtail/wagtailsearch/tests/test_related_fields.py
+++ b/wagtail/wagtailsearch/tests/test_related_fields.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.test import TestCase
 
 from wagtail.tests.search.models import SearchTest, SearchTestChild

--- a/wagtail/wagtailsearch/tests/test_signal_handlers.py
+++ b/wagtail/wagtailsearch/tests/test_signal_handlers.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.test import TestCase
 
 from wagtail.tests.search import models

--- a/wagtail/wagtailsearch/urls/admin.py
+++ b/wagtail/wagtailsearch/urls/admin.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.wagtailsearch.views import queries

--- a/wagtail/wagtailsearch/urls/frontend.py
+++ b/wagtail/wagtailsearch/urls/frontend.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.wagtailsearch.views import search

--- a/wagtail/wagtailsearch/utils.py
+++ b/wagtail/wagtailsearch/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import string
 
 MAX_QUERY_STRING_LENGTH = 255

--- a/wagtail/wagtailsearch/views/frontend.py
+++ b/wagtail/wagtailsearch/views/frontend.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf import settings
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http import JsonResponse

--- a/wagtail/wagtailsearch/views/queries.py
+++ b/wagtail/wagtailsearch/views/queries.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.shortcuts import render
 
 from wagtail.utils.pagination import paginate

--- a/wagtail/wagtailsearch/wagtail_hooks.py
+++ b/wagtail/wagtailsearch/wagtail_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import include, url
 
 from wagtail.wagtailcore import hooks

--- a/wagtail/wagtailsites/forms.py
+++ b/wagtail/wagtailsites/forms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 

--- a/wagtail/wagtailsites/tests.py
+++ b/wagtail/wagtailsites/tests.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission

--- a/wagtail/wagtailsites/urls.py
+++ b/wagtail/wagtailsites/urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.wagtailsites import views

--- a/wagtail/wagtailsites/views.py
+++ b/wagtail/wagtailsites/views.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.utils.translation import ugettext_lazy as __
 
 from wagtail.wagtailadmin.views.generic import CreateView, DeleteView, EditView, IndexView

--- a/wagtail/wagtailsites/wagtail_hooks.py
+++ b/wagtail/wagtailsites/wagtail_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import include, url
 from django.contrib.auth.models import Permission
 from django.core import urlresolvers

--- a/wagtail/wagtailsnippets/apps.py
+++ b/wagtail/wagtailsnippets/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/wagtailsnippets/blocks.py
+++ b/wagtail/wagtailsnippets/blocks.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.utils.functional import cached_property
 

--- a/wagtail/wagtailsnippets/models.py
+++ b/wagtail/wagtailsnippets/models.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.core.urlresolvers import reverse
 

--- a/wagtail/wagtailsnippets/permissions.py
+++ b/wagtail/wagtailsnippets/permissions.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib.auth import get_permission_codename
 
 from wagtail.wagtailsnippets.models import get_snippet_models

--- a/wagtail/wagtailsnippets/tests.py
+++ b/wagtail/wagtailsnippets/tests.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.core.exceptions import ImproperlyConfigured

--- a/wagtail/wagtailsnippets/urls.py
+++ b/wagtail/wagtailsnippets/urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.wagtailsnippets.views import chooser, snippets

--- a/wagtail/wagtailsnippets/views/chooser.py
+++ b/wagtail/wagtailsnippets/views/chooser.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import json
 
 from django.core.urlresolvers import reverse

--- a/wagtail/wagtailsnippets/views/snippets.py
+++ b/wagtail/wagtailsnippets/views/snippets.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import apps
 from django.core.urlresolvers import reverse
 from django.http import Http404

--- a/wagtail/wagtailsnippets/wagtail_hooks.py
+++ b/wagtail/wagtailsnippets/wagtail_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import include, url
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType

--- a/wagtail/wagtailusers/apps.py
+++ b/wagtail/wagtailusers/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/wagtailusers/forms.py
+++ b/wagtail/wagtailusers/forms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from itertools import groupby
 
 from django import forms

--- a/wagtail/wagtailusers/models.py
+++ b/wagtail/wagtailusers/models.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
 from django.db import models

--- a/wagtail/wagtailusers/templatetags/wagtailusers_tags.py
+++ b/wagtail/wagtailusers/templatetags/wagtailusers_tags.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django import template
 
 register = template.Library()

--- a/wagtail/wagtailusers/tests.py
+++ b/wagtail/wagtailusers/tests.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission

--- a/wagtail/wagtailusers/urls/groups.py
+++ b/wagtail/wagtailusers/urls/groups.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.wagtailusers.views import groups

--- a/wagtail/wagtailusers/urls/users.py
+++ b/wagtail/wagtailusers/urls/users.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from wagtail.wagtailusers.views import users

--- a/wagtail/wagtailusers/views/groups.py
+++ b/wagtail/wagtailusers/views/groups.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib.auth.models import Group
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404, redirect, render

--- a/wagtail/wagtailusers/views/users.py
+++ b/wagtail/wagtailusers/views/users.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.db.models import Q

--- a/wagtail/wagtailusers/wagtail_hooks.py
+++ b/wagtail/wagtailusers/wagtail_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import include, url
 from django.contrib.auth.models import Permission
 from django.core import urlresolvers


### PR DESCRIPTION
What is says up there. Also made this automatic through `isort`. If you run `isort` on your file, it will automatically add the imports while sorting. Couple this with [editor integration](https://github.com/timothycrosley/isort/wiki/isort-Plugins), and you will never forget this again. Drone will also check for these imports as part of its run.

As part of these changes, some strings that were automatically the correct type on all versions had to be explicitly set to the correct type. This was mostly generated class and function names. In both versions of Python, these have to be `str`s - bytes on Python 2, unicode on Python 3. This is achieved by wrapping the names in `str()`.