### PR TITLE
Remove TagSearchable class

### DIFF
--- a/wagtail/wagtailadmin/taggable.py
+++ b/wagtail/wagtailadmin/taggable.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
+import warnings
+
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count
 from taggit.models import Tag
 
-from wagtail.utils.deprecation import SearchFieldsShouldBeAList
+from wagtail.utils.deprecation import RemovedInWagtail17Warning, SearchFieldsShouldBeAList
 from wagtail.wagtailsearch import index
 
 
@@ -33,3 +35,6 @@ class TagSearchable(index.Indexed):
         ).annotate(
             item_count=Count('taggit_taggeditem_items')
         ).order_by('-item_count')[:10]
+
+
+warnings.warn("The wagtail.wagtailadmin.taggable module is deprecated.", category=RemovedInWagtail17Warning)


### PR DESCRIPTION
We've been slowly chipping away at this class over the last few releases. It now only contains a bit of search configuration for fields it doesn't even have and a "popular_tags" class method.

I think it's much neater to just define those things on the image and document models.