### PR TITLE
Support field widget media inside streamfield blocks

### DIFF
--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -74,6 +74,10 @@ class FieldBlock(Block):
         # the one this block works with natively
         return self.value_from_form(self.field.clean(self.value_for_form(value)))
 
+    @property
+    def media(self):
+        return self.field.widget.media
+
     class Meta:
         # No icon specified here, because that depends on the purpose that the
         # block is being used for. Feel encouraged to specify an icon in your

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -120,6 +120,31 @@ class TestFieldBlock(unittest.TestCase):
         value_from_form = block.value_from_datadict({'title': 'hello world'}, {}, 'title')
         self.assertEqual('hello world', value_from_form)
 
+    def test_widget_media(self):
+        class CalendarWidget(forms.TextInput):
+            @property
+            def media(self):
+                return forms.Media(
+                    css={'all': ('pretty.css',)},
+                    js=('animations.js', 'actions.js')
+                )
+
+        class CalenderBlock(blocks.FieldBlock):
+            def __init__(self, required=True, help_text=None, max_length=None, min_length=None, **kwargs):
+                # Set widget to CalenderWidget
+                self.field = forms.CharField(
+                    required=required,
+                    help_text=help_text,
+                    max_length=max_length,
+                    min_length=min_length,
+                    widget=CalendarWidget(),
+                )
+                super(blocks.FieldBlock, self).__init__(**kwargs)
+
+        block = CalenderBlock()
+        self.assertIn('pretty.css', ''.join(block.all_media().render_css()))
+        self.assertIn('animations.js', ''.join(block.all_media().render_js()))
+
 
 class TestRichTextBlock(TestCase):
     fixtures = ['test.json']


### PR DESCRIPTION
This pull request adds support for using widgets with media in streamfield. This is required for #2416 as the rich text editor's js and css is now added to the widget rather than included globally.