### PR TITLE
Implement jpegquality and outformat image filters

### DIFF
--- a/docs/topics/images.rst
+++ b/docs/topics/images.rst
@@ -203,9 +203,9 @@ Output image format
 
 Wagtail may automatically change the format of some images when they are resized:
 
- - PNG and JPEG images always won't change format
+ - PNG and JPEG images don't change format
  - GIF images without animation are converted to PNGs
- - BMP images are always converted to PNGs
+ - BMP images are converted to PNGs
 
 It is also possible to override the output format on a per-tag basis by using the
 ``format`` filter after the resize rule.
@@ -237,8 +237,15 @@ quality:
     # Make low-quality but small images
     WAGTAILIMAGES_JPEG_QUALITY = 40
 
-Note that this won't affect any previously generated images. You may want to
-delete all renditions so they can regenerate with the new setting.
+Note that this won't affect any previously generated images so you may want to
+delete all renditions so they can regenerate with the new setting. This can be
+done from the Django shell:
+
+.. code-block:: python
+
+    # Replace this with your custom rendition model if you use one
+    >>> from wagtail.wagtailimages.models import Rendition
+    >>> Rendition.objects.all().delete()
 
 Changing per-tag
 ^^^^^^^^^^^^^^^^

--- a/docs/topics/images.rst
+++ b/docs/topics/images.rst
@@ -32,18 +32,18 @@ The available resizing methods are as follows:
 
 .. glossary::
 
-    ``max`` 
+    ``max``
         (takes two dimensions)
 
         .. code-block:: html+django
 
             {% image page.photo max-1000x500 %}
 
-        Fit **within** the given dimensions. 
+        Fit **within** the given dimensions.
 
         The longest edge will be reduced to the matching dimension specified. For example, a portrait image of width 1000 and height 2000, treated with the ``max-1000x500`` rule (a landscape layout) would result in the image being shrunk so the *height* was 500 pixels and the width was 250.
 
-    ``min`` 
+    ``min``
         (takes two dimensions)
 
         .. code-block:: html+django
@@ -54,7 +54,7 @@ The available resizing methods are as follows:
 
         This may result in an image slightly **larger** than the dimensions you specify. A square image of width 2000 and height 2000, treated with the ``min-500x200`` rule would have its height and width changed to 500, i.e matching the *width* of the resize-rule, but greater than the height.
 
-    ``width`` 
+    ``width``
         (takes one dimension)
 
         .. code-block:: html+django
@@ -63,16 +63,16 @@ The available resizing methods are as follows:
 
         Reduces the width of the image to the dimension specified.
 
-    ``height`` 
+    ``height``
         (takes one dimension)
 
         .. code-block:: html+django
 
             {% image page.photo height-480 %}
 
-        Resize the height of the image to the dimension specified.. 
+        Resize the height of the image to the dimension specified..
 
-    ``fill`` 
+    ``fill``
         (takes two dimensions and an optional ``-c`` parameter)
 
         .. code-block:: html+django
@@ -84,9 +84,9 @@ The available resizing methods are as follows:
         This can be particularly useful for websites requiring square thumbnails of arbitrary images. For example, a landscape image of width 2000 and height 1000 treated with the ``fill200x200`` rule would have its height reduced to 200, then its width (ordinarily 400) cropped to 200.
 
         This resize-rule will crop to the image's focal point if it has been set. If not, it will crop to the centre of the image.
-        
+
         **On images that won't upscale**
-        
+
         It's possible to request an image with ``fill`` dimensions that the image can't support without upscaling. e.g. an image of width 400 and height 200 requested with ``fill-400x400``. In this situation the *ratio of the requested fill* will be matched, but the dimension will not. So that example 400x200 image (a 2:1 ratio) could become 200x200 (a 1:1 ratio, matching the resize-rule).
 
         **Cropping closer to the focal point**
@@ -105,7 +105,7 @@ The available resizing methods are as follows:
 
         If you find that ``-c100`` is too close, you can try ``-c75`` or ``-c50``. Any whole number from 0 to 100 is accepted.
 
-    ``original`` 
+    ``original``
         (takes no dimensions)
 
         .. code-block:: html+django
