### PR TITLE
Fix modeladmin's choose_parent view for non-superusers

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -99,6 +99,8 @@ linters:
             - '**/_streamfield.scss'
             - '**/page-editor.scss'
             - '**/_datetimepicker.scss'
+            - 'wagtail/contrib/modeladmin/static_src/modeladmin/scss/choose_parent_page.scss'
+            - 'wagtail/contrib/modeladmin/static_src/modeladmin/scss/index.scss'
 
     PlaceholderInExtend:
         enabled: false

--- a/wagtail/contrib/modeladmin/helpers.py
+++ b/wagtail/contrib/modeladmin/helpers.py
@@ -10,7 +10,7 @@ from django.utils.functional import cached_property
 from django.utils.http import urlquote
 from django.utils.translation import ugettext as _
 
-from wagtail.wagtailcore.models import Page
+from wagtail.wagtailcore.models import Page, UserPagePermissionsProxy
 
 
 class AdminURLHelper(object):

--- a/wagtail/contrib/modeladmin/static_src/modeladmin/scss/choose_parent_page.scss
+++ b/wagtail/contrib/modeladmin/static_src/modeladmin/scss/choose_parent_page.scss
@@ -1,6 +1,7 @@
-#id_parent_page li {
-	margin: 15px 0;
+.page_choice_field li {
+    margin: 15px 0;
 }
-#id_parent_page li label {
-	float: none;
+
+.page_choice_field li label {
+    float: none;
 }

--- a/wagtail/contrib/modeladmin/static_src/modeladmin/scss/index.scss
+++ b/wagtail/contrib/modeladmin/static_src/modeladmin/scss/index.scss
@@ -1,50 +1,60 @@
-.content header { margin-bottom: 0; }
-#result_list {
+.content header {
+    margin-bottom: 0;
+}
+
+.result_list {
     padding: 0 15px;
 }
-#result_list table { margin-bottom:0; }
-#result_list tbody th {
+
+.result_list table {
+    margin-bottom: 0;
+}
+
+.result_list tbody th {
     background-color: transparent;
     text-align: left;
     padding: 1.2em 1em;
 }
-#result_list tbody tr:hover ul.actions {
+
+.result_list tbody tr:hover ul.actions {
     visibility: visible;
 }
-#result_list tbody td, #result_list tbody th {
+
+.result_list tbody td,
+.result_list tbody th {
     vertical-align: top;
 }
 
-#changelist-filter {
+.changelist-filter {
     padding: 0 15px;
 }
 
-#changelist-filter h2 {
+.changelist-filter h2 {
     background-color: #fafafa;
     font-size: 13px;
     line-height: 31px;
     margin-top: 0;
     padding-left: 8px;
-    border-bottom: 1px solid #E6E6E6;
+    border-bottom: 1px solid #e6e6e6;
 }
 
-#changelist-filter h3 {
+.changelist-filter h3 {
     font-size: 12px;
     margin-bottom: 0;
 }
 
-#changelist-filter ul {
+.changelist-filter ul {
     padding-left: 0;
     margin-bottom: 25px;
 }
 
-#changelist-filter li {
+.changelist-filter li {
     list-style-type: none;
     margin: 0 0 4px;
     padding-left: 0;
 }
 
-#changelist-filter a {
+.changelist-filter a {
     font-family: Open Sans,Arial,sans-serif;
     border-radius: 3px;
     width: auto;
@@ -54,7 +64,7 @@
     font-weight: normal;
     vertical-align: middle;
     display: block;
-    background-color: white;
+    background-color: #fff;
     border: 1px solid #43b1b0;
     color: #43b1b0;
     text-decoration: none;
@@ -68,15 +78,15 @@
     -moz-box-sizing: border-box;
 }
 
-#changelist-filter a:hover {
+.changelist-filter a:hover {
     background-color: #358c8b;
     border-color: #358c8b;
-    color: white;
+    color: #fff;
     
 }
 
-#changelist-filter li.selected a {
-    color: white !important;
+.changelist-filter li.selected a {
+    color: #fff !important;
     border-color: #43b1b0 !important;
     background-color: #43b1b0;
 }
@@ -101,46 +111,56 @@ div.pagination {
     border-top: 1px dashed #d9d9d9;
     padding: 2em 1em 0;
 }
+
 div.pagination ul {
-    margin-top: -1.25em
+    margin-top: -1.25em;
 }
