### PR TITLE
Implement API v2 fields changes (RFC 5)

### DIFF
--- a/wagtail/api/v2/endpoints.py
+++ b/wagtail/api/v2/endpoints.py
@@ -175,8 +175,14 @@ class BaseAPIEndpoint(GenericViewSet):
             mentioned_fields = set()
 
             if 'fields' in request.GET:
+                first_position = True
                 for field in request.GET['fields'].split(','):
-                    if field.startswith('-'):
+                    if field == '*':
+                        if first_position:
+                            fields = fields.union(all_fields)
+                        else:
+                            raise BadRequestError("fields error: '*' must be in the first position")
+                    elif field.startswith('-'):
                         try:
                             fields.remove(field[1:])
                         except KeyError:
@@ -186,6 +192,8 @@ class BaseAPIEndpoint(GenericViewSet):
                     else:
                         fields.add(field)
                         mentioned_fields.add(field)
+
+                    first_position = False
 
             unknown_fields = mentioned_fields - set(all_fields)
 

--- a/wagtail/api/v2/endpoints.py
+++ b/wagtail/api/v2/endpoints.py
@@ -53,7 +53,8 @@ class BaseAPIEndpoint(GenericViewSet):
     ])
     body_fields = ['id']
     meta_fields = ['type', 'detail_url']
-    default_fields = ['id', 'type', 'detail_url']
+    listing_default_fields = ['id', 'type', 'detail_url']
+    nested_default_fields = ['id', 'type', 'detail_url']
     detail_only_fields = []
     name = None  # Set on subclass.
 
@@ -144,8 +145,12 @@ class BaseAPIEndpoint(GenericViewSet):
         return fields
 
     @classmethod
-    def get_default_fields(cls, model):
-        return cls.default_fields[:]
+    def get_listing_default_fields(cls, model):
+        return cls.listing_default_fields[:]
+
+    @classmethod
+    def get_nested_default_fields(cls, model):
+        return cls.nested_default_fields[:]
 
     def check_query_parameters(self, queryset):
         """
@@ -160,7 +165,7 @@ class BaseAPIEndpoint(GenericViewSet):
             raise BadRequestError("query parameter is not an operation or a recognised field: %s" % ', '.join(sorted(unknown_parameters)))
 
     @classmethod
-    def _get_serializer_class(cls, router, model, fields_config, show_details=False):
+    def _get_serializer_class(cls, router, model, fields_config, show_details=False, nested=False):
         # Get all available fields
         body_fields = cls.get_body_fields(model)
         meta_fields = cls.get_meta_fields(model)
@@ -178,7 +183,10 @@ class BaseAPIEndpoint(GenericViewSet):
                     pass
 
         # Get list of configured fields
-        fields = set(cls.get_default_fields(model))
+        if nested:
+            fields = set(cls.get_nested_default_fields(model))
+        else:
+            fields = set(cls.get_listing_default_fields(model))
 
         # If first field is '*' start with all fields
         if fields_config and fields_config[0][0] == '*':
@@ -220,7 +228,7 @@ class BaseAPIEndpoint(GenericViewSet):
                 child_model = django_field.related_model
                 child_endpoint_class = router.get_model_endpoint(child_model)
                 child_endpoint_class = child_endpoint_class[1] if child_endpoint_class else BaseAPIEndpoint
-                child_serializer_classes[field_name] = child_endpoint_class._get_serializer_class(router, child_model, sub_fields.get(field_name, []))
+                child_serializer_classes[field_name] = child_endpoint_class._get_serializer_class(router, child_model, sub_fields.get(field_name, []), nested=True)
 
             else:
                 if field_name in sub_fields:
@@ -331,11 +339,14 @@ class PagesAPIEndpoint(BaseAPIEndpoint):
         'first_published_at',
         'parent',
     ]
-    default_fields = BaseAPIEndpoint.default_fields + [
+    listing_default_fields = BaseAPIEndpoint.listing_default_fields + [
         'title',
         'html_url',
         'slug',
         'first_published_at',
+    ]
+    nested_default_fields = BaseAPIEndpoint.nested_default_fields + [
+        'title',
     ]
     detail_only_fields = ['parent']
     name = 'pages'

--- a/wagtail/api/v2/endpoints.py
+++ b/wagtail/api/v2/endpoints.py
@@ -190,8 +190,12 @@ class BaseAPIEndpoint(GenericViewSet):
             fields = set(cls.get_listing_default_fields(model))
 
         # If first field is '*' start with all fields
+        # If first field is '_' start with no fields
         if fields_config and fields_config[0][0] == '*':
             fields = set(all_fields)
+            fields_config = fields_config[1:]
+        elif fields_config and fields_config[0][0] == '_':
+            fields = set()
             fields_config = fields_config[1:]
 
         mentioned_fields = set()
@@ -229,7 +233,7 @@ class BaseAPIEndpoint(GenericViewSet):
 
                 # Inline (aka "child") models should display all fields by default
                 if isinstance(getattr(django_field, 'field', None), ParentalKey):
-                    if not child_sub_fields or child_sub_fields[0][0] != '*':
+                    if not child_sub_fields or child_sub_fields[0][0] not in ['*', '_']:
                         child_sub_fields = list(child_sub_fields)
                         child_sub_fields.insert(0, ('*', False, None))
 

--- a/wagtail/api/v2/endpoints.py
+++ b/wagtail/api/v2/endpoints.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 
 from django.apps import apps
 from django.conf.urls import url
+from django.core.exceptions import FieldDoesNotExist
 from django.core.urlresolvers import reverse
 from django.http import Http404
 from rest_framework import status
@@ -18,7 +19,8 @@ from .filters import (
     SearchFilter)
 from .pagination import WagtailPagination
 from .serializers import BaseSerializer, PageSerializer, get_serializer_class
-from .utils import BadRequestError, filter_page_type, page_models_from_string
+from .utils import (
+    BadRequestError, filter_page_type, page_models_from_string, parse_fields_parameter)
 
 
 class BaseAPIEndpoint(GenericViewSet):
@@ -88,31 +90,34 @@ class BaseAPIEndpoint(GenericViewSet):
             return Response(data, status=status.HTTP_400_BAD_REQUEST)
         return super(BaseAPIEndpoint, self).handle_exception(exc)
 
-    def get_body_fields(self, model):
+    @classmethod
+    def get_body_fields(cls, model):
         """
         This returns a list of field names that are allowed to
         be used in the API (excluding the id field)
         """
-        fields = self.body_fields[:]
+        fields = cls.body_fields[:]
 
         if hasattr(model, 'api_fields'):
             fields.extend(model.api_fields)
 
         return fields
 
-    def get_meta_fields(self, model):
+    @classmethod
+    def get_meta_fields(cls, model):
         """
         This returns a list of field names that are allowed to
         be used in the meta section in the API (excluding type and detail_url).
         """
-        meta_fields = self.meta_fields[:]
+        meta_fields = cls.meta_fields[:]
 
         if hasattr(model, 'api_meta_fields'):
             meta_fields.extend(model.api_meta_fields)
 
         return meta_fields
 
-    def get_available_fields(self, model, db_fields_only=False):
+    @classmethod
+    def get_available_fields(cls, model, db_fields_only=False):
         """
         Returns a list of all the fields that can be used in the API for the
         specified model class.
