### PR TITLE
Add options to filter deprecation warnings in tests

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -4,6 +4,7 @@ import sys
 import os
 import shutil
 import warnings
+import argparse
 
 from django.core.management import execute_from_command_line
 
@@ -11,22 +12,45 @@ from django.core.management import execute_from_command_line
 os.environ['DJANGO_SETTINGS_MODULE'] = 'wagtail.tests.settings'
 
 
+def make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--deprecation', choices=['all', 'pending', 'imminent', 'none'], default='pending')
+    parser.add_argument('--postgres', action='store_true')
+    parser.add_argument('--elasticsearch', action='store_true')
+    parser.add_argument('rest', nargs='*')
+    return parser
+
+
+def parse_args(args=None):
+    return make_parser().parse_args(args)
+
+
 def runtests():
-    # Don't ignore DeprecationWarnings
-    warnings.simplefilter('default', DeprecationWarning)
-    warnings.simplefilter('default', PendingDeprecationWarning)
+    args = parse_args()
 
-    args = sys.argv[1:]
+    only_wagtail = r'^wagtail(\.|$)'
+    if args.deprecation == 'all':
+        # Show all deprecation warnings from all packages
+        warnings.simplefilter('default', DeprecationWarning)
+        warnings.simplefilter('default', PendingDeprecationWarning)
+    elif args.deprecation == 'pending':
+        # Show all deprecation warnings from wagtail
+        warnings.filterwarnings('default', category=DeprecationWarning, module=only_wagtail)
+        warnings.filterwarnings('default', category=PendingDeprecationWarning, module=only_wagtail)
+    elif args.deprecation == 'imminent':
+        # Show only imminent deprecation warnings from wagtail
+        warnings.filterwarnings('default', category=DeprecationWarning, module=only_wagtail)
+    elif args.deprecation == 'none':
+        # Deprecation warnings are ignored by default
+        pass
 
-    if '--postgres' in args:
+    if args.postgres:
         os.environ['DATABASE_ENGINE'] = 'django.db.backends.postgresql_psycopg2'
-        args.remove('--postgres')
 
-    if '--elasticsearch' in args:
+    if args.elasticsearch:
         os.environ.setdefault('ELASTICSEARCH_URL', 'http://localhost:9200')
-        args.remove('--elasticsearch')
 
-    argv = sys.argv[:1] + ['test'] + args
+    argv = [sys.argv[0], 'test'] + args.rest
     try:
         execute_from_command_line(argv)
     finally:


### PR DESCRIPTION
The test output was extremely noisy with deprecation warnings. Half of these warnings were caused by external modules like django-taggit, and could be ignored. The warnings caused by Wagtail got lost in the noise though, rendering the test output useless for finding warnings. By default, the tests now only print deprecation warnings if raised by Wagtail.

Use `./runtests.py --deprecation=all` if you want all the warnings to be printed. This is useful when we want to fix third party packages before they break from being too outdated.

Use `./runtests.py --deprecation=pending` if you want the default behaviour.

Use `./runtests.py --deprecation=imminent` if you only want imminent DeprecationWarnings, ignoring PendingDeprecationWarnings.

Use `./runtests.py --deprecation=none` if you want to ignore all deprecation warnings.

This changes how `./runtests.py` passes arguments to `dj test`. Previously, you could intermingle arguments to `./runtests.py` and `dj test`, and `./runtests.py` would sort things out. Now, arguments to `dj test` must come at the end, after a `--`. For example:

```
$ ./runtests.py --deprecation=all -- --keepdb
```