### PR TITLE
Check POST requests method correctly

### DIFF
--- a/wagtail/contrib/settings/views.py
+++ b/wagtail/contrib/settings/views.py
@@ -51,7 +51,7 @@ def edit(request, site_pk, app_name, model_name):
     edit_handler_class = get_setting_edit_handler(model)
     form_class = edit_handler_class.get_form_class(model)
 
-    if request.POST:
+    if request.method == 'POST':
         form = form_class(request.POST, request.FILES, instance=instance)
 
         if form.is_valid():

--- a/wagtail/contrib/wagtailsearchpromotions/tests.py
+++ b/wagtail/contrib/wagtailsearchpromotions/tests.py
@@ -332,10 +332,7 @@ class TestSearchPromotionsDeleteView(TestCase, WagtailTestUtils):
 
     def test_post(self):
         # Submit
-        post_data = {
-            'foo': 'bar',
-        }
-        response = self.client.post(reverse('wagtailsearchpromotions:delete', args=(self.query.id, )), post_data)
+        response = self.client.post(reverse('wagtailsearchpromotions:delete', args=(self.query.id, )))
 
         # User should be redirected back to the index
         self.assertRedirects(response, reverse('wagtailsearchpromotions:index'))

--- a/wagtail/contrib/wagtailsearchpromotions/views.py
+++ b/wagtail/contrib/wagtailsearchpromotions/views.py
@@ -71,7 +71,7 @@ def save_searchpicks(query, new_query, searchpicks_formset):
 
 @permission_required('wagtailsearchpromotions.add_searchpromotion')
 def add(request):
-    if request.POST:
+    if request.method == 'POST':
         # Get query
         query_form = search_forms.QueryForm(request.POST)
         if query_form.is_valid():
@@ -107,7 +107,7 @@ def add(request):
 def edit(request, query_id):
     query = get_object_or_404(Query, id=query_id)
 
-    if request.POST:
+    if request.method == 'POST':
         # Get query
         query_form = search_forms.QueryForm(request.POST)
         # and the recommendations
@@ -145,7 +145,7 @@ def edit(request, query_id):
 def delete(request, query_id):
     query = get_object_or_404(Query, id=query_id)
 
-    if request.POST:
+    if request.method == 'POST':
         query.editors_picks.all().delete()
         messages.success(request, _("Editor's picks deleted."))
         return redirect('wagtailsearchpromotions:index')

--- a/wagtail/wagtailadmin/views/account.py
+++ b/wagtail/wagtailadmin/views/account.py
@@ -48,7 +48,7 @@ def change_password(request):
     can_change_password = request.user.has_usable_password()
 
     if can_change_password:
-        if request.POST:
+        if request.method == 'POST':
             form = PasswordChangeForm(request.user, request.POST)
 
             if form.is_valid():
