### PR TITLE
Update django-taggit version to 0.18.x branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ except ImportError:
 install_requires = [
     "Django>=1.8.1,<1.10",
     "django-modelcluster>=1.1,<1.2",
-    "django-taggit>=0.17.5",
+    "django-taggit>=0.18,<0.19",
     "django-treebeard>=3.0,<5.0",
     "djangorestframework>=3.1.3",
     "Pillow>=2.6.1",

--- a/wagtail/wagtailcore/tests/test_sites.py
+++ b/wagtail/wagtailcore/tests/test_sites.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
-from django.test import TestCase
 from django.http.request import HttpRequest
+from django.test import TestCase
 
 from wagtail.wagtailcore.models import Page, Site
 


### PR DESCRIPTION
Django taggit 0.18.1 contains my PR to quiet Django deprecation warnings. We should use the 0.18.x branch, as it is nicely up to date.