@@ -145,9 +145,9 @@ Wagtail can assign the image data to another variable using Django's ``as`` synt
 
     {% image page.photo width-400 as tmp_photo %}
 
-    <img src="{{ tmp_photo.url }}" width="{{ tmp_photo.width }}" 
+    <img src="{{ tmp_photo.url }}" width="{{ tmp_photo.width }}"
         height="{{ tmp_photo.height }}" alt="{{ tmp_photo.alt }}" class="my-custom-class" />
-        
+
 
 This syntax exposes the underlying image Rendition (``tmp_photo``) to the developer. A "Rendition" contains the information specific to the way you've requested to format the image using the resize-rule, i.e. dimensions and source URL.
 
@@ -158,7 +158,7 @@ Therefore, if you'd added the field ``author`` to your AbstractImage in the abov
 (Due to the links in the database between renditions and their parent image, you *could* access it as ``{{ tmp_photo.image.author }}``, but that has reduced readability.)
 
 
-.. Note::      
+.. Note::
     The image property used for the ``src`` attribute is actually ``image.url``, not ``image.src``.
 
 
@@ -197,3 +197,63 @@ Wagtail comes with three pre-defined image formats, but more can be defined in P
     The CSS classes added to images do **not** come with any accompanying stylesheets, or inline styles. e.g. the ``left`` class will do nothing, by default. The developer is expected to add these classes to their front end CSS files, to define exactly what they want ``left``, ``right`` or ``full-width`` to mean.
 
 For more information about image formats, including creating your own, see :ref:`rich_text_image_formats`
+
+Output image format
+-------------------
+
+Wagtail may automatically change the format of some images when they are resized:
+
+ - PNG and JPEG images always won't change format
+ - GIF images without animation are converted to PNGs
+ - BMP images are always converted to PNGs
+
+It is also possible to override the output format on a per-tag basis by using the
+``format`` filter after the resize rule.
+
+For example, to make the tag always convert the image to a JPEG, use ``format-jpeg``:
+
+.. code-block:: html+Django
+
+    {% image page.photo width-400 format-jpeg %}
+
+You may also use ``format-png`` or ``format-gif``.
+
+JPEG image quality
+------------------
+
+Wagtail's JPEG image quality setting defaults to 85 (which is quite high). This
+can be changed either globally or on a per-tag basis.
+
+Changing globally
+^^^^^^^^^^^^^^^^^
+
+Use the ``WAGTAILIMAGES_JPEG_QUALITY`` setting to change the global default JPEG
+quality:
+
+.. code-block:: python
+
+    # settings.py
+
+    # Make low-quality but small images
+    WAGTAILIMAGES_JPEG_QUALITY = 40
+
+Note that this won't affect any previously generated images. You may want to
+delete all renditions so they can regenerate with the new setting.
+
+Changing per-tag
+^^^^^^^^^^^^^^^^
+
+It's also possible to have different JPEG qualities on individual tags by using
+the ``jpegquality`` filter. This will always override the default setting:
+
+.. code-block:: html+Django
+
+    {% image page.photo width-400 jpegquality-40 %}
+
+Note that this will have no effect on PNG or GIF files. If you want all images
+to be low quality, you can use this filter with ``format-jpeg`` (which forces
+all images to output in JPEG format):
+
+.. code-block:: html+Django
+
+    {% image page.photo width-400 format-jpeg jpegquality-40 %}

--- a/wagtail/wagtailimages/image_operations.py
+++ b/wagtail/wagtailimages/image_operations.py
@@ -216,3 +216,14 @@ class WidthHeightOperation(Operation):
             return
 
         return willow.resize((width, height))
+
+
+class JPEGQualityOperation(Operation):
+    def construct(self, quality):
+        self.quality = int(quality)
+
+        if self.quality > 100:
+            raise ValueError("JPEG quality must not be higher than 100")
+
+    def run(self, willow, image, env):
+        env['jpeg-quality'] = self.quality

--- a/wagtail/wagtailimages/image_operations.py
+++ b/wagtail/wagtailimages/image_operations.py
@@ -26,7 +26,7 @@ class Operation(object):
     def construct(self, *args):
         raise NotImplementedError
 
