### PR TITLE
Add a title to explorer actions

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
@@ -1,5 +1,5 @@
 <div {{ self.attrs }} class="c-dropdown  {% if is_parent %}t-inverted{% else %}t-default{% endif %}" data-dropdown>
-    <a href="#" class="c-dropdown__button  u-btn-current">
+    <a href="#" title="{{ title }}" class="c-dropdown__button  u-btn-current">
         {{ label }}
         <div data-dropdown-toggle class="o-icon  c-dropdown__toggle  [ icon icon-arrow-down ]"></div>
     </a>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
@@ -7,7 +7,7 @@
         <ul role="menu" class="c-dropdown__menu  u-toggle  u-arrow u-arrow--tl u-background">
         {% for button in buttons %}
             <li class="c-dropdown__item ">
-                <a href="{{ button.url }}" class="u-link is-live {{ button.classes|join:' ' }}">
+                <a href="{{ button.url }}" title="{{ button.attrs.title }}" class="u-link is-live {{ button.classes|join:' ' }}">
                     {{ button.label }}
                 </a>
             </li>

--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -69,13 +69,14 @@ def page_listing_buttons(page, page_perms, is_parent=False):
         yield PageListingButton(_('Draft'), reverse('wagtailadmin_pages:view_draft', args=[page.id]),
                                 attrs={'title': _('Preview draft'), 'target': '_blank'}, priority=20)
     if page.live and page.url:
-        yield PageListingButton(_('Live'), page.url, attrs={'target': "_blank", 'title': 'View live'}, priority=30)
+        yield PageListingButton(_('Live'), page.url, attrs={'target': "_blank", 'title': _('View live')}, priority=30)
     if page_perms.can_add_subpage():
         if is_parent:
             yield Button(_('Add child page'), reverse('wagtailadmin_pages:add_subpage', args=[page.id]),
-                         classes={'button', 'button-small', 'bicolor', 'icon', 'white', 'icon-plus'}, priority=40)
+                         attrs={'title': _("Add a child page to '{0}' ".format(page.title))}, classes={'button', 'button-small', 'bicolor', 'icon', 'white', 'icon-plus'}, priority=40)
         else:
-            yield PageListingButton(_('Add child page'), reverse('wagtailadmin_pages:add_subpage', args=[page.id]), priority=40)
+            yield PageListingButton(_('Add child page'), reverse('wagtailadmin_pages:add_subpage', args=[page.id]),
+                                    attrs={'title': _("Add a child page to '{0}' ".format(page.title))}, priority=40)
 
     yield ButtonWithDropdownFromHook(
         _('More'),
@@ -83,20 +84,20 @@ def page_listing_buttons(page, page_perms, is_parent=False):
         page=page,
         page_perms=page_perms,
         is_parent=is_parent,
-        attrs={'target': '_blank', 'title': 'View more options'}, priority=50)
+        attrs={'target': '_blank', 'title': _('View more options')}, priority=50)
 
 
 @hooks.register('register_page_listing_more_buttons')
 def page_listing_more_buttons(page, page_perms, is_parent=False):
     if page_perms.can_move():
         yield Button(_('Move'), reverse('wagtailadmin_pages:move', args=[page.id]),
-                     attrs={"title": 'Move this page'}, priority=10)
+                     attrs={"title": _('Move this page')}, priority=10)
     if not page.is_root():
         yield Button(_('Copy'), reverse('wagtailadmin_pages:copy', args=[page.id]),
-                     attrs={'title': 'Copy this page'}, priority=20)
+                     attrs={'title': _('Copy this page')}, priority=20)
     if page_perms.can_delete():
         yield Button(_('Delete'), reverse('wagtailadmin_pages:delete', args=[page.id]),
-                     attrs={'title': 'Delete this page'}, priority=30)
+                     attrs={'title': _('Delete this page')}, priority=30)
     if page_perms.can_unpublish():
         yield Button(_('Unpublish'), reverse('wagtailadmin_pages:unpublish', args=[page.id]),
-                     attrs={'title': 'Unpublish this page'}, priority=40)
+                     attrs={'title': _('Unpublish this page')}, priority=40)

--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -5,7 +5,6 @@ from django.contrib.auth.models import Permission
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
-
 from wagtail.wagtailadmin.menu import MenuItem, SubmenuMenuItem, settings_menu
 from wagtail.wagtailadmin.search import SearchArea
 from wagtail.wagtailadmin.widgets import Button, ButtonWithDropdownFromHook, PageListingButton
