### PR TITLE
image serve view refactor for better DRY override

### DIFF
--- a/docs/advanced_topics/images/image_serve_view.rst
+++ b/docs/advanced_topics/images/image_serve_view.rst
@@ -94,3 +94,46 @@ method in your urls configuration:
 
        url(r'^images/([^/]*)/(\d*)/([^/]*)/[^/]*$', ServeView.as_view(action='redirect'), name='wagtailimages_serve'),
    ]
+
+Sendfile integration
+====================
+
+To serve files with the Django application `sendfile`_, you can use the view
+``SendFileView``. For more details about using the sendfile app, please read its
+documentation.
+
+.. _sendfile: https://github.com/johnsensible/django-sendfile
+
+This view can be used out of the box:
+
+.. code-block:: python
+
+   from wagtail.wagtailimages.views.serve import SendFileView
+
+   urlpatterns = [
+       ...
+
+       url(r'^images/([^/]*)/(\d*)/([^/]*)/[^/]*$', SendFileView.as_view(), name='wagtailimages_serve'),
+   ]
+
+
+You can inherit it to override the backend defined in the ``SENDFILE_BACKEND``
+setting :
+
+.. code-block:: python
+
+    from wagtail.wagtailimages.views.serve import SendFileView
+
+    class MySendFileView(SendFileView):
+        backend = MyCustomBackend
+
+You can also inherit it to serve private files. For example, if the only need
+is to be authenticated (e.g. for Django >= 1.9):
+
+.. code-block:: python
+
+    from django.contrib.auth.mixins import MyPrivateSendFileView
+    from wagtail.wagtailimages.views.serve import SendFileView
+
+    class PrivateSendFileView(LoginRequiredMixin, SendFileView):
+        raise_exception = True

--- a/wagtail/tests/dummy_sendfile_backend.py
+++ b/wagtail/tests/dummy_sendfile_backend.py
@@ -1,0 +1,10 @@
+from __future__ import unicode_literals
+
+from django.http import HttpResponse
+
+
+def sendfile(request, filename, **kwargs):
+    """
+    Dummy sendfile backend implementation.
+    """
+    return HttpResponse('Dummy backend response')

--- a/wagtail/wagtailimages/tests/urls.py
+++ b/wagtail/wagtailimages/tests/urls.py
@@ -2,11 +2,14 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import url
 
-from wagtail.wagtailimages.views.serve import ServeView
+from wagtail.tests import dummy_sendfile_backend
+from wagtail.wagtailimages.views.serve import SendFileView, ServeView
 
 
 urlpatterns = [
     url(r'^actions/serve/(.*)/(\d*)/(.*)/[^/]*', ServeView.as_view(action='serve'), name='wagtailimages_serve_action_serve'),
     url(r'^actions/redirect/(.*)/(\d*)/(.*)/[^/]*', ServeView.as_view(action='redirect'), name='wagtailimages_serve_action_redirect'),
     url(r'^custom_key/(.*)/(\d*)/(.*)/[^/]*', ServeView.as_view(key='custom'), name='wagtailimages_serve_custom_key'),
+    url(r'^sendfile/(.*)/(\d*)/(.*)/[^/]*', SendFileView.as_view(), name='wagtailimages_sendfile'),
+    url(r'^sendfile-dummy/(.*)/(\d*)/(.*)/[^/]*', SendFileView.as_view(backend=dummy_sendfile_backend.sendfile), name='wagtailimages_sendfile_dummy'),
 ]

--- a/wagtail/wagtailimages/views/serve.py
+++ b/wagtail/wagtailimages/views/serve.py
@@ -63,15 +63,18 @@ class ServeView(View):
         except InvalidFilterSpecError:
             return HttpResponse("Invalid filter spec: " + filter_spec, content_type='text/plain', status=400)
 
-        # Serve it
-        if self.action == 'serve':
-            # Open and serve the file
-            rendition.file.open('rb')
-            image_format = imghdr.what(rendition.file)
-            return StreamingHttpResponse(FileWrapper(rendition.file), content_type='image/' + image_format)
-        elif self.action == 'redirect':
-            # Redirect to the file's public location
-            return HttpResponsePermanentRedirect(rendition.url)
+        return getattr(self, self.action)(rendition)
+
+    def serve(self, rendition):
+        # Open and serve the file
+        rendition.file.open('rb')
+        image_format = imghdr.what(rendition.file)
+        return StreamingHttpResponse(FileWrapper(rendition.file),
+                                     content_type='image/' + image_format)
+
+    def redirect(self, rendition):
+        # Redirect to the file's public location
+        return HttpResponsePermanentRedirect(rendition.url)
 
 
 serve = ServeView.as_view()

--- a/wagtail/wagtailimages/views/serve.py
+++ b/wagtail/wagtailimages/views/serve.py
@@ -14,6 +14,7 @@ from django.utils.decorators import classonlymethod
 from django.utils.six import text_type
 from django.views.generic import View
 
+from wagtail.utils.sendfile import sendfile
 from wagtail.wagtailimages.exceptions import InvalidFilterSpecError
 from wagtail.wagtailimages.models import SourceImageIOError, get_image_model
 
@@ -78,3 +79,10 @@ class ServeView(View):
 
 
 serve = ServeView.as_view()
+
+
+class SendFileView(ServeView):
+    backend = None
+
+    def serve(self, rendition):
+        return sendfile(self.request, rendition.file.path, backend=self.backend)


### PR DESCRIPTION
Should not introduce any regression and we could easily override action methods. Concretly, I need it to just override ``serve`` action to use ``sendfile`` method.

BTW, it should be nice if we can also add an another view which inherit from it and just override the ``serve`` method action to use the ``sendfile`` methods (maybe from available wrapper in wagtail (at ``wagtail.utils.sendfile.sendfile``) as a fallback). Anyway, I don't think I'm the only one who's interested? I can also make the pull request once this one would be merged. In fact, it would be just something like : 

````python
class SendFileView(ServeView):
    def serve(self, rendition):
        return sendfile(self.request, rendition.file.path)
````

Thanks for review!