+
 p.no-results {
     margin: 30px 1em 0;
 }
 
 @media screen and (min-width: 50em) {
-    #changelist-filter {
+    .changelist-filter {
         float: right;
         padding: 0 1.5%;
     }
-    #result_list {
+
+    .result_list {
         padding: 0 1.5% 0 0;
     }
-    #result_list tbody th:first-child {
+
+    .result_list tbody th:first-child {
         padding-left: 50px;
     }
-    #result_list.col12 tbody td:last-child {
+
+    .result_list.col12 tbody td:last-child {
         padding-right: 50px;
     }
+
     div.pagination {
         padding-left: 50px;
         padding-right: 50px;
     }
+
     div.pagination.col9 {
         width: 73.5%;
     }
+
     p.no-results {
         margin: 30px 50px 0;
     }
 }
 
 @media screen and (min-width: 1200px) {
-    #result_list.col9 {
+    .result_list.col9 {
         width: 79%;
     }
-    #changelist-filter {
+
+    .changelist-filter {
         width: 21%;
     }
+
     div.pagination.col9 {
         width: 77.5%;
     }

--- a/wagtail/contrib/modeladmin/templates/modeladmin/index.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/index.html
@@ -42,14 +42,14 @@
 
                     {% block filters %}
                         {% if view.has_filters and all_count %}
-                        <div id="changelist-filter" class="col3">
+                        <div class="changelist-filter col3">
                             <h2>{% trans 'Filter' %}</h2>
                             {% for spec in view.filter_specs %}{% admin_list_filter view spec %}{% endfor %}
                         </div>
                         {% endif %}
                     {% endblock %}
 
-                    <div id="result_list" class="{% if view.has_filters and all_count %}col9{% else %}col12{% endif %}">
+                    <div class="result_list {% if view.has_filters and all_count %}col9{% else %}col12{% endif %}">
                         {% block result_list %}
                             {% if not all_count %}
                                 <div class="nice-padding" style="margin-top:30px;">

--- a/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
@@ -4,9 +4,9 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.test import TestCase
 
-from wagtail.wagtailcore.models import Page, GroupPagePermission
 from wagtail.tests.testapp.models import BusinessIndex
 from wagtail.tests.utils import WagtailTestUtils
+from wagtail.wagtailcore.models import GroupPagePermission, Page
 
 
 class TestIndexView(TestCase, WagtailTestUtils):

--- a/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission
 from django.test import TestCase
 
-from wagtail.wagtailcore.models import Page
+from wagtail.wagtailcore.models import Page, GroupPagePermission
 from wagtail.tests.testapp.models import BusinessIndex
 from wagtail.tests.utils import WagtailTestUtils
 
@@ -179,6 +179,46 @@ class TestChooseParentView(TestCase, WagtailTestUtils):
         expected_path = '/admin/pages/add/tests/eventpage/2/'
         expected_next_path = '/admin/tests/eventpage/'
         self.assertRedirects(response, '%s?next=%s' % (expected_path, expected_next_path))
+
+
+class TestChooseParentViewForNonSuperuser(TestCase, WagtailTestUtils):
+    fixtures = ['test_specific.json']
+
+    def setUp(self):
+        homepage = Page.objects.get(url_path='/home/')
+        business_index = BusinessIndex(title='Public Business Index')
+        homepage.add_child(instance=business_index)
+
+        another_business_index = BusinessIndex(title='Another Business Index')
+        homepage.add_child(instance=another_business_index)
+
+        secret_business_index = BusinessIndex(title='Private Business Index')
+        homepage.add_child(instance=secret_business_index)
+
+        business_editors = Group.objects.create(name='Business editors')
+        business_editors.permissions.add(Permission.objects.get(codename='access_admin'))
+        GroupPagePermission.objects.create(
+            group=business_editors,
+            page=business_index,
+            permission_type='add'
+        )
+        GroupPagePermission.objects.create(
+            group=business_editors,
+            page=another_business_index,
+            permission_type='add'
+        )
+
+        user = get_user_model().objects._create_user(username='test2', email='test2@email.com', password='password', is_staff=True, is_superuser=False)
+        user.groups.add(business_editors)
+        # Login
+        self.client.login(username='test2', password='password')
+
+    def test_simple(self):
+        response = self.client.get('/admin/tests/businesschild/choose_parent/')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Public Business Index')
+        self.assertNotContains(response, 'Private Business Index')
 
 
 class TestEditorAccess(TestCase):

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -4,7 +4,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.test import TestCase
 
-from wagtail.tests.modeladmintest.models import Book, Author
+from wagtail.tests.modeladmintest.models import Author, Book
 from wagtail.tests.utils import WagtailTestUtils
 
 

--- a/wagtail/tests/modeladmintest/apps.py
+++ b/wagtail/tests/modeladmintest/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/wagtail/tests/modeladmintest/models.py
+++ b/wagtail/tests/modeladmintest/models.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -1,10 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
-from wagtail.contrib.modeladmin.options import (
-    ModelAdmin, ModelAdminGroup, modeladmin_register)
-from wagtail.tests.testapp.models import (
-    BusinessChild, EventPage, SingleEventPage
-)
+from wagtail.contrib.modeladmin.options import ModelAdmin, ModelAdminGroup, modeladmin_register
+from wagtail.tests.testapp.models import BusinessChild, EventPage, SingleEventPage
 
 from .models import Author, Book
 

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -1,9 +1,12 @@
+from __future__ import absolute_import, unicode_literals
+
 from wagtail.contrib.modeladmin.options import (
     ModelAdmin, ModelAdminGroup, modeladmin_register)
-from .models import Author, Book
 from wagtail.tests.testapp.models import (
-    EventPage, SingleEventPage, BusinessChild
+    BusinessChild, EventPage, SingleEventPage
 )
+
+from .models import Author, Book
 
 
 class AuthorModelAdmin(ModelAdmin):


### PR DESCRIPTION
Fixes #2477

In addition to adding the missing import, I've rewritten the logic to do the filtering by both content type and permission in a single pass. This is because I'm not particularly confident that Django and the database will be smart enough to avoid enumerating `Page.objects.descendant_of(some_high_level_page)` in full, which is potentially a huge data set.