@@ -121,7 +126,7 @@ class BaseAPIEndpoint(GenericViewSet):
         an underlying column in the database (eg, type/detail_url and any custom
         fields that are callables)
         """
-        fields = self.get_body_fields(model) + self.get_meta_fields(model)
+        fields = cls.get_body_fields(model) + cls.get_meta_fields(model)
 
         if db_fields_only:
             # Get list of available database fields then remove any fields in our
@@ -137,8 +142,9 @@ class BaseAPIEndpoint(GenericViewSet):
 
         return fields
 
-    def get_default_fields(self, model):
-        return self.default_fields[:]
+    @classmethod
+    def get_default_fields(cls, model):
+        return cls.default_fields[:]
 
     def check_query_parameters(self, queryset):
         """
@@ -152,6 +158,71 @@ class BaseAPIEndpoint(GenericViewSet):
         if unknown_parameters:
             raise BadRequestError("query parameter is not an operation or a recognised field: %s" % ', '.join(sorted(unknown_parameters)))
 
+    @classmethod
+    def _get_serializer_class(cls, router, model, fields_config):
+        # Get all available fields
+        body_fields = cls.get_body_fields(model)
+        meta_fields = cls.get_meta_fields(model)
+        all_fields = body_fields + meta_fields
+
+        # Remove any duplicates
+        all_fields = list(OrderedDict.fromkeys(all_fields))
+
+        # Get list of configured fields
+        fields = set(cls.get_default_fields(model))
+
+        # If first field is '*' start with all fields
+        if fields_config and fields_config[0][0] == '*':
+            fields = set(all_fields)
+            fields_config = fields_config[1:]
+
+        mentioned_fields = set()
+        sub_fields = {}
+
+        for field_name, negated, field_sub_fields in fields_config:
+            if negated:
+                try:
+                    fields.remove(field_name)
+                except KeyError:
+                    pass
+            else:
+                fields.add(field_name)
+                if field_sub_fields:
+                    sub_fields[field_name] = field_sub_fields
+
+            mentioned_fields.add(field_name)
+
+        unknown_fields = mentioned_fields - set(all_fields)
+
+        if unknown_fields:
+            raise BadRequestError("unknown fields: %s" % ', '.join(sorted(unknown_fields)))
+
+        # Build nested serialisers
+        child_serializer_classes = {}
+
+        for field_name in fields:
+            try:
+                django_field = model._meta.get_field(field_name)
+            except FieldDoesNotExist:
+                django_field = None
+
+            if django_field and django_field.is_relation:
+                # Get a serializer class for the related object
+                child_model = django_field.related_model
+                child_endpoint_class = router.get_model_endpoint(child_model)
+                child_endpoint_class = child_endpoint_class[1] if child_endpoint_class else BaseAPIEndpoint
+                child_serializer_classes[field_name] = child_endpoint_class._get_serializer_class(router, child_model, sub_fields.get(field_name, []))
+
+            else:
+                if field_name in sub_fields:
+                    # Sub fields were given for a non-related field
+                    raise BadRequestError("'%s' does not support nested fields" % field_name)
+
+        # Reorder fields so it matches the order of all_fields
+        fields = [field for field in all_fields if field in fields]
+
+        return get_serializer_class(model, fields, meta_fields=meta_fields, child_serializer_classes=child_serializer_classes, base=cls.base_serializer_class)
+
     def get_serializer_class(self):
         request = self.request
 
@@ -161,56 +232,26 @@ class BaseAPIEndpoint(GenericViewSet):
         else:
             model = type(self.get_object())
 
-        # Get all available fields
-        body_fields = self.get_body_fields(model)
-        meta_fields = self.get_meta_fields(model)
-        all_fields = body_fields + meta_fields
-
-        # Remove any duplicates
-        all_fields = list(OrderedDict.fromkeys(all_fields))
-
         if self.action == 'listing_view':
-            # Listing views just show the title field and any other allowed field the user specified
-            fields = set(self.get_default_fields(model))
-            mentioned_fields = set()
-
             if 'fields' in request.GET:
-                first_position = True
-                for field in request.GET['fields'].split(','):
-                    if field == '*':
-                        if first_position:
-                            fields = fields.union(all_fields)
-                        else:
-                            raise BadRequestError("fields error: '*' must be in the first position")
-                    elif field.startswith('-'):
-                        try:
-                            fields.remove(field[1:])
-                        except KeyError:
-                            pass  # Error handling done by checking mentioned_fields below
-
-                        mentioned_fields.add(field[1:])
-                    else:
-                        fields.add(field)
-                        mentioned_fields.add(field)
-
-                    first_position = False
-
-            unknown_fields = mentioned_fields - set(all_fields)
-
-            if unknown_fields:
-                raise BadRequestError("unknown fields: %s" % ', '.join(sorted(unknown_fields)))
-
-            # Reorder fields so it matches the order of all_fields
-            fields = [field for field in all_fields if field in fields]
+                try:
+                    fields_config = parse_fields_parameter(request.GET['fields'])
+                except ValueError as e:
+                    raise BadRequestError("fields error: %s" % str(e))
+            else:
+                # Use default fields
+                fields_config = []
         else:
             # Detail views show all fields all the time
-            fields = all_fields
+            fields_config = [
+                ('*', False, None)
+            ]
 
         # If showing details, add the parent field
         if isinstance(self, PagesAPIEndpoint) and self.action == 'detail_view':
-            fields.insert(2, 'parent')
+            fields_config.insert(2, ('parent', False, None))
 
-        return get_serializer_class(model, fields, meta_fields=meta_fields, base=self.base_serializer_class)
+        return self._get_serializer_class(self.request.wagtailapi_router, model, fields_config)
 
     def get_serializer_context(self):
         """

--- a/wagtail/api/v2/endpoints.py
+++ b/wagtail/api/v2/endpoints.py
@@ -52,7 +52,6 @@ class BaseAPIEndpoint(GenericViewSet):
     body_fields = ['id']
     meta_fields = ['type', 'detail_url']
     default_fields = ['id', 'type', 'detail_url']
-    soft_default_fields = []
     name = None  # Set on subclass.
 
     def __init__(self, *args, **kwargs):
@@ -138,15 +137,8 @@ class BaseAPIEndpoint(GenericViewSet):
 
         return fields
 
-    def get_default_fields(self, model, include_soft=False):
-        fields = self.default_fields[:]
-
-        # Soft default fields are fields that are only there if the user hasn't
-        # specified any fields
-        if include_soft:
-            fields.extend(self.soft_default_fields)
-
-        return fields
+    def get_default_fields(self, model):
+        return self.default_fields[:]
 
     def check_query_parameters(self, queryset):
         """
