### PR TITLE
Fix isort on drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ build:
     image: python:3.5
     commands:
       - XDG_CACHE_HOME=/drone/pip-cache pip install wheel
-      - XDG_CACHE_HOME=/drone/pip-cache pip install isort==4.2.2 -e .[testing,docs]
+      - XDG_CACHE_HOME=/drone/pip-cache pip install isort>=4.2.5 -e .[testing,docs]
       - isort --check-only --diff --recursive wagtail
   js:
     image: node:4.2.4

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ build:
     image: python:3.5
     commands:
       - XDG_CACHE_HOME=/drone/pip-cache pip install wheel
-      - XDG_CACHE_HOME=/drone/pip-cache pip install isort -e .[testing,docs]
+      - XDG_CACHE_HOME=/drone/pip-cache pip install isort==4.2.2 -e .[testing,docs]
       - isort --check-only --diff --recursive wagtail
   js:
     image: node:4.2.4

--- a/wagtail/wagtailcore/tests/test_sites.py
+++ b/wagtail/wagtailcore/tests/test_sites.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
-from django.test import TestCase
 from django.http.request import HttpRequest
+from django.test import TestCase
 
 from wagtail.wagtailcore.models import Page, Site
 


### PR DESCRIPTION
isort 4.2.3+ is broken on Drone due to timothycrosley/isort#414. This commit pins isort to 4.2.2, as well as fixing an import order error that snuck in.