### PR TITLE
Make get_upload_to an overrideable method of AbstractRendition

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -131,6 +131,7 @@ Contributors
 * João Luiz Lorencetti
 * Jason Morrison
 * Mario César
+* Robert Moggach
 
 Translators
 ===========

--- a/wagtail/wagtailimages/migrations/0013_make_rendition_upload_callable.py
+++ b/wagtail/wagtailimages/migrations/0013_make_rendition_upload_callable.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import wagtail.wagtailimages.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailimages', '0012_copy_image_permissions_to_collections'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='rendition',
+            name='file',
+            field=models.ImageField(upload_to=wagtail.wagtailimages.models.get_rendition_upload_to, width_field='width', height_field='height'),
+        ),
+    ]


### PR DESCRIPTION
Allow custom upload path logic on subclasses of AbstractRendition, as we do for AbstractImage. Supersedes #2165