### PR TITLE
Changes messages in empty list of images\documents

### DIFF
--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/results.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/results.html
@@ -21,7 +21,7 @@
          
          {% search_other %}
     {% else %}
-        {% url 'wagtaildocs:add' as wagtaildocs_add_document_url %}
+        {% url 'wagtaildocs:add_multiple' as wagtaildocs_add_document_url %}
         {% if current_collection %}
             <p>{% blocktrans %}You haven't uploaded any documents in this collection. Why not <a href="{{ wagtaildocs_add_document_url }}">upload one now</a>?{% endblocktrans %}</p>
         {% else %}

--- a/wagtail/wagtailimages/templates/wagtailimages/images/results.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/results.html
@@ -36,9 +36,9 @@
     {% else %}
         {% url 'wagtailimages:add_multiple' as wagtailimages_add_image_url %}
         {% if current_collection %}
-            <p>{% blocktrans %}You've not uploaded any images in this collection. Why not <a href="{{ wagtailimages_add_image_url }}">add one now</a>?{% endblocktrans %}</p>
+            <p>{% blocktrans %}You haven't uploaded any images in this collection. Why not <a href="{{ wagtailimages_add_image_url }}">upload one now</a>?{% endblocktrans %}</p>
         {% else %}
-            <p>{% blocktrans %}You've not uploaded any images. Why not <a href="{{ wagtailimages_add_image_url }}">add one now</a>?{% endblocktrans %}</p>
+            <p>{% blocktrans %}You haven't uploaded any images. Why not <a href="{{ wagtailimages_add_image_url }}">upload one now</a>?{% endblocktrans %}</p>
         {% endif %}
     {% endif %}
 {% endif %}


### PR DESCRIPTION
This commit introduces tiny UX improvements for empty lists of images and documents:
 * Same message in both lists
 * Gives link to multiple upload form in both lists