-    def run(self, willow, image):
+    def run(self, willow, image, env):
         raise NotImplementedError
 
 
@@ -34,7 +34,7 @@ class DoNothingOperation(Operation):
     def construct(self):
         pass
 
-    def run(self, willow, image):
+    def run(self, willow, image, env):
         pass
 
 
@@ -63,7 +63,7 @@ class FillOperation(Operation):
         if self.crop_closeness > 1:
             self.crop_closeness = 1
 
-    def run(self, willow, image):
+    def run(self, willow, image, env):
         image_width, image_height = willow.get_size()
         focal_point = image.get_focal_point()
 
@@ -151,7 +151,7 @@ class MinMaxOperation(Operation):
         self.width = int(width_str)
         self.height = int(height_str)
 
-    def run(self, willow, image):
+    def run(self, willow, image, env):
         image_width, image_height = willow.get_size()
 
         horz_scale = self.width / image_width
@@ -190,7 +190,7 @@ class WidthHeightOperation(Operation):
     def construct(self, size):
         self.size = int(size)
 
-    def run(self, willow, image):
+    def run(self, willow, image, env):
         image_width, image_height = willow.get_size()
 
         if self.method == 'width':

--- a/wagtail/wagtailimages/image_operations.py
+++ b/wagtail/wagtailimages/image_operations.py
@@ -227,3 +227,14 @@ class JPEGQualityOperation(Operation):
 
     def run(self, willow, image, env):
         env['jpeg-quality'] = self.quality
+
+
+class FormatOperation(Operation):
+    def construct(self, fmt):
+        self.format = fmt
+
+        if self.format not in ['jpeg', 'png', 'gif']:
+            raise ValueError("Format must be either 'jpeg', 'png' or 'gif'")
+
+    def run(self, willow, image, env):
+        env['output-format'] = self.format

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -404,8 +404,9 @@ class Filter(models.Model):
             # Fix orientation of image
             willow = willow.auto_orient()
 
+            env = {}
             for operation in self.operations:
-                willow = operation.run(willow, image) or willow
+                willow = operation.run(willow, image, env) or willow
 
             if original_format == 'jpeg':
                 # Allow changing of JPEG compression quality

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -410,8 +410,7 @@ class Filter(models.Model):
                 'original-format': original_format,
             }
             for operation in self.operations:
-                # Check that the operation can take the new "env" argument
-                # (added in Wagtail 1.5)
+                # Check that the operation can take the "env" argument
                 try:
                     inspect.getcallargs(operation.run, willow, image, env)
                     accepts_env = True

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -25,6 +25,7 @@ from taggit.managers import TaggableManager
 from unidecode import unidecode
 from willow.image import Image as WillowImage
 
+from wagtail.utils.deprecation import RemovedInWagtail19Warning
 from wagtail.wagtailadmin.utils import get_object_usage
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import CollectionMember
@@ -421,7 +422,7 @@ class Filter(models.Model):
                     accepts_env = False
                     warnings.warn("ImageOperation run methods should take 4 "
                                   "arguments. %d.run only takes 3.",
-                                  RemovedInWagtail17Warning)
+                                  RemovedInWagtail19Warning)
 
                 # Call operation
                 if accepts_env:

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -430,7 +430,9 @@ class Filter(models.Model):
 
             if original_format == 'jpeg':
                 # Allow changing of JPEG compression quality
-                if hasattr(settings, 'WAGTAILIMAGES_JPEG_QUALITY'):
+                if 'jpeg-quality' in env:
+                    quality = env['jpeg-quality']
+                elif hasattr(settings, 'WAGTAILIMAGES_JPEG_QUALITY'):
                     quality = settings.WAGTAILIMAGES_JPEG_QUALITY
                 else:
                     quality = 85

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -428,7 +428,23 @@ class Filter(models.Model):
                 else:
                     willow = operation.run(willow, image) or willow
 