@@ -182,7 +174,7 @@ class BaseAPIEndpoint(GenericViewSet):
             if 'fields' in request.GET:
                 fields = set(request.GET['fields'].split(','))
             else:
-                fields = set(self.get_default_fields(model, include_soft=True))
+                fields = set(self.get_default_fields(model))
 
             unknown_fields = fields - set(all_fields)
 
@@ -272,11 +264,11 @@ class PagesAPIEndpoint(BaseAPIEndpoint):
         'parent',
     ]
     default_fields = BaseAPIEndpoint.default_fields + [
+        'title',
         'html_url',
         'slug',
         'first_published_at',
     ]
-    soft_default_fields = BaseAPIEndpoint.soft_default_fields + ['title']
     name = 'pages'
     model = Page
 

--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -16,7 +16,7 @@ class FieldsFilter(BaseFilterBackend):
         This performs field level filtering on the result set
         Eg: ?title=James Joyce
         """
-        fields = set(view.get_available_fields(queryset.model)).union({'id'})
+        fields = set(view.get_available_fields(queryset.model, db_fields_only=True))
 
         for field_name, value in request.GET.items():
             if field_name in fields:
@@ -67,7 +67,7 @@ class OrderingFilter(BaseFilterBackend):
                 reverse_order = False
 
             # Add ordering
-            if order_by == 'id' or order_by in view.get_available_fields(queryset.model):
+            if order_by in view.get_available_fields(queryset.model):
                 queryset = queryset.order_by(order_by)
             else:
                 # Unknown field

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -284,7 +284,8 @@ class BaseSerializer(serializers.ModelSerializer):
         fields = [field for field in fields if field.field_name not in self.meta_fields]
 
         # Make sure id is always first. This will be filled in later
-        data['id'] = None
+        if 'id' in [field.field_name for field in fields]:
+            data['id'] = None
 
         # Serialise meta fields
         meta = OrderedDict()
@@ -301,7 +302,8 @@ class BaseSerializer(serializers.ModelSerializer):
             else:
                 meta[field.field_name] = field.to_representation(attribute)
 
-        data['meta'] = meta
+        if meta:
+            data['meta'] = meta
 
         # Serialise core fields
         for field in fields:

--- a/wagtail/api/v2/tests/test_documents.py
+++ b/wagtail/api/v2/tests/test_documents.py
@@ -79,6 +79,35 @@ class TestDocumentListing(TestCase):
             self.assertEqual(set(document.keys()), {'id', 'meta', 'title'})
             self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url', 'tags'})
 
+    def test_remove_fields(self):
+        response = self.get_response(fields='-title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['items']:
+            self.assertEqual(set(document.keys()), {'id', 'meta'})
+
+    def test_remove_meta_fields(self):
+        response = self.get_response(fields='-download_url')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['items']:
+            self.assertEqual(set(document.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'tags'})
+
+    def test_remove_all_meta_fields(self):
+        response = self.get_response(fields='-type,-detail_url,-tags,-download_url')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['items']:
+            self.assertEqual(set(document.keys()), {'id', 'title'})
+
+    def test_remove_id_field(self):
+        response = self.get_response(fields='-id')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['items']:
+            self.assertEqual(set(document.keys()), {'meta', 'title'})
+
     def test_fields_tags(self):
         response = self.get_response(fields='tags')
         content = json.loads(response.content.decode('UTF-8'))
@@ -95,6 +124,13 @@ class TestDocumentListing(TestCase):
 
     def test_fields_unknown_field_gives_error(self):
         response = self.get_response(fields='123,title,abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_fields_remove_unknown_field_gives_error(self):
+        response = self.get_response(fields='-123,-title,-abc')
         content = json.loads(response.content.decode('UTF-8'))
 
         self.assertEqual(response.status_code, 400)

--- a/wagtail/api/v2/tests/test_documents.py
+++ b/wagtail/api/v2/tests/test_documents.py
@@ -77,7 +77,7 @@ class TestDocumentListing(TestCase):
 
         for document in content['items']:
             self.assertEqual(set(document.keys()), {'id', 'meta', 'title'})
-            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url'})
+            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url', 'tags'})
 
     def test_fields_tags(self):
         response = self.get_response(fields='tags')

--- a/wagtail/api/v2/tests/test_documents.py
+++ b/wagtail/api/v2/tests/test_documents.py
@@ -108,12 +108,35 @@ class TestDocumentListing(TestCase):
         for document in content['items']:
             self.assertEqual(set(document.keys()), {'meta', 'title'})
 
+    def test_all_fields(self):
+        response = self.get_response(fields='*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['items']:
+            self.assertEqual(set(document.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'tags', 'download_url'})
+
+    def test_all_fields_then_remove_something(self):
+        response = self.get_response(fields='*,-title,-download_url')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['items']:
+            self.assertEqual(set(document.keys()), {'id', 'meta'})
+            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'tags'})
+
     def test_fields_tags(self):
         response = self.get_response(fields='tags')
         content = json.loads(response.content.decode('UTF-8'))
 
         for document in content['items']:
             self.assertIsInstance(document['meta']['tags'], list)
+
+    def test_star_in_wrong_position_gives_error(self):
+        response = self.get_response(fields='title,*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "fields error: '*' must be in the first position"})
 
     def test_fields_which_are_not_in_api_fields_gives_error(self):
         response = self.get_response(fields='uploaded_by_user')

--- a/wagtail/api/v2/tests/test_documents.py
+++ b/wagtail/api/v2/tests/test_documents.py
@@ -413,6 +413,71 @@ class TestDocumentDetail(TestCase):
         self.assertIn('download_url', content['meta'])
         self.assertEqual(content['meta']['download_url'], 'http://api.example.com/documents/1/wagtail_by_markyharky.jpg')
 
+    # FIELDS
+
+    def test_remove_fields(self):
+        response = self.get_response(2, fields='-title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('id', set(content.keys()))
+        self.assertNotIn('title', set(content.keys()))
+
+    def test_remove_meta_fields(self):
+        response = self.get_response(2, fields='-download_url')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('detail_url', set(content['meta'].keys()))
+        self.assertNotIn('download_url', set(content['meta'].keys()))
+
+    def test_remove_id_field(self):
+        response = self.get_response(2, fields='-id')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('title', set(content.keys()))
+        self.assertNotIn('id', set(content.keys()))
+
+    def test_remove_all_fields(self):
+        response = self.get_response(2, fields='_,id,type')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(set(content.keys()), {'id', 'meta'})
+        self.assertEqual(set(content['meta'].keys()), {'type'})
+
+    def test_star_in_wrong_position_gives_error(self):
+        response = self.get_response(2, fields='title,*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "fields error: '*' must be in the first position"})
+
+    def test_fields_which_are_not_in_api_fields_gives_error(self):
+        response = self.get_response(2, fields='path')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: path"})
+
+    def test_fields_unknown_field_gives_error(self):
+        response = self.get_response(2, fields='123,title,abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_fields_remove_unknown_field_gives_error(self):
+        response = self.get_response(2, fields='-123,-title,-abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_nested_fields_on_non_relational_field_gives_error(self):
+        response = self.get_response(2, fields='title(foo,bar)')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "'title' does not support nested fields"})
+
 
 @override_settings(
     WAGTAILFRONTENDCACHE={

--- a/wagtail/api/v2/tests/test_images.py
+++ b/wagtail/api/v2/tests/test_images.py
@@ -76,6 +76,35 @@ class TestImageListing(TestCase):
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height'})
             self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
 
+    def test_remove_fields(self):
+        response = self.get_response(fields='-title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'meta'})
+
+    def test_remove_meta_fields(self):
+        response = self.get_response(fields='-tags')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url'})
+
+    def test_remove_all_meta_fields(self):
+        response = self.get_response(fields='-type,-detail_url,-tags')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'title'})
+
+    def test_remove_id_field(self):
+        response = self.get_response(fields='-id')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'meta', 'title'})
+
     def test_fields_tags(self):
         response = self.get_response(fields='tags')
         content = json.loads(response.content.decode('UTF-8'))
@@ -94,6 +123,13 @@ class TestImageListing(TestCase):
 
     def test_fields_unknown_field_gives_error(self):
         response = self.get_response(fields='123,title,abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_fields_remove_unknown_field_gives_error(self):
+        response = self.get_response(fields='-123,-title,-abc')
         content = json.loads(response.content.decode('UTF-8'))
 
         self.assertEqual(response.status_code, 400)

--- a/wagtail/api/v2/tests/test_images.py
+++ b/wagtail/api/v2/tests/test_images.py
@@ -105,6 +105,22 @@ class TestImageListing(TestCase):
         for image in content['items']:
             self.assertEqual(set(image.keys()), {'meta', 'title'})
 
+    def test_all_fields(self):
+        response = self.get_response(fields='*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+
+    def test_all_fields_then_remove_something(self):
+        response = self.get_response(fields='*,-title,-tags')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'width', 'height'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url'})
+
     def test_fields_tags(self):
         response = self.get_response(fields='tags')
         content = json.loads(response.content.decode('UTF-8'))
@@ -113,6 +129,13 @@ class TestImageListing(TestCase):
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title'})
             self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
             self.assertIsInstance(image['meta']['tags'], list)
+
+    def test_star_in_wrong_position_gives_error(self):
+        response = self.get_response(fields='title,*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "fields error: '*' must be in the first position"})
 
     def test_fields_which_are_not_in_api_fields_gives_error(self):
         response = self.get_response(fields='uploaded_by_user')

--- a/wagtail/api/v2/tests/test_images.py
+++ b/wagtail/api/v2/tests/test_images.py
@@ -69,19 +69,19 @@ class TestImageListing(TestCase):
             self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
 
     def test_fields(self):
-        response = self.get_response(fields='title,width,height')
+        response = self.get_response(fields='width,height')
         content = json.loads(response.content.decode('UTF-8'))
 
         for image in content['items']:
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
 
     def test_fields_tags(self):
         response = self.get_response(fields='tags')
         content = json.loads(response.content.decode('UTF-8'))
 
         for image in content['items']:
-            self.assertEqual(set(image.keys()), {'id', 'meta'})
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'title'})
             self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
             self.assertIsInstance(image['meta']['tags'], list)
 

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -249,7 +249,7 @@ class TestPageListing(TestCase):
                 self.assertEqual(set(feed_image.keys()), {'id', 'meta', 'title'})
                 self.assertIsInstance(feed_image['id'], int)
                 self.assertIsInstance(feed_image['meta'], dict)
-                self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url', 'tags'})
+                self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url'})
                 self.assertEqual(feed_image['meta']['type'], 'wagtailimages.Image')
                 self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/api/v2beta/images/%d/' % feed_image['id'])
 
@@ -768,7 +768,7 @@ class TestPageDetail(TestCase):
         self.assertEqual(set(content['feed_image'].keys()), {'id', 'meta', 'title'})
         self.assertEqual(content['feed_image']['id'], 7)
         self.assertIsInstance(content['feed_image']['meta'], dict)
-        self.assertEqual(set(content['feed_image']['meta'].keys()), {'type', 'detail_url', 'tags'})
+        self.assertEqual(set(content['feed_image']['meta'].keys()), {'type', 'detail_url'})
         self.assertEqual(content['feed_image']['meta']['type'], 'wagtailimages.Image')
         self.assertEqual(content['feed_image']['meta']['detail_url'], 'http://localhost/api/v2beta/images/7/')
 

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -183,7 +183,7 @@ class TestPageListing(TestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         for page in content['items']:
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'tags'})
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'tags', 'title'})
             self.assertIsInstance(page['tags'], list)
 
     def test_fields_ordering(self):

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -154,6 +154,35 @@ class TestPageListing(TestCase):
         for page in content['items']:
             self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'feed_image'})
 
+    def test_remove_fields(self):
+        response = self.get_response(fields='-title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'meta'})
+
+    def test_remove_meta_fields(self):
+        response = self.get_response(fields='-html_url')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'slug', 'first_published_at'})
+
+    def test_remove_all_meta_fields(self):
+        response = self.get_response(fields='-type,-detail_url,-slug,-first_published_at,-html_url')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'title'})
+
+    def test_remove_id_field(self):
+        response = self.get_response(fields='-id')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'meta', 'title'})
+
     def test_fields_child_relation(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='title,related_links')
         content = json.loads(response.content.decode('UTF-8'))
@@ -220,6 +249,13 @@ class TestPageListing(TestCase):
 
     def test_fields_unknown_field_gives_error(self):
         response = self.get_response(fields='123,title,abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_fields_remove_unknown_field_gives_error(self):
+        response = self.get_response(fields='-123,-title,-abc')
         content = json.loads(response.content.decode('UTF-8'))
 
         self.assertEqual(response.status_code, 400)

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -189,7 +189,7 @@ class TestPageListing(TestCase):
 
         for page in content['items']:
             self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image'})
-            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'seo_title', 'slug', 'parent', 'html_url', 'search_description'})
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'seo_title', 'slug', 'html_url', 'search_description'})
 
     def test_all_fields_then_remove_something(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='*,-title,-date,-seo_title')
@@ -197,7 +197,7 @@ class TestPageListing(TestCase):
 
         for page in content['items']:
             self.assertEqual(set(page.keys()), {'id', 'meta', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image'})
-            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'slug', 'parent', 'html_url', 'search_description'})
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'slug', 'html_url', 'search_description'})
 
     def test_nested_fields(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='feed_image(width,height)')
@@ -292,6 +292,14 @@ class TestPageListing(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_parent_field_gives_error(self):
+        # parent field isn't allowed in listings
+        response = self.get_response(fields='parent')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: parent"})
 
     def test_fields_without_type_gives_error(self):
         response = self.get_response(fields='title,related_links')

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -221,12 +221,13 @@ class TestPageListing(TestCase):
             self.assertEqual(set(page['feed_image'].keys()), {'id', 'meta', 'title', 'width', 'height'})
 
     def test_nested_nested_fields(self):
-        response = self.get_response(type='demosite.BlogEntryPage', fields='carousel_items(image(width,height),embed_url)')
+        response = self.get_response(type='demosite.BlogEntryPage', fields='carousel_items(image(width,height))')
         content = json.loads(response.content.decode('UTF-8'))
 
         for page in content['items']:
             for carousel_item in page['carousel_items']:
-                self.assertEqual(set(carousel_item.keys()), {'id', 'meta', 'image', 'embed_url'})
+                # Note: inline objects default to displaying all fields
+                self.assertEqual(set(carousel_item.keys()), {'id', 'meta', 'image', 'embed_url', 'caption', 'link'})
                 self.assertEqual(set(carousel_item['image'].keys()), {'id', 'meta', 'title', 'width', 'height'})
 
     def test_fields_child_relation(self):

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -183,6 +183,22 @@ class TestPageListing(TestCase):
         for page in content['items']:
             self.assertEqual(set(page.keys()), {'meta', 'title'})
 
+    def test_all_fields(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image'})
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'seo_title', 'slug', 'parent', 'html_url', 'search_description'})
+
+    def test_all_fields_then_remove_something(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='*,-title,-date,-seo_title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image'})
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'slug', 'parent', 'html_url', 'search_description'})
+
     def test_fields_child_relation(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='title,related_links')
         content = json.loads(response.content.decode('UTF-8'))
@@ -232,6 +248,13 @@ class TestPageListing(TestCase):
             'related_links',
         ]
         self.assertEqual(list(content['items'][0].keys()), field_order)
+
+    def test_star_in_wrong_position_gives_error(self):
+        response = self.get_response(fields='title,*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "fields error: '*' must be in the first position"})
 
     def test_fields_without_type_gives_error(self):
         response = self.get_response(fields='title,related_links')

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -199,6 +199,14 @@ class TestPageListing(TestCase):
             self.assertEqual(set(page.keys()), {'id', 'meta', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image'})
             self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'slug', 'html_url', 'search_description'})
 
+    def test_remove_all_fields(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='_,id,type')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'meta'})
+            self.assertEqual(set(page['meta'].keys()), {'type'})
+
     def test_nested_fields(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='feed_image(width,height)')
         content = json.loads(response.content.decode('UTF-8'))
@@ -219,6 +227,13 @@ class TestPageListing(TestCase):
 
         for page in content['items']:
             self.assertEqual(set(page['feed_image'].keys()), {'id', 'meta', 'title', 'width', 'height'})
+
+    def test_remove_all_nested_fields(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='feed_image(_,id)')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page['feed_image'].keys()), {'id'})
 
     def test_nested_nested_fields(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='carousel_items(image(width,height))')

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -153,6 +153,12 @@ class TestParseFieldsParameter(TestCase):
 
         self.assertEqual(str(e.exception), "unexpected end of input (did you miss out a close bracket?)")
 
+    def test_invalid_subfields_on_negated_field(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('-test(foo)')
+
+        self.assertEqual(str(e.exception), "unexpected char '(' at position 5")
+
     def test_invalid_star_field_in_wrong_position(self):
         with self.assertRaises(FieldsParameterParseError) as e:
             parse_fields_parameter('test,*')

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -1,0 +1,148 @@
+from __future__ import absolute_import, unicode_literals
+
+from unittest import TestCase
+
+from ..utils import FieldsParameterParseError, parse_fields_parameter
+
+
+class TestParseFieldsParameter(TestCase):
+    # GOOD STUFF
+
+    def test_valid_single_field(self):
+        parsed = parse_fields_parameter('test')
+
+        self.assertEqual(parsed, [
+            ('test', False, None),
+        ])
+
+    def test_valid_multiple_fields(self):
+        parsed = parse_fields_parameter('test,another_test')
+
+        self.assertEqual(parsed, [
+            ('test', False, None),
+            ('another_test', False, None),
+        ])
+
+    def test_valid_negated_field(self):
+        parsed = parse_fields_parameter('-test')
+
+        self.assertEqual(parsed, [
+            ('test', True, None),
+        ])
+
+    def test_valid_nested_fields(self):
+        parsed = parse_fields_parameter('test(foo,bar)')
+
+        self.assertEqual(parsed, [
+            ('test', False, [
+                ('foo', False, None),
+                ('bar', False, None),
+            ]),
+        ])
+
+    def test_valid_star_field(self):
+        parsed = parse_fields_parameter('*,test')
+
+        self.assertEqual(parsed, [
+            ('*', False, None),
+            ('test', False, None),
+        ])
+
+
+    # BAD STUFF
+
+    def test_invalid_char(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test#')
+
+        self.assertEqual(str(e.exception), "unexpected char '#' at position 4")
+
+    def test_invalid_whitespace_before_identifier(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter(' test')
+
+        self.assertEqual(str(e.exception), "unexpected whitespace at position 0")
+
+    def test_invalid_whitespace_after_identifier(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test ')
+
+        self.assertEqual(str(e.exception), "unexpected whitespace at position 4")
+
+    def test_invalid_whitespace_after_comma(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test, test')
+
+        self.assertEqual(str(e.exception), "unexpected whitespace at position 5")
+
+    def test_invalid_whitespace_before_comma(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test ,test')
+
+        self.assertEqual(str(e.exception), "unexpected whitespace at position 4")
+
+    def test_invalid_unexpected_negation_operator(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test-')
+
+        self.assertEqual(str(e.exception), "unexpected char '-' at position 4")
+
+    def test_invalid_unexpected_open_bracket(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test,(foo)')
+
+        self.assertEqual(str(e.exception), "unexpected char '(' at position 5")
+
+    def test_invalid_unexpected_close_bracket(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test)')
+
+        self.assertEqual(str(e.exception), "unexpected char ')' at position 4")
+
+    def test_invalid_unexpected_comma_in_middle(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test,,foo')
+
+        self.assertEqual(str(e.exception), "unexpected char ',' at position 5")
+
+    def test_invalid_unexpected_comma_at_end(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test,foo,')
+
+        self.assertEqual(str(e.exception), "unexpected char ',' at position 9")
+
+    def test_invalid_unclosed_bracket(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test(foo')
+
+        self.assertEqual(str(e.exception), "unexpected end of input (did you miss out a close bracket?)")
+
+    def test_invalid_star_field_in_wrong_position(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test,*')
+
+        self.assertEqual(str(e.exception), "'*' must be in the first position")
+
+    def test_invalid_negated_star(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('-*')
+
+        self.assertEqual(str(e.exception), "'*' cannot be negated")
+
+    def test_invalid_star_with_nesting(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('*(foo,bar)')
+
+        self.assertEqual(str(e.exception), "unexpected char '(' at position 1")
+
+    def test_invalid_star_with_chars_after(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('*foo')
+
+        self.assertEqual(str(e.exception), "unexpected char 'f' at position 1")
+
+    def test_invalid_star_with_chars_before(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('foo*')
+
+        self.assertEqual(str(e.exception), "unexpected char '*' at position 3")

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -48,6 +48,42 @@ class TestParseFieldsParameter(TestCase):
             ('test', False, None),
         ])
 
+    def test_valid_underscore_field(self):
+        parsed = parse_fields_parameter('_,test')
+
+        self.assertEqual(parsed, [
+            ('_', False, None),
+            ('test', False, None),
+        ])
+
+    def test_valid_field_with_underscore_in_middle(self):
+        parsed = parse_fields_parameter('a_test')
+
+        self.assertEqual(parsed, [
+            ('a_test', False, None),
+        ])
+
+    def test_valid_negated_field_with_underscore_in_middle(self):
+        parsed = parse_fields_parameter('-a_test')
+
+        self.assertEqual(parsed, [
+            ('a_test', True, None),
+        ])
+
+    def test_valid_field_with_underscore_at_beginning(self):
+        parsed = parse_fields_parameter('_test')
+
+        self.assertEqual(parsed, [
+            ('_test', False, None),
+        ])
+
+    def test_valid_field_with_underscore_at_end(self):
+        parsed = parse_fields_parameter('test_')
+
+        self.assertEqual(parsed, [
+            ('test_', False, None),
+        ])
+
 
     # BAD STUFF
 
@@ -146,3 +182,27 @@ class TestParseFieldsParameter(TestCase):
             parse_fields_parameter('foo*')
 
         self.assertEqual(str(e.exception), "unexpected char '*' at position 3")
+
+    def test_invalid_underscore_in_wrong_position(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test,_')
+
+        self.assertEqual(str(e.exception), "'_' must be in the first position")
+
+    def test_invalid_negated_underscore(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('-_')
+
+        self.assertEqual(str(e.exception), "'_' cannot be negated")
+
+    def test_invalid_underscore_with_nesting(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('_(foo,bar)')
+
+        self.assertEqual(str(e.exception), "unexpected char '(' at position 1")
+
+    def test_invalid_star_and_underscore(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('*,_')
+
+        self.assertEqual(str(e.exception), "'_' must be in the first position")

--- a/wagtail/api/v2/utils.py
+++ b/wagtail/api/v2/utils.py
@@ -169,6 +169,10 @@ def parse_fields_parameter(fields_str):
                     raise FieldsParameterParseError("'%s' cannot be negated" % ident)
 
             if fields_str and fields_str[0] == '(':
+                if negated:
+                    # Negated fields cannot contain subfields
+                    raise FieldsParameterParseError("unexpected char '(' at position %d" % get_position(fields_str))
+
                 sub_fields, fields_str = parse_fields(fields_str[1:], expect_close_bracket=True)
 
             fields.append((ident, negated, sub_fields))

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -40,6 +40,9 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
         'children',
     ]
 
+    # Allow the parent field to appear on listings
+    detail_only_fields = []
+
     known_query_parameters = PagesAPIEndpoint.known_query_parameters.union([
         'has_children'
     ])

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -26,7 +26,7 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
         SearchFilter,
     ]
 
-    extra_meta_fields = PagesAPIEndpoint.extra_meta_fields + [
+    meta_fields = PagesAPIEndpoint.meta_fields + [
         'latest_revision_created_at',
         'status',
         'children',

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -34,7 +34,7 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
         'parent',
     ]
 
-    default_fields = PagesAPIEndpoint.default_fields + [
+    listing_default_fields = PagesAPIEndpoint.listing_default_fields + [
         'latest_revision_created_at',
         'status',
         'children',

--- a/wagtail/wagtailadmin/api/serializers.py
+++ b/wagtail/wagtailadmin/api/serializers.py
@@ -82,9 +82,3 @@ class AdminPageSerializer(PageSerializer):
     status = PageStatusField(read_only=True)
     children = PageChildrenField(read_only=True)
     descendants = PageDescendantsField(read_only=True)
-
-    meta_fields = PageSerializer.meta_fields + [
-        'status',
-        'children',
-        'descendants',
-    ]

--- a/wagtail/wagtailadmin/tests/api/test_images.py
+++ b/wagtail/wagtailadmin/tests/api/test_images.py
@@ -105,6 +105,22 @@ class TestAdminImageListing(AdminAPITestCase, TestImageListing):
         for image in content['items']:
             self.assertEqual(set(image.keys()), {'meta', 'title', 'width', 'height', 'thumbnail'})
 
+    def test_all_fields(self):
+        response = self.get_response(fields='*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+
+    def test_all_fields_then_remove_something(self):
+        response = self.get_response(fields='*,-title,-tags')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'width', 'height', 'thumbnail'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url'})
+
     def test_fields_tags(self):
         response = self.get_response(fields='tags')
         content = json.loads(response.content.decode('UTF-8'))

--- a/wagtail/wagtailadmin/tests/api/test_images.py
+++ b/wagtail/wagtailadmin/tests/api/test_images.py
@@ -137,7 +137,6 @@ class TestAdminImageDetail(AdminAPITestCase, TestImageDetail):
     def get_response(self, image_id, **params):
         return self.client.get(reverse('wagtailadmin_api_v1:images:detail', args=(image_id, )), params)
 
-
     def test_basic(self):
         response = self.get_response(5)
 

--- a/wagtail/wagtailadmin/tests/api/test_images.py
+++ b/wagtail/wagtailadmin/tests/api/test_images.py
@@ -76,6 +76,35 @@ class TestAdminImageListing(AdminAPITestCase, TestImageListing):
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
             self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
 
+    def test_remove_fields(self):
+        response = self.get_response(fields='-title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'width', 'height', 'thumbnail'})
+
+    def test_remove_meta_fields(self):
+        response = self.get_response(fields='-tags')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url'})
+
+    def test_remove_all_meta_fields(self):
+        response = self.get_response(fields='-type,-detail_url,-tags')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'title', 'width', 'height', 'thumbnail'})
+
+    def test_remove_id_field(self):
+        response = self.get_response(fields='-id')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'meta', 'title', 'width', 'height', 'thumbnail'})
+
     def test_fields_tags(self):
         response = self.get_response(fields='tags')
         content = json.loads(response.content.decode('UTF-8'))

--- a/wagtail/wagtailadmin/tests/api/test_images.py
+++ b/wagtail/wagtailadmin/tests/api/test_images.py
@@ -68,6 +68,23 @@ class TestAdminImageListing(AdminAPITestCase, TestImageListing):
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
             self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
 
+    def test_fields(self):
+        response = self.get_response(fields='width,height')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+
+    def test_fields_tags(self):
+        response = self.get_response(fields='tags')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+            self.assertIsInstance(image['meta']['tags'], list)
+
 
 class TestAdminImageDetail(AdminAPITestCase, TestImageDetail):
     fixtures = ['demosite.json']

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -166,7 +166,7 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
 
             if feed_image is not None:
                 self.assertIsInstance(feed_image, dict)
-                self.assertEqual(set(feed_image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
+                self.assertEqual(set(feed_image.keys()), {'id', 'meta', 'title'})
                 self.assertIsInstance(feed_image['id'], int)
                 self.assertIsInstance(feed_image['meta'], dict)
                 self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url'})
@@ -181,13 +181,14 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
             parent = page['meta']['parent']
 
             # All blog entry pages have the same parent
-            self.assertEqual(parent, {
+            self.assertDictEqual(parent, {
                 'id': 5,
                 'meta': {
                     'type': 'demosite.BlogIndexPage',
                     'detail_url': 'http://localhost/admin/api/v2beta/pages/5/',
                     'html_url': 'http://localhost/blog-index/',
-                }
+                },
+                'title': "Blog index"
             })
 
     def test_fields_descendants(self):
@@ -354,7 +355,7 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
 
         # Check that the feed image was serialised properly
         self.assertIsInstance(content['feed_image'], dict)
-        self.assertEqual(set(content['feed_image'].keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
+        self.assertEqual(set(content['feed_image'].keys()), {'id', 'meta', 'title'})
         self.assertEqual(content['feed_image']['id'], 7)
         self.assertIsInstance(content['feed_image']['meta'], dict)
         self.assertEqual(set(content['feed_image']['meta'].keys()), {'type', 'detail_url'})

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -146,6 +146,13 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
             self.assertEqual(set(page.keys()), {'id', 'meta', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image'})
             self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'slug', 'parent', 'html_url', 'search_description', 'children', 'descendants', 'latest_revision_created_at'})
 
+    def test_all_nested_fields(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='feed_image(*)')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page['feed_image'].keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
+
     def test_fields_foreign_key(self):
         # Only the base the detail_url is different here from the public API
         response = self.get_response(type='demosite.BlogEntryPage', fields='title,date,feed_image')
@@ -156,7 +163,7 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
 
             if feed_image is not None:
                 self.assertIsInstance(feed_image, dict)
-                self.assertEqual(set(feed_image.keys()), {'id', 'meta'})
+                self.assertEqual(set(feed_image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
                 self.assertIsInstance(feed_image['id'], int)
                 self.assertIsInstance(feed_image['meta'], dict)
                 self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url'})
@@ -320,7 +327,7 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
         # Check the parent field
         self.assertIn('parent', content['meta'])
         self.assertIsInstance(content['meta']['parent'], dict)
-        self.assertEqual(set(content['meta']['parent'].keys()), {'id', 'meta'})
+        self.assertEqual(set(content['meta']['parent'].keys()), {'id', 'meta', 'title'})
         self.assertEqual(content['meta']['parent']['id'], 5)
         self.assertIsInstance(content['meta']['parent']['meta'], dict)
         self.assertEqual(set(content['meta']['parent']['meta'].keys()), {'type', 'detail_url', 'html_url'})
@@ -344,7 +351,7 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
 
         # Check that the feed image was serialised properly
         self.assertIsInstance(content['feed_image'], dict)
-        self.assertEqual(set(content['feed_image'].keys()), {'id', 'meta'})
+        self.assertEqual(set(content['feed_image'].keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
         self.assertEqual(content['feed_image']['id'], 7)
         self.assertIsInstance(content['feed_image']['meta'], dict)
         self.assertEqual(set(content['feed_image']['meta'].keys()), {'type', 'detail_url'})

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -107,6 +107,9 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
 
     # FIELDS
 
+    # Not applicable to the admin API
+    test_parent_field_gives_error = None
+
     def test_fields_default(self):
         response = self.get_response(type='demosite.BlogEntryPage')
         content = json.loads(response.content.decode('UTF-8'))

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -130,6 +130,22 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
         for page in content['items']:
             self.assertEqual(set(page.keys()), {'id', 'title'})
 
+    def test_all_fields(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image'})
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'seo_title', 'slug', 'parent', 'html_url', 'search_description', 'children', 'descendants', 'status', 'latest_revision_created_at'})
+
+    def test_all_fields_then_remove_something(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='*,-title,-date,-seo_title,-status')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image'})
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'slug', 'parent', 'html_url', 'search_description', 'children', 'descendants', 'latest_revision_created_at'})
+
     def test_fields_foreign_key(self):
         # Only the base the detail_url is different here from the public API
         response = self.get_response(type='demosite.BlogEntryPage', fields='title,date,feed_image')

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -115,6 +115,21 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
             self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
             self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'children', 'status', 'slug', 'first_published_at', 'latest_revision_created_at'})
 
+    def test_remove_meta_fields(self):
+        response = self.get_response(fields='-html_url')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'slug', 'first_published_at', 'latest_revision_created_at', 'status', 'children'})
+
+    def test_remove_all_meta_fields(self):
+        response = self.get_response(fields='-type,-detail_url,-slug,-first_published_at,-html_url,-latest_revision_created_at,-status,-children')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'title'})
+
     def test_fields_foreign_key(self):
         # Only the base the detail_url is different here from the public API
         response = self.get_response(type='demosite.BlogEntryPage', fields='title,date,feed_image')

--- a/wagtail/wagtaildocs/api/v2/endpoints.py
+++ b/wagtail/wagtaildocs/api/v2/endpoints.py
@@ -10,8 +10,9 @@ from .serializers import DocumentSerializer
 class DocumentsAPIEndpoint(BaseAPIEndpoint):
     base_serializer_class = DocumentSerializer
     filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
-    extra_body_fields = ['title']
-    extra_meta_fields = ['tags', ]
-    default_fields = ['title', 'tags']
+    body_fields = BaseAPIEndpoint.body_fields + ['title']
+    meta_fields = BaseAPIEndpoint.meta_fields + ['tags', 'download_url']
+    default_fields = BaseAPIEndpoint.default_fields + ['download_url']
+    soft_default_fields = BaseAPIEndpoint.soft_default_fields + ['title', 'tags']
     name = 'documents'
     model = get_document_model()

--- a/wagtail/wagtaildocs/api/v2/endpoints.py
+++ b/wagtail/wagtaildocs/api/v2/endpoints.py
@@ -12,6 +12,7 @@ class DocumentsAPIEndpoint(BaseAPIEndpoint):
     filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
     body_fields = BaseAPIEndpoint.body_fields + ['title']
     meta_fields = BaseAPIEndpoint.meta_fields + ['tags', 'download_url']
-    default_fields = BaseAPIEndpoint.default_fields + ['title', 'tags', 'download_url']
+    listing_default_fields = BaseAPIEndpoint.listing_default_fields + ['title', 'tags', 'download_url']
+    nested_default_fields = BaseAPIEndpoint.nested_default_fields + ['title', 'download_url']
     name = 'documents'
     model = get_document_model()

--- a/wagtail/wagtaildocs/api/v2/endpoints.py
+++ b/wagtail/wagtaildocs/api/v2/endpoints.py
@@ -12,7 +12,6 @@ class DocumentsAPIEndpoint(BaseAPIEndpoint):
     filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
     body_fields = BaseAPIEndpoint.body_fields + ['title']
     meta_fields = BaseAPIEndpoint.meta_fields + ['tags', 'download_url']
-    default_fields = BaseAPIEndpoint.default_fields + ['download_url']
-    soft_default_fields = BaseAPIEndpoint.soft_default_fields + ['title', 'tags']
+    default_fields = BaseAPIEndpoint.default_fields + ['title', 'tags', 'download_url']
     name = 'documents'
     model = get_document_model()

--- a/wagtail/wagtaildocs/api/v2/serializers.py
+++ b/wagtail/wagtaildocs/api/v2/serializers.py
@@ -22,11 +22,3 @@ class DocumentDownloadUrlField(Field):
 
 class DocumentSerializer(BaseSerializer):
     download_url = DocumentDownloadUrlField(read_only=True)
-
-    default_fields = BaseSerializer.default_fields + [
-        'download_url',
-    ]
-
-    meta_fields = BaseSerializer.meta_fields + [
-        'download_url',
-    ]

--- a/wagtail/wagtailimages/api/admin/endpoints.py
+++ b/wagtail/wagtailimages/api/admin/endpoints.py
@@ -11,7 +11,7 @@ class ImagesAdminAPIEndpoint(ImagesAPIEndpoint):
         'thumbnail',
     ]
 
-    soft_default_fields = ImagesAPIEndpoint.soft_default_fields + [
+    default_fields = ImagesAPIEndpoint.default_fields + [
         'width',
         'height',
         'thumbnail',

--- a/wagtail/wagtailimages/api/admin/endpoints.py
+++ b/wagtail/wagtailimages/api/admin/endpoints.py
@@ -11,7 +11,7 @@ class ImagesAdminAPIEndpoint(ImagesAPIEndpoint):
         'thumbnail',
     ]
 
-    default_fields = ImagesAPIEndpoint.default_fields + [
+    listing_default_fields = ImagesAPIEndpoint.listing_default_fields + [
         'width',
         'height',
         'thumbnail',

--- a/wagtail/wagtailimages/api/admin/endpoints.py
+++ b/wagtail/wagtailimages/api/admin/endpoints.py
@@ -7,11 +7,11 @@ from .serializers import AdminImageSerializer
 class ImagesAdminAPIEndpoint(ImagesAPIEndpoint):
     base_serializer_class = AdminImageSerializer
 
-    extra_body_fields = ImagesAPIEndpoint.extra_body_fields + [
+    body_fields = ImagesAPIEndpoint.body_fields + [
         'thumbnail',
     ]
 
-    default_fields = ImagesAPIEndpoint.default_fields + [
+    soft_default_fields = ImagesAPIEndpoint.soft_default_fields + [
         'width',
         'height',
         'thumbnail',

--- a/wagtail/wagtailimages/api/v2/endpoints.py
+++ b/wagtail/wagtailimages/api/v2/endpoints.py
@@ -13,6 +13,6 @@ class ImagesAPIEndpoint(BaseAPIEndpoint):
     filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
     body_fields = BaseAPIEndpoint.body_fields + ['title', 'width', 'height']
     meta_fields = BaseAPIEndpoint.meta_fields + ['tags']
-    soft_default_fields = BaseAPIEndpoint.soft_default_fields + ['title', 'tags']
+    default_fields = BaseAPIEndpoint.default_fields + ['title', 'tags']
     name = 'images'
     model = get_image_model()

--- a/wagtail/wagtailimages/api/v2/endpoints.py
+++ b/wagtail/wagtailimages/api/v2/endpoints.py
@@ -11,8 +11,8 @@ from .serializers import ImageSerializer
 class ImagesAPIEndpoint(BaseAPIEndpoint):
     base_serializer_class = ImageSerializer
     filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
-    extra_body_fields = ['title', 'width', 'height']
-    extra_meta_fields = ['tags']
-    default_fields = ['title', 'tags']
+    body_fields = BaseAPIEndpoint.body_fields + ['title', 'width', 'height']
+    meta_fields = BaseAPIEndpoint.meta_fields + ['tags']
+    soft_default_fields = BaseAPIEndpoint.soft_default_fields + ['title', 'tags']
     name = 'images'
     model = get_image_model()

--- a/wagtail/wagtailimages/api/v2/endpoints.py
+++ b/wagtail/wagtailimages/api/v2/endpoints.py
@@ -13,6 +13,7 @@ class ImagesAPIEndpoint(BaseAPIEndpoint):
     filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
     body_fields = BaseAPIEndpoint.body_fields + ['title', 'width', 'height']
     meta_fields = BaseAPIEndpoint.meta_fields + ['tags']
-    default_fields = BaseAPIEndpoint.default_fields + ['title', 'tags']
+    listing_default_fields = BaseAPIEndpoint.listing_default_fields + ['title', 'tags']
+    nested_default_fields = BaseAPIEndpoint.nested_default_fields + ['title']
     name = 'images'
     model = get_image_model()


### PR DESCRIPTION
See: https://github.com/torchbox/wagtail-rfcs/blob/master/accepted/005-wagtail-api-fields.rst

 - [x] Refactoring to give endpoint classes more control over the fields the serialisers will render
 - [x] "title" and "tags" no longer disappear when a user specifies custom set of fields
 - [x] Implemented '-' operator for removing fields
 - [x] ``*`` operator for adding all fields into the response
 - [x] Nested fields
 - [x] ``_`` operator for removing all fields from the response

This is implemented on top of the Admin API as I expect that'll be merged before this (and it makes development much easier since this affects both)