### PR TITLE
Make AdminPageChooser use models instead of ContentTypes

### DIFF
--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -514,31 +514,34 @@ class BasePageChooserPanel(BaseChooserPanel):
             content_type=cls.target_content_type(), can_choose_root=cls.can_choose_root)}
 
     @classmethod
+    def target_models(cls):
+        if cls.page_type:
+            target_models = []
+
+            for page_type in cls.page_type:
+                try:
+                    target_models.append(resolve_model_string(page_type))
+                except LookupError:
+                    raise ImproperlyConfigured(
+                        "{0}.page_type must be of the form 'app_label.model_name', given {1!r}".format(
+                            cls.__name__, page_type
+                        )
+                    )
+                except ValueError:
+                    raise ImproperlyConfigured(
+                        "{0}.page_type refers to model {1!r} that has not been installed".format(
+                            cls.__name__, page_type
+                        )
+                    )
+
+            return target_models
+        else:
+            return [cls.model._meta.get_field(cls.field_name).rel.to]
+
+    @classmethod
     def target_content_type(cls):
         if cls._target_content_type is None:
-            if cls.page_type:
-                target_models = []
-
-                for page_type in cls.page_type:
-                    try:
-                        target_models.append(resolve_model_string(page_type))
-                    except LookupError:
-                        raise ImproperlyConfigured(
-                            "{0}.page_type must be of the form 'app_label.model_name', given {1!r}".format(
-                                cls.__name__, page_type
-                            )
-                        )
-                    except ValueError:
-                        raise ImproperlyConfigured(
-                            "{0}.page_type refers to model {1!r} that has not been installed".format(
-                                cls.__name__, page_type
-                            )
-                        )
-
-                cls._target_content_type = list(ContentType.objects.get_for_models(*target_models).values())
-            else:
-                target_model = cls.model._meta.get_field(cls.field_name).rel.to
-                cls._target_content_type = [ContentType.objects.get_for_model(target_model)]
+            cls._target_content_type = list(ContentType.objects.get_for_models(*cls.target_models()).values())
 
         return cls._target_content_type
 

--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -511,7 +511,7 @@ class BasePageChooserPanel(BaseChooserPanel):
     @classmethod
     def widget_overrides(cls):
         return {cls.field_name: widgets.AdminPageChooser(
-            content_type=cls.target_content_type(), can_choose_root=cls.can_choose_root)}
+            models=cls.target_models(), can_choose_root=cls.can_choose_root)}
 
     @classmethod
     def target_models(cls):


### PR DESCRIPTION
This removes the need to have to perform a query in order to initialise an AdminPageChooser object

Fixes #2433