-            if original_format == 'jpeg':
+            # Find the output format to use
+            if 'output-format' in env:
+                # Developer specified an output format
+                output_format = env['output-format']
+            else:
+                # Default to outputting in original format
+                output_format = original_format
+
+                # Convert BMP files to PNG
+                if original_format == 'bmp':
+                    output_format = 'png'
+
+                # Convert unanimated GIFs to PNG as well
+                if original_format == 'gif' and not willow.has_animation():
+                    output_format = 'png'
+
+            if output_format == 'jpeg':
                 # Allow changing of JPEG compression quality
                 if 'jpeg-quality' in env:
                     quality = env['jpeg-quality']
@@ -438,17 +454,10 @@ class Filter(models.Model):
                     quality = 85
 
                 return willow.save_as_jpeg(output, quality=quality)
-            elif original_format == 'gif':
-                # Convert image to PNG if it's not animated
-                if not willow.has_animation():
-                    return willow.save_as_png(output)
-                else:
-                    return willow.save_as_gif(output)
-            elif original_format == 'bmp':
-                # Convert to PNG
+            elif output_format == 'png':
                 return willow.save_as_png(output)
-            else:
-                return willow.save(original_format, output)
+            elif output_format == 'gif':
+                return willow.save_as_gif(output)
 
     def get_cache_key(self, image):
         vary_parts = []

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -406,7 +406,9 @@ class Filter(models.Model):
             # Fix orientation of image
             willow = willow.auto_orient()
 
-            env = {}
+            env = {
+                'original-format': original_format,
+            }
             for operation in self.operations:
                 # Check that the operation can take the new "env" argument
                 # (added in Wagtail 1.5)

--- a/wagtail/wagtailimages/tests/test_image_operations.py
+++ b/wagtail/wagtailimages/tests/test_image_operations.py
@@ -414,7 +414,7 @@ class TestFilter(TestCase):
         self.assertEqual(run_mock.call_count, 2)
 
     def test_runs_operations_without_env_argument(self):
-        # The "env" argument was added in Wagtial 1.5. This tests that
+        # The "env" argument was added in Wagtail 1.5. This tests that
         # image operations written for 1.4 will still work
 
         run_mock = Mock()

--- a/wagtail/wagtailimages/tests/test_image_operations.py
+++ b/wagtail/wagtailimages/tests/test_image_operations.py
@@ -447,3 +447,43 @@ def register_image_operations():
         ('operation1', Mock(return_value=TestFilter.operation_instance)),
         ('operation2', Mock(return_value=TestFilter.operation_instance))
     ]
+
+
+class TestFormatFilter(TestCase):
+    def test_jpeg(self):
+        fil = Filter(spec='width-400|format-jpeg')
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(),
+        )
+        out = fil.run(image, BytesIO())
+
+        self.assertEqual(out.format_name, 'jpeg')
+
+    def test_png(self):
+        fil = Filter(spec='width-400|format-png')
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(),
+        )
+        out = fil.run(image, BytesIO())
+
+        self.assertEqual(out.format_name, 'png')
+
+    def test_gif(self):
+        fil = Filter(spec='width-400|format-gif')
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(),
+        )
+        out = fil.run(image, BytesIO())
+
+        self.assertEqual(out.format_name, 'gif')
+
+    def test_invalid(self):
+        fil = Filter(spec='width-400|format-foo')
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(),
+        )
+        self.assertRaises(InvalidFilterSpecError, fil.run, image, BytesIO())

--- a/wagtail/wagtailimages/tests/test_image_operations.py
+++ b/wagtail/wagtailimages/tests/test_image_operations.py
@@ -2,16 +2,16 @@ from __future__ import absolute_import, unicode_literals
 
 import warnings
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils.six import BytesIO
-from mock import Mock
+from mock import Mock, patch
 
 from wagtail.utils.deprecation import RemovedInWagtail17Warning
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailimages import image_operations
 from wagtail.wagtailimages.exceptions import InvalidFilterSpecError
 from wagtail.wagtailimages.models import Filter, Image
-from wagtail.wagtailimages.tests.utils import get_test_image_file
+from wagtail.wagtailimages.tests.utils import get_test_image_file, get_test_image_file_jpeg
 
 
 class WillowOperationRecorder(object):
