### PR TITLE
PageChooserBlock supports limiting of page type

### DIFF
--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import datetime
 
 from django import forms
+from django.contrib.contenttypes.models import ContentType
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.template.loader import render_to_string
 from django.utils import six
@@ -383,18 +384,22 @@ class ChooserBlock(FieldBlock):
 
 
 class PageChooserBlock(ChooserBlock):
+    from wagtail.wagtailcore.models import Page
+    page_model = Page
+
     def __init__(self, can_choose_root=False, **kwargs):
         self.can_choose_root = can_choose_root
         super(PageChooserBlock, self).__init__(**kwargs)
 
     @cached_property
     def target_model(self):
-        from wagtail.wagtailcore.models import Page  # TODO: allow limiting to specific page types
-        return Page
+        return self.page_model
 
     @cached_property
     def widget(self):
         from wagtail.wagtailadmin.widgets import AdminPageChooser
+        ct = ContentType.objects.get_for_model(self.page_model)
+        return AdminPageChooser(content_type=ct, can_choose_root=self.can_choose_root)
         return AdminPageChooser(can_choose_root=self.can_choose_root)
 
     def render_basic(self, value):


### PR DESCRIPTION
Fixed the TODO "allow limiting to specific page types" by adding a class attribute `page_model`