### PR TITLE
PageChooserBlock supports limiting of page type

### DIFF
--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -383,19 +383,22 @@ class ChooserBlock(FieldBlock):
 
 
 class PageChooserBlock(ChooserBlock):
+    from wagtail.wagtailcore.models import Page
+    page_model = Page
+
     def __init__(self, can_choose_root=False, **kwargs):
         self.can_choose_root = can_choose_root
         super(PageChooserBlock, self).__init__(**kwargs)
 
     @cached_property
     def target_model(self):
-        from wagtail.wagtailcore.models import Page  # TODO: allow limiting to specific page types
-        return Page
+        return self.page_model
 
     @cached_property
     def widget(self):
         from wagtail.wagtailadmin.widgets import AdminPageChooser
-        return AdminPageChooser(can_choose_root=self.can_choose_root)
+        ct = ContentType.objects.get_for_model(self.page_model)
+        return AdminPageChooser(content_type=ct, can_choose_root=self.can_choose_root)
 
     def render_basic(self, value):
         if value:


### PR DESCRIPTION
Fixed the TODO "allow limiting to specific page types" by adding a class attribute `page_model`