### PR TITLE
Do not use ContentTypes in PageChooserPanel 

### DIFF
--- a/wagtail/tests/test_utils.py
+++ b/wagtail/tests/test_utils.py
@@ -11,6 +11,8 @@ from wagtail.utils.deprecation import RemovedInWagtail17Warning, SearchFieldsSho
 class TestThisShouldBeAList(SimpleTestCase):
     def test_add_a_list(self):
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+
             base = SearchFieldsShouldBeAList(['hello'])
             result = base + ['world']
 
@@ -23,6 +25,8 @@ class TestThisShouldBeAList(SimpleTestCase):
 
     def test_add_a_tuple(self):
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+
             base = SearchFieldsShouldBeAList(['hello'])
             result = base + ('world',)
 

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import warnings
 from datetime import date
 
 import mock
@@ -12,6 +13,7 @@ from wagtail.tests.testapp.forms import ValidatedPageForm
 from wagtail.tests.testapp.models import (
     EventPage, EventPageChooserModel, EventPageSpeaker, PageChooserModel, SimplePage, ValidatedPage)
 from wagtail.tests.utils import WagtailTestUtils
+from wagtail.utils.deprecation import RemovedInWagtail17Warning
 from wagtail.wagtailadmin.edit_handlers import (
     FieldPanel, InlinePanel, ObjectList, PageChooserPanel, RichTextFieldPanel, TabbedInterface,
     extract_panel_definitions_from_model_class, get_form_for_model)
@@ -528,28 +530,68 @@ class TestPageChooserPanel(TestCase):
 
         self.assertIn(expected_js, result)
 
-    def test_target_content_type(self):
+    def test_target_models(self):
         result = PageChooserPanel(
             'barbecue',
             'wagtailcore.site'
-        ).bind_to_model(PageChooserModel).target_content_type()[0]
-        self.assertEqual(result.name, 'site')
+        ).bind_to_model(PageChooserModel).target_models()
+        self.assertEqual(result, [Site])
 
-    def test_target_content_type_malformed_type(self):
+    def test_target_models_malformed_type(self):
         result = PageChooserPanel(
             'barbecue',
             'snowman'
         ).bind_to_model(PageChooserModel)
         self.assertRaises(ImproperlyConfigured,
-                          result.target_content_type)
+                          result.target_models)
 
-    def test_target_content_type_nonexistent_type(self):
+    def test_target_models_nonexistent_type(self):
         result = PageChooserPanel(
             'barbecue',
             'snowman.lorry'
         ).bind_to_model(PageChooserModel)
         self.assertRaises(ImproperlyConfigured,
-                          result.target_content_type)
+                          result.target_models)
+
+    def test_target_content_type(self):
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
+
+            result = PageChooserPanel(
+                'barbecue',
+                'wagtailcore.site'
+            ).bind_to_model(PageChooserModel).target_content_type()[0]
+            self.assertEqual(result.name, 'site')
+
+            self.assertEqual(len(ws), 1)
+            self.assertIs(ws[0].category, RemovedInWagtail17Warning)
+
+    def test_target_content_type_malformed_type(self):
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
+
+            result = PageChooserPanel(
+                'barbecue',
+                'snowman'
+            ).bind_to_model(PageChooserModel)
+            self.assertRaises(ImproperlyConfigured,
+                              result.target_content_type)
+
+            self.assertEqual(len(ws), 1)
+            self.assertIs(ws[0].category, RemovedInWagtail17Warning)
+
+    def test_target_content_type_nonexistent_type(self):
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
+
+            result = PageChooserPanel(
+                'barbecue',
+                'snowman.lorry'
+            ).bind_to_model(PageChooserModel)
+            self.assertRaises(ImproperlyConfigured,
+                              result.target_content_type)
+            self.assertEqual(len(ws), 1)
+            self.assertIs(ws[0].category, RemovedInWagtail17Warning)
 
 
 class TestInlinePanel(TestCase, WagtailTestUtils):

--- a/wagtail/wagtailadmin/tests/test_widgets.py
+++ b/wagtail/wagtailadmin/tests/test_widgets.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
+import warnings
+
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
 from wagtail.tests.testapp.models import EventPage, SimplePage
+from wagtail.utils.deprecation import RemovedInWagtail17Warning
 from wagtail.wagtailadmin import widgets
 from wagtail.wagtailcore.models import Page
 
@@ -52,25 +55,44 @@ class TestAdminPageChooserWidget(TestCase):
     # def test_render_html_init_with_content_type omitted as HTML does not
     # change when selecting a content type
 
-    def test_render_js_init_with_content_type(self):
-        content_type = ContentType.objects.get_for_model(SimplePage)
-        widget = widgets.AdminPageChooser(content_type=content_type)
+    def test_render_js_init_with_target_model(self):
+        widget = widgets.AdminPageChooser(target_models=[SimplePage])
 
         js_init = widget.render_js_init('test-id', 'test', None)
         self.assertEqual(js_init, "createPageChooser(\"test-id\", [\"tests.simplepage\"], null, false);")
 
-    def test_render_js_init_with_multiple_content_types(self):
-        content_types = [
-            # Not using get_for_models as we need deterministic ordering
-            ContentType.objects.get_for_model(SimplePage),
-            ContentType.objects.get_for_model(EventPage),
-        ]
-        widget = widgets.AdminPageChooser(content_type=content_types)
+    def test_render_js_init_with_multiple_target_models(self):
+        target_models = [SimplePage, EventPage]
+        widget = widgets.AdminPageChooser(target_models=target_models)
 
         js_init = widget.render_js_init('test-id', 'test', None)
         self.assertEqual(
             js_init, "createPageChooser(\"test-id\", [\"tests.simplepage\", \"tests.eventpage\"], null, false);"
         )
+
+    def test_render_js_init_with_content_type(self):
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
+            content_type = ContentType.objects.get_for_model(SimplePage)
+            widget = widgets.AdminPageChooser(content_type=content_type)
+
+            self.assertEqual(len(ws), 1)
+            self.assertIs(ws[0].category, RemovedInWagtail17Warning)
+        self.assertEqual(widget.target_models, [SimplePage])
+
+    def test_render_js_init_with_multiple_content_types(self):
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
+            content_types = [
+                # Not using get_for_models as we need deterministic ordering
+                ContentType.objects.get_for_model(SimplePage),
+                ContentType.objects.get_for_model(EventPage),
+            ]
+            widget = widgets.AdminPageChooser(content_type=content_types)
+
+            self.assertEqual(len(ws), 1)
+            self.assertIs(ws[0].category, RemovedInWagtail17Warning)
+        self.assertEqual(widget.target_models, [SimplePage, EventPage])
 
     def test_render_js_init_with_can_choose_root(self):
         widget = widgets.AdminPageChooser(can_choose_root=True)


### PR DESCRIPTION
Using ContentTypes can lead to the awkward case where they are used before the database is migrated, leading to errors on start up. Removing ContentTypes and using plain Model classes instead makes this impossible, and also makes the code clearer.

Fixes #2433