@@ -68,7 +67,7 @@ def page_listing_buttons(page, page_perms, is_parent=False):
                                 attrs={'title': _('Edit this page')}, priority=10)
     if page.has_unpublished_changes:
         yield PageListingButton(_('Draft'), reverse('wagtailadmin_pages:view_draft', args=[page.id]),
-                                attrs={'target': '_blank'}, priority=20)
+                                attrs={'title': _('Preview draft'), 'target': '_blank'}, priority=20)
     if page.live and page.url:
         yield PageListingButton(_('Live'), page.url, attrs={'target': "_blank"}, priority=30)
     if page_perms.can_add_subpage():

--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -83,7 +83,7 @@ def page_listing_buttons(page, page_perms, is_parent=False):
         page=page,
         page_perms=page_perms,
         is_parent=is_parent,
-        attrs={'target': '_blank'}, priority=50)
+        attrs={'target': '_blank', 'title': 'View more options'}, priority=50)
 
 
 @hooks.register('register_page_listing_more_buttons')

--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -69,7 +69,7 @@ def page_listing_buttons(page, page_perms, is_parent=False):
         yield PageListingButton(_('Draft'), reverse('wagtailadmin_pages:view_draft', args=[page.id]),
                                 attrs={'title': _('Preview draft'), 'target': '_blank'}, priority=20)
     if page.live and page.url:
-        yield PageListingButton(_('Live'), page.url, attrs={'target': "_blank"}, priority=30)
+        yield PageListingButton(_('Live'), page.url, attrs={'target': "_blank", 'title': 'View live'}, priority=30)
     if page_perms.can_add_subpage():
         if is_parent:
             yield Button(_('Add child page'), reverse('wagtailadmin_pages:add_subpage', args=[page.id]),
@@ -89,10 +89,14 @@ def page_listing_buttons(page, page_perms, is_parent=False):
 @hooks.register('register_page_listing_more_buttons')
 def page_listing_more_buttons(page, page_perms, is_parent=False):
     if page_perms.can_move():
-        yield Button(_('Move'), reverse('wagtailadmin_pages:move', args=[page.id]), priority=10)
+        yield Button(_('Move'), reverse('wagtailadmin_pages:move', args=[page.id]),
+                     attrs={"title": 'Move this page'}, priority=10)
     if not page.is_root():
-        yield Button(_('Copy'), reverse('wagtailadmin_pages:copy', args=[page.id]), priority=20)
+        yield Button(_('Copy'), reverse('wagtailadmin_pages:copy', args=[page.id]),
+                     attrs={'title': 'Copy this page'}, priority=20)
     if page_perms.can_delete():
-        yield Button(_('Delete'), reverse('wagtailadmin_pages:delete', args=[page.id]), priority=30)
+        yield Button(_('Delete'), reverse('wagtailadmin_pages:delete', args=[page.id]),
+                     attrs={'title': 'Delete this page'}, priority=30)
     if page_perms.can_unpublish():
-        yield Button(_('Unpublish'), reverse('wagtailadmin_pages:unpublish', args=[page.id]), priority=40)
+        yield Button(_('Unpublish'), reverse('wagtailadmin_pages:unpublish', args=[page.id]),
+                     attrs={'title': 'Unpublish this page'}, priority=40)

--- a/wagtail/wagtailadmin/widgets.py
+++ b/wagtail/wagtailadmin/widgets.py
@@ -243,9 +243,14 @@ class BaseDropdownMenuButton(Button):
         raise NotImplementedError
 
     def render(self):
+        if 'title' in self.attrs:
+            title = self.attrs['title']
+        else:
+            title = None
         return render_to_string(self.template_name, {
             'buttons': self.get_buttons_in_dropdown(),
             'label': self.label,
+            'title': title,
             'is_parent': self.is_parent})
 
 


### PR DESCRIPTION
Currently the actions on the explorer menu are short verbs and do not actually describe what the buttons do. Adding a title to these should assist in letting the user know what each button does. Currently one would expect the 'Draft' button would create a draft, having a title on it will explain to the user in a more verbose way what the button actually does (In this case, preview the draft). 

Currently we have a button with the label 'Add a child page'  which describes what the button does, while we also have  'Edit', 'Draft' etc which are short verbs. I'm not sure whether we should be using short verbs as labels, or whether the labels should describe what they do, or a mixture of both. Perhaps we could remove the 'Add child page' in favour of the already existing plus icon to the right of the page status.

cc @davecranwell @mazil