### PR TITLE
Remove redundant debug settings from project template

### DIFF
--- a/wagtail/project_template/project_name/settings/dev.py
+++ b/wagtail/project_template/project_name/settings/dev.py
@@ -5,9 +5,6 @@ from .base import *
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-for template_engine in TEMPLATES:
-    template_engine['OPTIONS']['debug'] = True
-
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '{{ secret_key }}'
 


### PR DESCRIPTION
Fixes #2078.

I've double checked that removing this code leads to the same behaviour as before.