### PR TITLE
Fix site settings docs for setting an icon

### DIFF
--- a/docs/reference/contrib/settings.rst
+++ b/docs/reference/contrib/settings.rst
@@ -66,7 +66,7 @@ You can add an icon to the menu by passing an 'icon' argument to the ``register_
 
 .. code-block:: python
 
-    @register_setting(icon='icon-placeholder')
+    @register_setting(icon='placeholder')
     class SocialMediaSettings(BaseSetting):
         class Meta:
             verbose_name = 'social media accounts'


### PR DESCRIPTION
The "icon-" prefix is automatically added in SettingMenuItem.
Using "icon-placeholder" as suggested would thus result in the CSS class "icon-icon-placeholder".

This is my first time doing a PR, so please let me know if I've messed something up, but this seemed like low hanging fruit. :)