@@ -487,3 +487,87 @@ class TestFormatFilter(TestCase):
             file=get_test_image_file(),
         )
         self.assertRaises(InvalidFilterSpecError, fil.run, image, BytesIO())
+
+
+class TestJPEGQualityFilter(TestCase):
+    def test_default_quality(self):
+        fil = Filter(spec='width-400')
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file_jpeg(),
+        )
+
+        f = BytesIO()
+        with patch('PIL.Image.Image.save') as save:
+            out = fil.run(image, f)
+
+        save.assert_called_with(f, 'JPEG', quality=85)
+
+    def test_jpeg_quality_filter(self):
+        fil = Filter(spec='width-400|jpegquality-40')
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file_jpeg(),
+        )
+
+        f = BytesIO()
+        with patch('PIL.Image.Image.save') as save:
+            out = fil.run(image, f)
+
+        save.assert_called_with(f, 'JPEG', quality=40)
+
+    def test_jpeg_quality_filter_invalid(self):
+        fil = Filter(spec='width-400|jpegquality-abc')
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file_jpeg(),
+        )
+        self.assertRaises(InvalidFilterSpecError, fil.run, image, BytesIO())
+
+    def test_jpeg_quality_filter_no_value(self):
+        fil = Filter(spec='width-400|jpegquality')
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file_jpeg(),
+        )
+        self.assertRaises(InvalidFilterSpecError, fil.run, image, BytesIO())
+
+    def test_jpeg_quality_filter_too_big(self):
+        fil = Filter(spec='width-400|jpegquality-101')
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file_jpeg(),
+        )
+        self.assertRaises(InvalidFilterSpecError, fil.run, image, BytesIO())
+
+    @override_settings(
+        WAGTAILIMAGES_JPEG_QUALITY=50
+    )
+    def test_jpeg_quality_setting(self):
+        fil = Filter(spec='width-400')
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file_jpeg(),
+        )
+
+        f = BytesIO()
+        with patch('PIL.Image.Image.save') as save:
+            out = fil.run(image, f)
+
+        save.assert_called_with(f, 'JPEG', quality=50)
+
+    @override_settings(
+        WAGTAILIMAGES_JPEG_QUALITY=50
+    )
+    def test_jpeg_quality_filter_overrides_setting(self):
+        fil = Filter(spec='width-400|jpegquality-40')
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file_jpeg(),
+        )
+
+        f = BytesIO()
+        with patch('PIL.Image.Image.save') as save:
+            out = fil.run(image, f)
+
+        save.assert_called_with(f, 'JPEG', quality=40)

--- a/wagtail/wagtailimages/tests/test_image_operations.py
+++ b/wagtail/wagtailimages/tests/test_image_operations.py
@@ -81,7 +81,7 @@ class ImageOperationTestCase(TestCase):
             operation_recorder = WillowOperationRecorder((image.width, image.height))
 
             # Run
-            operation.run(operation_recorder, image)
+            operation.run(operation_recorder, image, {})
 
             # Check
             self.assertEqual(operation_recorder.ran_operations, expected_output)

--- a/wagtail/wagtailimages/tests/test_image_operations.py
+++ b/wagtail/wagtailimages/tests/test_image_operations.py
@@ -499,7 +499,7 @@ class TestJPEGQualityFilter(TestCase):
 
         f = BytesIO()
         with patch('PIL.Image.Image.save') as save:
-            out = fil.run(image, f)
+            fil.run(image, f)
 
         save.assert_called_with(f, 'JPEG', quality=85)
 
@@ -512,7 +512,7 @@ class TestJPEGQualityFilter(TestCase):
 
         f = BytesIO()
         with patch('PIL.Image.Image.save') as save:
-            out = fil.run(image, f)
+            fil.run(image, f)
 
         save.assert_called_with(f, 'JPEG', quality=40)
 
@@ -552,7 +552,7 @@ class TestJPEGQualityFilter(TestCase):
 
         f = BytesIO()
         with patch('PIL.Image.Image.save') as save:
-            out = fil.run(image, f)
+            fil.run(image, f)
 
         save.assert_called_with(f, 'JPEG', quality=50)
 
