### PR TITLE
Improve L10N and I18N for revisions list.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
  * Use `PasswordChangeForm` when user changes their password, requiring the user to enter their current password (Matthijs Melissen)
  * Highlight current day in date picker (Jonas Lergell)
  * Fix: The currently selected day is now highlighted only in the correct month in date pickers (Jonas Lergell)
+ * Improved L10N and I18N for revisions list. (Roel Bruggink)
 
 
 1.4.2 (xx.xx.2016)

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/revisions/list.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/revisions/list.html
@@ -1,11 +1,12 @@
 {% load i18n wagtailadmin_tags gravatar %}
+{% load l10n %}
 
 <table class="listing">
     <col width="100%" />
 
     <thead>
         <tr>
-            <th><a href="{% url 'wagtailadmin_pages:revisions_index' page.id %}?ordering={% if ordering == "created_at" %}-{% endif %}created_at" class="icon icon-arrow-{% if ordering == "created_at" %}up-after{% elif ordering == "-created_at" %}down-after{% else %}down-after{% endif %} {% if ordering == "created_at" or ordering == "-created_at" %}teal{% endif %}">Revision date</a></th>
+            <th><a href="{% url 'wagtailadmin_pages:revisions_index' page.id %}?ordering={% if ordering == "created_at" %}-{% endif %}created_at" class="icon icon-arrow-{% if ordering == "created_at" %}up-after{% elif ordering == "-created_at" %}down-after{% else %}down-after{% endif %} {% if ordering == "created_at" or ordering == "-created_at" %}teal{% endif %}">{% trans 'Revision date' %}</a></th>
         </tr>
     </thead>
     <tbody>
@@ -13,7 +14,7 @@
             {% for revision in revisions %}
                 <tr {% if revision == page.get_latest_revision %}class="index"{% endif %}>
                     <td class="title">
-                        <h2><a href="{% url 'wagtailadmin_pages:revisions_revert' page.id revision.id %}">{{ revision.created_at|date:"d M Y H:i" }}</a> <span class="unbold">by<span class="avatar small icon icon-user"><img src="{% gravatar_url revision.user.email 25 %}" /></span>{{ revision.user }}</span> {% if revision == page.get_latest_revision %}({% trans 'Current draft' %}){% endif %}</h2>
+                        <h2><a href="{% url 'wagtailadmin_pages:revisions_revert' page.id revision.id %}">{{ revision.created_at }}</a> <span class="unbold">{% trans 'by' %}<span class="avatar small icon icon-user"><img src="{% gravatar_url revision.user.email 25 %}" /></span>{{ revision.user }}</span> {% if revision == page.get_latest_revision %}({% trans 'Current draft' %}){% endif %}</h2>
 
                         <ul class="actions">
                             <li><a href="{% url 'wagtailadmin_pages:revisions_view' page.id revision.id %}" class="button button-small button-secondary" target="_blank">{% trans 'Preview' %}</a></li>
@@ -27,7 +28,7 @@
                 </tr>
             {% endfor %}
         {% else %}
-            {% block no_results %}<tr><td class="no-results-message"><p>No revisions of this page exist</p></td></tr>{% endblock %}
+            {% block no_results %}<tr><td class="no-results-message"><p>{% trans 'No revisions of this page exist' %}</p></td></tr>{% endblock %}
         {% endif %}
     </tbody>
 </table>


### PR DESCRIPTION
Replaces #2412.

The {% trans 'by' %} is highly debatable, as it is context dependent.
ie "This is done by Jos Henken" vs "Jos Henken should hit with a 2 by 4."

I've removed the date formatting for the non-English :)