### PR TITLE
Fix incorrect bases for Meta classes on multi-inherited Blocks

### DIFF
--- a/wagtail/wagtailcore/blocks/base.py
+++ b/wagtail/wagtailcore/blocks/base.py
@@ -17,8 +17,6 @@ from django.utils.text import capfirst
 # calls force_text, which would cause it to lose its 'safe' flag
 
 
-
-
 __all__ = ['BaseBlock', 'Block', 'BoundBlock', 'DeclarativeSubBlocksMetaclass', 'BlockWidget', 'BlockField']
 
 
@@ -33,9 +31,11 @@ class BaseBlock(type):
 
         cls = super(BaseBlock, mcs).__new__(mcs, name, bases, attrs)
 
-        base_meta_class = getattr(cls, '_meta_class', None)
-        bases = tuple(cls for cls in [meta_class, base_meta_class] if cls) or ()
-        cls._meta_class = type(str(name + 'Meta'), bases + (object, ), {})
+        # Get all the Meta classes from all the bases
+        meta_class_bases = [meta_class] + [getattr(base, '_meta_class', None)
+                                           for base in bases]
+        meta_class_bases = tuple(filter(bool, meta_class_bases))
+        cls._meta_class = type(str(name + 'Meta'), meta_class_bases, {})
 
         return cls
 
@@ -46,7 +46,7 @@ class Block(six.with_metaclass(BaseBlock, object)):
 
     TEMPLATE_VAR = 'value'
 
-    class Meta:
+    class Meta(object):
         label = None
         icon = "placeholder"
         classname = None

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -452,7 +452,10 @@ class TestMeta(unittest.TestCase):
         block = HeadingBlock(template='subheading.html')
         self.assertEqual(block.meta.template, 'subheading.html')
 
-    def test_meta_multiple_inheritance(self):
+    def test_meta_nested_inheritance(self):
+        """
+        Check that having a multi-level inheritance chain works
+        """
         class HeadingBlock(blocks.CharBlock):
             class Meta:
                 template = 'heading.html'
@@ -465,6 +468,39 @@ class TestMeta(unittest.TestCase):
         block = SubHeadingBlock()
         self.assertEqual(block.meta.template, 'subheading.html')
         self.assertEqual(block.meta.test, 'Foo')
+
+    def test_meta_multi_inheritance(self):
+        """
+        Check that multi-inheritance and Meta classes work together
+        """
+        class LeftBlock(blocks.CharBlock):
+            class Meta:
+                template = 'template.html'
+                clash = 'the band'
+                label = 'Left block'
+
+        class RightBlock(blocks.CharBlock):
+            class Meta:
+                default = 'hello'
+                clash = 'the album'
+                label = 'Right block'
+
+        class ChildBlock(LeftBlock, RightBlock):
+            class Meta:
+                label = 'Child block'
+
+        block = ChildBlock()
+        # These should be directly inherited from the LeftBlock/RightBlock
+        self.assertEqual(block.meta.template, 'template.html')
+        self.assertEqual(block.meta.default, 'hello')
+
+        # This should be inherited from the LeftBlock, solving the collision,
+        # as LeftBlock comes first
+        self.assertEqual(block.meta.clash, 'the band')
+
+        # This should come from ChildBlock itself, ignoring the label on
+        # LeftBlock/RightBlock
+        self.assertEqual(block.meta.label, 'Child block')
 
 
 class TestStructBlock(SimpleTestCase):


### PR DESCRIPTION
Constructing the `Meta` class for a Block did not properly take in to account multi-inheritance, looking only at the left-most parent class for a `_meta_class` to inherit from. This PR fixes this by constructing a `Meta` class that takes in to account all of the base classes of the Block.