@@ -568,6 +568,6 @@ class TestJPEGQualityFilter(TestCase):
 
         f = BytesIO()
         with patch('PIL.Image.Image.save') as save:
-            out = fil.run(image, f)
+            fil.run(image, f)
 
         save.assert_called_with(f, 'JPEG', quality=40)

--- a/wagtail/wagtailimages/tests/test_image_operations.py
+++ b/wagtail/wagtailimages/tests/test_image_operations.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
+import warnings
+
 from django.test import TestCase
 from django.utils.six import BytesIO
 from mock import Mock
 
+from wagtail.utils.deprecation import RemovedInWagtail17Warning
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailimages import image_operations
 from wagtail.wagtailimages.exceptions import InvalidFilterSpecError
@@ -394,7 +397,12 @@ class TestFilter(TestCase):
     operation_instance = Mock()
 
     def test_runs_operations(self):
-        self.operation_instance.run = Mock()
+        run_mock = Mock()
+
+        def run(willow, image, env):
+            run_mock(willow, image, env)
+
+        self.operation_instance.run = run
 
         fil = Filter(spec='operation1|operation2')
         image = Image.objects.create(
@@ -403,7 +411,34 @@ class TestFilter(TestCase):
         )
         fil.run(image, BytesIO())
 
-        self.assertEqual(self.operation_instance.run.call_count, 2)
+        self.assertEqual(run_mock.call_count, 2)
+
+    def test_runs_operations_without_env_argument(self):
+        # The "env" argument was added in Wagtial 1.5. This tests that
+        # image operations written for 1.4 will still work
+
+        run_mock = Mock()
+
+        def run(willow, image):
+            run_mock(willow, image)
+
+        self.operation_instance.run = run
+
+        fil = Filter(spec='operation1|operation2')
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(),
+        )
+
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
+
+            fil.run(image, BytesIO())
+
+            self.assertEqual(len(ws), 2)
+            self.assertIs(ws[0].category, RemovedInWagtail17Warning)
+
+        self.assertEqual(run_mock.call_count, 2)
 
 
 @hooks.register('register_image_operations')

--- a/wagtail/wagtailimages/tests/utils.py
+++ b/wagtail/wagtailimages/tests/utils.py
@@ -14,3 +14,10 @@ def get_test_image_file(filename='test.png', colour='white', size=(640, 480)):
     image = PIL.Image.new('RGB', size, colour)
     image.save(f, 'PNG')
     return ImageFile(f, name=filename)
+
+
+def get_test_image_file_jpeg(filename='test.jpg', colour='white', size=(640, 480)):
+    f = BytesIO()
+    image = PIL.Image.new('RGB', size, colour)
+    image.save(f, 'JPEG')
+    return ImageFile(f, name=filename)

--- a/wagtail/wagtailimages/wagtail_hooks.py
+++ b/wagtail/wagtailimages/wagtail_hooks.py
@@ -76,6 +76,7 @@ def register_image_operations():
         ('max', image_operations.MinMaxOperation),
         ('width', image_operations.WidthHeightOperation),
         ('height', image_operations.WidthHeightOperation),
+        ('jpegquality', image_operations.JPEGQualityOperation),
     ]
 
 

--- a/wagtail/wagtailimages/wagtail_hooks.py
+++ b/wagtail/wagtailimages/wagtail_hooks.py
@@ -77,6 +77,7 @@ def register_image_operations():
         ('width', image_operations.WidthHeightOperation),
         ('height', image_operations.WidthHeightOperation),
         ('jpegquality', image_operations.JPEGQualityOperation),
+        ('format', image_operations.FormatOperation),
     ]
 
 


### PR DESCRIPTION
This pull request implements two new image filters:
 - ``format`` - This allows the developer to specify an output format to use in a placement (For example, ``format-png`` will force Wagtail to always output PNG files irrespective of the original format) (fixes #2472)
 - ``jpegquality`` -  This allows the developer to specifiy the amount of compression to apply JPEG files in an image placement (fixes #908 and #1847)

These are made possible by a new ``env`` argument that gets passed into image filter run methods. It's a mutable dictionary that can be used to pass messages along the filter chain and back to Wagtail.

The docs also fix #1205 