### PR TITLE
Replaces direct usages of Document model

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Changelog
  * Fix: The currently selected day is now highlighted only in the correct month in date pickers (Jonas Lergell)
  * Fix: Fixed crash when an image without a source file was resized with the "dynamic serve view"
  * Fix: Registered settings admin menu items now show active correctly (Matthew Downey)
+ * Fix: Direct usage of ``Document`` model replaced with ``get_document_model`` function in ``wagtail.contrib.wagtailmedusa`` and in ``wagtail.contrib.wagtailapi``
 
 
 1.4.3 (04.04.2016)

--- a/docs/releases/1.5.rst
+++ b/docs/releases/1.5.rst
@@ -43,6 +43,7 @@ Bug fixes
  * The currently selected day is now highlighted only in the correct month in date pickers (Jonas Lergell)
  * Fixed crash when an image without a source file was resized with the "dynamic serve view"
  * Registered settings admin menu items now show active correctly (Matthew Downey)
+ * Direct usage of ``Document`` model replaced with ``get_document_model`` function in ``wagtail.contrib.wagtailmedusa`` and in ``wagtail.contrib.wagtailapi``
 
 
 Upgrade considerations

--- a/wagtail/api/v2/endpoints.py
+++ b/wagtail/api/v2/endpoints.py
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from wagtail.wagtailcore.models import Page
-from wagtail.wagtaildocs.models import Document
+from wagtail.wagtaildocs.models import get_document_model
 from wagtail.wagtailimages.models import get_image_model
 
 from .filters import (
@@ -282,4 +282,4 @@ class DocumentsAPIEndpoint(BaseAPIEndpoint):
     extra_meta_fields = ['tags', ]
     default_fields = ['title', 'tags']
     name = 'documents'
-    model = Document
+    model = get_document_model()

--- a/wagtail/api/v2/signal_handlers.py
+++ b/wagtail/api/v2/signal_handlers.py
@@ -6,7 +6,7 @@ from django.db.models.signals import post_delete, post_save
 from wagtail.contrib.wagtailfrontendcache.utils import purge_url_from_cache
 from wagtail.wagtailcore.models import get_page_models
 from wagtail.wagtailcore.signals import page_published, page_unpublished
-from wagtail.wagtaildocs.models import Document
+from wagtail.wagtaildocs.models import get_document_model
 from wagtail.wagtailimages.models import get_image_model
 
 from .utils import get_base_url
@@ -31,6 +31,7 @@ def purge_document_from_cache(instance, **kwargs):
 
 def register_signal_handlers():
     Image = get_image_model()
+    Document = get_document_model()
 
     for model in get_page_models():
         page_published.connect(purge_page_from_cache, sender=model)
@@ -44,6 +45,7 @@ def register_signal_handlers():
 
 def unregister_signal_handlers():
     Image = get_image_model()
+    Document = get_document_model()
 
     for model in get_page_models():
         page_published.disconnect(purge_page_from_cache, sender=model)

--- a/wagtail/api/v2/tests/test_documents.py
+++ b/wagtail/api/v2/tests/test_documents.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from wagtail.api.v2 import signal_handlers
-from wagtail.wagtaildocs.models import Document
+from wagtail.wagtaildocs.models import get_document_model
 
 
 class TestDocumentListing(TestCase):
@@ -39,7 +39,7 @@ class TestDocumentListing(TestCase):
         # Check that the total count is there and correct
         self.assertIn('total_count', content['meta'])
         self.assertIsInstance(content['meta']['total_count'], int)
-        self.assertEqual(content['meta']['total_count'], Document.objects.count())
+        self.assertEqual(content['meta']['total_count'], get_document_model().objects.count())
 
         # Check that the items section is there
         self.assertIn('items', content)
@@ -118,7 +118,7 @@ class TestDocumentListing(TestCase):
         self.assertEqual(document_id_list, [10])
 
     def test_filtering_tags(self):
-        Document.objects.get(id=3).tags.add('test')
+        get_document_model().objects.get(id=3).tags.add('test')
 
         response = self.get_response(tags='test')
         content = json.loads(response.content.decode('UTF-8'))
@@ -196,7 +196,7 @@ class TestDocumentListing(TestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         # The total count must not be affected by "limit"
-        self.assertEqual(content['meta']['total_count'], Document.objects.count())
+        self.assertEqual(content['meta']['total_count'], get_document_model().objects.count())
 
     def test_limit_not_integer_gives_error(self):
         response = self.get_response(limit='abc')
@@ -249,7 +249,7 @@ class TestDocumentListing(TestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         # The total count must not be affected by "offset"
-        self.assertEqual(content['meta']['total_count'], Document.objects.count())
+        self.assertEqual(content['meta']['total_count'], get_document_model().objects.count())
 
     def test_offset_not_integer_gives_error(self):
         response = self.get_response(offset='abc')
@@ -336,8 +336,8 @@ class TestDocumentDetail(TestCase):
         self.assertEqual(content['meta']['tags'], [])
 
     def test_tags(self):
-        Document.objects.get(id=1).tags.add('hello')
-        Document.objects.get(id=1).tags.add('world')
+        get_document_model().objects.get(id=1).tags.add('hello')
+        get_document_model().objects.get(id=1).tags.add('world')
 
         response = self.get_response(1)
         content = json.loads(response.content.decode('UTF-8'))
@@ -378,11 +378,11 @@ class TestDocumentCacheInvalidation(TestCase):
         signal_handlers.unregister_signal_handlers()
 
     def test_resave_document_purges(self, purge):
-        Document.objects.get(id=5).save()
+        get_document_model().objects.get(id=5).save()
 
         purge.assert_any_call('http://api.example.com/api/v2beta/documents/5/')
 
     def test_delete_document_purges(self, purge):
-        Document.objects.get(id=5).delete()
+        get_document_model().objects.get(id=5).delete()
 
         purge.assert_any_call('http://api.example.com/api/v2beta/documents/5/')

--- a/wagtail/contrib/wagtailapi/endpoints.py
+++ b/wagtail/contrib/wagtailapi/endpoints.py
@@ -12,7 +12,7 @@ from rest_framework.viewsets import GenericViewSet
 
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.utils import resolve_model_string
-from wagtail.wagtaildocs.models import Document
+from wagtail.wagtaildocs.models import get_document_model
 from wagtail.wagtailimages.models import get_image_model
 
 from .filters import ChildOfFilter, DescendantOfFilter, FieldsFilter, OrderingFilter, SearchFilter
@@ -239,4 +239,4 @@ class DocumentsAPIEndpoint(BaseAPIEndpoint):
     filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
     extra_api_fields = ['title', 'tags']
     name = 'documents'
-    model = Document
+    model = get_document_model()

--- a/wagtail/contrib/wagtailapi/signal_handlers.py
+++ b/wagtail/contrib/wagtailapi/signal_handlers.py
@@ -6,7 +6,7 @@ from django.db.models.signals import post_delete, post_save
 from wagtail.contrib.wagtailfrontendcache.utils import purge_url_from_cache
 from wagtail.wagtailcore.models import get_page_models
 from wagtail.wagtailcore.signals import page_published, page_unpublished
-from wagtail.wagtaildocs.models import Document
+from wagtail.wagtaildocs.models import get_document_model
 from wagtail.wagtailimages.models import get_image_model
 
 from .utils import get_base_url
@@ -31,6 +31,7 @@ def purge_document_from_cache(instance, **kwargs):
 
 def register_signal_handlers():
     Image = get_image_model()
+    Document = get_document_model()
 
     for model in get_page_models():
         page_published.connect(purge_page_from_cache, sender=model)
@@ -44,6 +45,7 @@ def register_signal_handlers():
 
 def unregister_signal_handlers():
     Image = get_image_model()
+    Document = get_document_model()
 
     for model in get_page_models():
         page_published.disconnect(purge_page_from_cache, sender=model)

--- a/wagtail/contrib/wagtailapi/tests/test_documents.py
+++ b/wagtail/contrib/wagtailapi/tests/test_documents.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from wagtail.contrib.wagtailapi import signal_handlers
-from wagtail.wagtaildocs.models import Document
+from wagtail.wagtaildocs.models import get_document_model
 
 
 class TestDocumentListing(TestCase):
@@ -39,7 +39,7 @@ class TestDocumentListing(TestCase):
         # Check that the total count is there and correct
         self.assertIn('total_count', content['meta'])
         self.assertIsInstance(content['meta']['total_count'], int)
-        self.assertEqual(content['meta']['total_count'], Document.objects.count())
+        self.assertEqual(content['meta']['total_count'], get_document_model().objects.count())
 
         # Check that the documents section is there
         self.assertIn('documents', content)
@@ -113,7 +113,7 @@ class TestDocumentListing(TestCase):
         self.assertEqual(document_id_list, [10])
 
     def test_filtering_tags(self):
-        Document.objects.get(id=3).tags.add('test')
+        get_document_model().objects.get(id=3).tags.add('test')
 
         response = self.get_response(tags='test')
         content = json.loads(response.content.decode('UTF-8'))
@@ -191,7 +191,7 @@ class TestDocumentListing(TestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         # The total count must not be affected by "limit"
-        self.assertEqual(content['meta']['total_count'], Document.objects.count())
+        self.assertEqual(content['meta']['total_count'], get_document_model().objects.count())
 
     def test_limit_not_integer_gives_error(self):
         response = self.get_response(limit='abc')
@@ -244,7 +244,7 @@ class TestDocumentListing(TestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         # The total count must not be affected by "offset"
-        self.assertEqual(content['meta']['total_count'], Document.objects.count())
+        self.assertEqual(content['meta']['total_count'], get_document_model().objects.count())
 
     def test_offset_not_integer_gives_error(self):
         response = self.get_response(offset='abc')
@@ -331,8 +331,8 @@ class TestDocumentDetail(TestCase):
         self.assertEqual(content['tags'], [])
 
     def test_tags(self):
-        Document.objects.get(id=1).tags.add('hello')
-        Document.objects.get(id=1).tags.add('world')
+        get_document_model().objects.get(id=1).tags.add('hello')
+        get_document_model().objects.get(id=1).tags.add('world')
 
         response = self.get_response(1)
         content = json.loads(response.content.decode('UTF-8'))
@@ -375,11 +375,11 @@ class TestDocumentCacheInvalidation(TestCase):
         signal_handlers.unregister_signal_handlers()
 
     def test_resave_document_purges(self, purge):
-        Document.objects.get(id=5).save()
+        get_document_model().objects.get(id=5).save()
 
         purge.assert_any_call('http://api.example.com/api/v1/documents/5/')
 
     def test_delete_document_purges(self, purge):
-        Document.objects.get(id=5).delete()
+        get_document_model().objects.get(id=5).delete()
 
         purge.assert_any_call('http://api.example.com/api/v1/documents/5/')

--- a/wagtail/contrib/wagtailmedusa/renderers.py
+++ b/wagtail/contrib/wagtailmedusa/renderers.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django_medusa.renderers import StaticSiteRenderer
 from wagtail.wagtailcore.models import Site
-from wagtail.wagtaildocs.models import Document
+from wagtail.wagtaildocs.models import get_document_model
 
 
 class PageRenderer(StaticSiteRenderer):
@@ -19,6 +19,8 @@ class PageRenderer(StaticSiteRenderer):
 
 class DocumentRenderer(StaticSiteRenderer):
     def get_paths(self):
+        Document = get_document_model()
+
         # Return list of paths to documents
         return (doc.url for doc in Document.objects.all())
 


### PR DESCRIPTION
We need to use `get_document_model` instead of `Document` directly because Wagtail provides ability to define custom document model.

Fixes #2460