@@ -83,7 +83,7 @@ password_reset_complete = _wrap_password_reset_view(auth_views.password_reset_co
 
 
 def notification_preferences(request):
-    if request.POST:
+    if request.method == 'POST':
         form = NotificationPreferencesForm(request.POST, instance=UserProfile.get_for_user(request.user))
 
         if form.is_valid():

--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -149,7 +149,7 @@ def external_link(request):
     else:
         form_class = ExternalLinkChooserForm
 
-    if request.POST:
+    if request.method == 'POST':
         form = form_class(request.POST)
         if form.is_valid():
             return render_modal_workflow(
@@ -180,7 +180,7 @@ def email_link(request):
     else:
         form_class = EmailLinkChooserForm
 
-    if request.POST:
+    if request.method == 'POST':
         form = form_class(request.POST)
         if form.is_valid():
             return render_modal_workflow(

--- a/wagtail/wagtailadmin/views/page_privacy.py
+++ b/wagtail/wagtailadmin/views/page_privacy.py
@@ -21,7 +21,7 @@ def set_privacy(request, page_id):
         restriction = None
         restriction_exists_on_ancestor = False
 
-    if request.POST:
+    if request.method == 'POST':
         form = PageViewRestrictionForm(request.POST)
         if form.is_valid() and not restriction_exists_on_ancestor:
             if form.cleaned_data['restriction_type'] == 'none':

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -170,7 +170,7 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
     edit_handler_class = page_class.get_edit_handler()
     form_class = edit_handler_class.get_form_class(page_class)
 
-    if request.POST:
+    if request.method == 'POST':
         form = form_class(request.POST, request.FILES, instance=page,
                           parent_page=parent_page)
 
@@ -266,7 +266,7 @@ def edit(request, page_id):
 
     errors_debug = None
 
-    if request.POST:
+    if request.method == 'POST':
         form = form_class(request.POST, request.FILES, instance=page,
                           parent_page=parent)
 
@@ -640,7 +640,7 @@ def move_confirm(request, page_to_move_id, destination_id):
     if not page_to_move.permissions_for_user(request.user).can_move_to(destination):
         raise PermissionDenied
 
-    if request.POST:
+    if request.method == 'POST':
         # any invalid moves *should* be caught by the permission check above,
         # so don't bother to catch InvalidMoveToDescendant
 
@@ -665,7 +665,7 @@ def set_page_position(request, page_to_move_id):
     if not parent_page.permissions_for_user(request.user).can_reorder_children():
         raise PermissionDenied
 
-    if request.POST:
+    if request.method == 'POST':
         # Get position parameter
         position = request.GET.get('position', None)
 

--- a/wagtail/wagtailcore/views.py
+++ b/wagtail/wagtailcore/views.py
@@ -33,7 +33,7 @@ def authenticate_with_password(request, page_view_restriction_id, page_id):
     restriction = get_object_or_404(PageViewRestriction, id=page_view_restriction_id)
     page = get_object_or_404(Page, id=page_id).specific
 
-    if request.POST:
+    if request.method == 'POST':
         form = PasswordPageViewRestrictionForm(request.POST, instance=restriction)
         if form.is_valid():
             has_existing_session = (settings.SESSION_COOKIE_NAME in request.COOKIES)

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -361,10 +361,7 @@ class TestDocumentDeleteView(TestCase, WagtailTestUtils):
 
     def test_delete(self):
         # Submit title change
-        post_data = {
-            'foo': 'bar'
-        }
-        response = self.client.post(reverse('wagtaildocs:delete', args=(self.document.id,)), post_data)
+        response = self.client.post(reverse('wagtaildocs:delete', args=(self.document.id,)))
 
         # User should be redirected back to the index
         self.assertRedirects(response, reverse('wagtaildocs:index'))
@@ -501,7 +498,7 @@ class TestMultipleDocumentUploader(TestCase, WagtailTestUtils):
         """
         This tests that only AJAX requests are allowed to POST to the add view
         """
-        response = self.client.post(reverse('wagtaildocs:add_multiple'), {})
+        response = self.client.post(reverse('wagtaildocs:add_multiple'))
 
         # Check response
         self.assertEqual(response.status_code, 400)
@@ -510,7 +507,7 @@ class TestMultipleDocumentUploader(TestCase, WagtailTestUtils):
         """
         This tests that the add view checks for a file when a user POSTs to it
         """
-        response = self.client.post(reverse('wagtaildocs:add_multiple'), {}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        response = self.client.post(reverse('wagtaildocs:add_multiple'), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
 
         # Check response
         self.assertEqual(response.status_code, 400)

--- a/wagtail/wagtaildocs/views/chooser.py
+++ b/wagtail/wagtaildocs/views/chooser.py
@@ -100,7 +100,7 @@ def chooser_upload(request):
     Document = get_document_model()
     DocumentForm = get_document_form(Document)
 
-    if request.POST:
+    if request.method == 'POST':
         document = Document(uploaded_by_user=request.user)
         form = DocumentForm(request.POST, request.FILES, instance=document)
 

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -90,7 +90,7 @@ def add(request):
     Document = get_document_model()
     DocumentForm = get_document_form(Document)
 
-    if request.POST:
+    if request.method == 'POST':
         doc = Document(uploaded_by_user=request.user)
         form = DocumentForm(request.POST, request.FILES, instance=doc, user=request.user)
         if form.is_valid():
@@ -124,7 +124,7 @@ def edit(request, document_id):
     if not permission_policy.user_has_permission_for_instance(request.user, 'change', doc):
         return permission_denied(request)
 
-    if request.POST:
+    if request.method == 'POST':
         original_file = doc.file
         form = DocumentForm(request.POST, request.FILES, instance=doc, user=request.user)
         if form.is_valid():
@@ -183,7 +183,7 @@ def delete(request, document_id):
     if not permission_policy.user_has_permission_for_instance(request.user, 'delete', doc):
         return permission_denied(request)
 
-    if request.POST:
+    if request.method == 'POST':
         doc.delete()
         messages.success(request, _("Document '{0}' deleted.").format(doc.title))
         return redirect('wagtaildocs:index')

--- a/wagtail/wagtailembeds/views/chooser.py
+++ b/wagtail/wagtailembeds/views/chooser.py
@@ -17,7 +17,7 @@ def chooser(request):
 
 
 def chooser_upload(request):
-    if request.POST:
+    if request.method == 'POST':
         form = EmbedForm(request.POST, request.FILES)
 
         if form.is_valid():

--- a/wagtail/wagtailimages/tests/test_admin_views.py
+++ b/wagtail/wagtailimages/tests/test_admin_views.py
@@ -369,9 +369,7 @@ class TestImageDeleteView(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, 'wagtailimages/images/confirm_delete.html')
 
     def test_delete(self):
-        response = self.post({
-            'hello': 'world'
-        })
+        response = self.post()
 
         # Should redirect back to index
         self.assertRedirects(response, reverse('wagtailimages:index'))

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -117,7 +117,7 @@ def chooser_upload(request):
 
     searchform = SearchForm()
 
-    if request.POST:
+    if request.method == 'POST':
         image = Image(uploaded_by_user=request.user)
         form = ImageForm(request.POST, request.FILES, instance=image)
 
@@ -154,7 +154,7 @@ def chooser_upload(request):
 def chooser_select_format(request, image_id):
     image = get_object_or_404(get_image_model(), id=image_id)
 
-    if request.POST:
+    if request.method == 'POST':
         form = ImageInsertionForm(request.POST, initial={'alt_text': image.default_alt_text})
         if form.is_valid():
 

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -91,7 +91,7 @@ def edit(request, image_id):
     if not permission_policy.user_has_permission_for_instance(request.user, 'change', image):
         return permission_denied(request)
 
-    if request.POST:
+    if request.method == 'POST':
         original_file = image.file
         form = ImageForm(request.POST, request.FILES, instance=image, user=request.user)
         if form.is_valid():
@@ -224,7 +224,7 @@ def delete(request, image_id):
     if not permission_policy.user_has_permission_for_instance(request.user, 'delete', image):
         return permission_denied(request)
 
-    if request.POST:
+    if request.method == 'POST':
         image.delete()
         messages.success(request, _("Image '{0}' deleted.").format(image.title))
         return redirect('wagtailimages:index')
@@ -239,7 +239,7 @@ def add(request):
     ImageModel = get_image_model()
     ImageForm = get_image_form(ImageModel)
 
-    if request.POST:
+    if request.method == 'POST':
         image = ImageModel(uploaded_by_user=request.user)
         form = ImageForm(request.POST, request.FILES, instance=image, user=request.user)
         if form.is_valid():

--- a/wagtail/wagtailredirects/tests.py
+++ b/wagtail/wagtailredirects/tests.py
@@ -386,10 +386,10 @@ class TestRedirectsDeleteView(TestCase, WagtailTestUtils):
     def get(self, params={}, redirect_id=None):
         return self.client.get(reverse('wagtailredirects:delete', args=(redirect_id or self.redirect.id, )), params)
 
-    def post(self, post_data={}, redirect_id=None):
+    def post(self, redirect_id=None):
         return self.client.post(reverse(
             'wagtailredirects:delete', args=(redirect_id or self.redirect.id, )
-        ), post_data)
+        ))
 
     def test_simple(self):
         response = self.get()
@@ -400,9 +400,7 @@ class TestRedirectsDeleteView(TestCase, WagtailTestUtils):
         self.assertEqual(self.get(redirect_id=100000).status_code, 404)
 
     def test_delete(self):
-        response = self.post({
-            'hello': 'world'
-        })
+        response = self.post()
 
         # Should redirect back to index
         self.assertRedirects(response, reverse('wagtailredirects:index'))

--- a/wagtail/wagtailredirects/views.py
+++ b/wagtail/wagtailredirects/views.py
@@ -64,7 +64,7 @@ def edit(request, redirect_id):
     ):
         return permission_denied(request)
 
-    if request.POST:
+    if request.method == 'POST':
         form = RedirectForm(request.POST, request.FILES, instance=theredirect)
         if form.is_valid():
             form.save()
@@ -93,7 +93,7 @@ def delete(request, redirect_id):
     ):
         return permission_denied(request)
 
-    if request.POST:
+    if request.method == 'POST':
         theredirect.delete()
         messages.success(request, _("Redirect '{0}' deleted.").format(theredirect.title))
         return redirect('wagtailredirects:index')
@@ -105,7 +105,7 @@ def delete(request, redirect_id):
 
 @permission_checker.require('add')
 def add(request):
-    if request.POST:
+    if request.method == 'POST':
         form = RedirectForm(request.POST, request.FILES)
         if form.is_valid():
             theredirect = form.save()

--- a/wagtail/wagtailsnippets/tests.py
+++ b/wagtail/wagtailsnippets/tests.py
@@ -263,9 +263,8 @@ class TestSnippetDelete(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
 
     def test_delete_post(self):
-        post_data = {'foo': 'bar'}  # For some reason, this test doesn't work without a bit of POST data
         response = self.client.post(
-            reverse('wagtailsnippets:delete', args=('tests', 'advert', self.test_snippet.id, )), post_data
+            reverse('wagtailsnippets:delete', args=('tests', 'advert', self.test_snippet.id, ))
         )
 
         # Should be redirected to explorer page

--- a/wagtail/wagtailsnippets/views/snippets.py
+++ b/wagtail/wagtailsnippets/views/snippets.py
@@ -126,7 +126,7 @@ def create(request, app_label, model_name):
     edit_handler_class = get_snippet_edit_handler(model)
     form_class = edit_handler_class.get_form_class(model)
 
-    if request.POST:
+    if request.method == 'POST':
         form = form_class(request.POST, request.FILES, instance=instance)
 
         if form.is_valid():
@@ -169,7 +169,7 @@ def edit(request, app_label, model_name, id):
     edit_handler_class = get_snippet_edit_handler(model)
     form_class = edit_handler_class.get_form_class(model)
 
-    if request.POST:
+    if request.method == 'POST':
         form = form_class(request.POST, request.FILES, instance=instance)
 
         if form.is_valid():
@@ -211,7 +211,7 @@ def delete(request, app_label, model_name, id):
 
     instance = get_object_or_404(model, id=id)
 
-    if request.POST:
+    if request.method == 'POST':
         instance.delete()
         messages.success(
             request,

--- a/wagtail/wagtailusers/views/groups.py
+++ b/wagtail/wagtailusers/views/groups.py
@@ -76,7 +76,7 @@ def index(request):
 @permission_required('auth.add_group')
 def create(request):
     group = Group()
-    if request.POST:
+    if request.method == 'POST':
         form = GroupForm(request.POST, instance=group)
         permission_panels = [
             cls(request.POST, instance=group)
@@ -110,7 +110,7 @@ def create(request):
 @permission_required('auth.change_group')
 def edit(request, group_id):
     group = get_object_or_404(Group, id=group_id)
-    if request.POST:
+    if request.method == 'POST':
         form = GroupForm(request.POST, instance=group)
         permission_panels = [
             cls(request.POST, instance=group)
@@ -146,7 +146,7 @@ def edit(request, group_id):
 def delete(request, group_id):
     group = get_object_or_404(Group, id=group_id)
 
-    if request.POST:
+    if request.method == 'POST':
         group.delete()
         messages.success(request, _("Group '{0}' deleted.").format(group.name))
         return redirect('wagtailusers_groups:index')

--- a/wagtail/wagtailusers/views/users.py
+++ b/wagtail/wagtailusers/views/users.py
@@ -88,7 +88,7 @@ def index(request):
 
 @permission_required(add_user_perm)
 def create(request):
-    if request.POST:
+    if request.method == 'POST':
         form = UserCreationForm(request.POST)
         if form.is_valid():
             user = form.save()
@@ -109,7 +109,7 @@ def create(request):
 @permission_required(change_user_perm)
 def edit(request, user_id):
     user = get_object_or_404(User, id=user_id)
-    if request.POST:
+    if request.method == 'POST':
         form = UserEditForm(request.POST, instance=user)
         if form.is_valid():
             user = form.save()


### PR DESCRIPTION
Instead of using `if request.POST:`, use `if request.method == 'POST':`. Workarounds due to incorrect method checks in the tests have also been removed.