### PR TITLE
Initial work on the Admin API

### DIFF
--- a/wagtail/api/v2/endpoints.py
+++ b/wagtail/api/v2/endpoints.py
@@ -191,6 +191,15 @@ class BaseAPIEndpoint(GenericViewSet):
         ]
 
     @classmethod
+    def get_model_listing_urlpath(cls, model, namespace=''):
+        if namespace:
+            url_name = namespace + ':listing'
+        else:
+            url_name = 'listing'
+
+        return reverse(url_name)
+
+    @classmethod
     def get_object_detail_urlpath(cls, model, pk, namespace=''):
         if namespace:
             url_name = namespace + ':detail'

--- a/wagtail/api/v2/endpoints.py
+++ b/wagtail/api/v2/endpoints.py
@@ -57,6 +57,15 @@ class BaseAPIEndpoint(GenericViewSet):
     default_fields = []
     name = None  # Set on subclass.
 
+    def __init__(self, *args, **kwargs):
+        super(BaseAPIEndpoint, self).__init__(*args, **kwargs)
+
+        # seen_types is a mapping of type name strings (format: "app_label.ModelName")
+        # to model classes. When an object is serialised in the API, its model
+        # is added to this mapping. This is used by the Admin API which appends a
+        # summary of the used types to the response.
+        self.seen_types = OrderedDict()
+
     def get_queryset(self):
         return self.model.objects.all().order_by('id')
 

--- a/wagtail/api/v2/router.py
+++ b/wagtail/api/v2/router.py
@@ -30,6 +30,20 @@ class WagtailAPIRouter(object):
             if issubclass(model, class_.model):
                 return name, class_
 
+    def get_model_listing_urlpath(self, model):
+        """
+        Returns a URL path (excluding scheme and hostname) to the listing
+        page of a model
+
+        Returns None if the model is not represented by any endpoints.
+        """
+        endpoint = self.get_model_endpoint(model)
+
+        if endpoint:
+            endpoint_name, endpoint_class = endpoint[0], endpoint[1]
+            url_namespace = self.url_namespace + ':' + endpoint_name
+            return endpoint_class.get_model_listing_urlpath(model, namespace=url_namespace)
+
     def get_object_detail_urlpath(self, model, pk):
         """
         Returns a URL path (excluding scheme and hostname) to the detail

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -40,7 +40,9 @@ class TypeField(Field):
         return instance
 
     def to_representation(self, obj):
-        return type(obj)._meta.app_label + '.' + type(obj).__name__
+        name = type(obj)._meta.app_label + '.' + type(obj).__name__
+        self.context['view'].seen_types[name] = type(obj)
+        return name
 
 
 class DetailUrlField(Field):
@@ -95,7 +97,9 @@ class PageTypeField(Field):
         return instance
 
     def to_representation(self, page):
-        return page.specific_class._meta.app_label + '.' + page.specific_class.__name__
+        name = page.specific_class._meta.app_label + '.' + page.specific_class.__name__
+        self.context['view'].seen_types[name] = page.specific_class
+        return name
 
 
 class DocumentDownloadUrlField(Field):

--- a/wagtail/wagtailadmin/api.py
+++ b/wagtail/wagtailadmin/api.py
@@ -1,9 +1,36 @@
 from wagtail.api.shared.router import WagtailAPIRouter
+from wagtail.api.shared.utils import BadRequestError, page_models_from_string, filter_page_type
 from wagtail.api.v2.endpoints import PagesAPIEndpoint, ImagesAPIEndpoint, DocumentsAPIEndpoint
+
+from wagtail.wagtailcore.models import Page
 
 
 class PagesAdminAPIEndpoint(PagesAPIEndpoint):
-    pass
+    def get_queryset(self):
+        request = self.request
+
+        # Allow pages to be filtered to a specific type
+        try:
+            models = page_models_from_string(request.GET.get('type', 'wagtailcore.Page'))
+        except (LookupError, ValueError):
+            raise BadRequestError("type doesn't exist")
+
+        if not models:
+            models = [Page]
+
+        if len(models) == 1:
+            queryset = models[0].objects.all()
+        else:
+            queryset = Page.objects.all()
+
+            # Filter pages by specified models
+            queryset = filter_page_type(queryset, models)
+
+        # Hide root page
+        # TODO: Add "include_root" flag
+        queryset = queryset.exclude(depth=1)
+
+        return queryset
 
 
 class ImagesAdminAPIEndpoint(ImagesAPIEndpoint):

--- a/wagtail/wagtailadmin/api.py
+++ b/wagtail/wagtailadmin/api.py
@@ -1,0 +1,20 @@
+from wagtail.api.shared.router import WagtailAPIRouter
+from wagtail.api.v2.endpoints import PagesAPIEndpoint, ImagesAPIEndpoint, DocumentsAPIEndpoint
+
+
+class PagesAdminAPIEndpoint(PagesAPIEndpoint):
+    pass
+
+
+class ImagesAdminAPIEndpoint(ImagesAPIEndpoint):
+    pass
+
+
+class DocumentsAdminAPIEndpoint(DocumentsAPIEndpoint):
+    pass
+
+
+admin_api_v1 = WagtailAPIRouter('wagtailadmin_api_v1')
+admin_api_v1.register_endpoint('pages', PagesAdminAPIEndpoint)
+admin_api_v1.register_endpoint('images', ImagesAdminAPIEndpoint)
+admin_api_v1.register_endpoint('documents', DocumentsAdminAPIEndpoint)

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -10,18 +10,21 @@ from wagtail.api.v2.filters import (
 from wagtail.wagtailcore.models import Page
 
 from .serializers import AdminPageSerializer, AdminImageSerializer
+from .filters import HasChildrenFilter
 
 
 class PagesAdminAPIEndpoint(PagesAPIEndpoint):
     base_serializer_class = AdminPageSerializer
 
-    # Use unrestricted filters
+    # Use unrestricted child_of/descendant_of filters
+    # Add has_children filter
     filter_backends = [
         FieldsFilter,
         ChildOfFilter,
         DescendantOfFilter,
+        HasChildrenFilter,
         OrderingFilter,
-        SearchFilter
+        SearchFilter,
     ]
 
     extra_meta_fields = PagesAPIEndpoint.extra_meta_fields + [
@@ -35,6 +38,10 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
         'status',
         'children',
     ]
+
+    known_query_parameters = PagesAPIEndpoint.known_query_parameters.union([
+        'has_children'
+    ])
 
     def get_queryset(self):
         request = self.request

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -1,5 +1,9 @@
 from wagtail.api.v2.utils import BadRequestError, page_models_from_string, filter_page_type
 from wagtail.api.v2.endpoints import PagesAPIEndpoint, ImagesAPIEndpoint, DocumentsAPIEndpoint
+from wagtail.api.v2.filters import (
+    FieldsFilter, OrderingFilter, SearchFilter,
+    ChildOfFilter, DescendantOfFilter
+)
 
 from wagtail.wagtailcore.models import Page
 
@@ -8,6 +12,15 @@ from .serializers import AdminPageSerializer, AdminImageSerializer
 
 class PagesAdminAPIEndpoint(PagesAPIEndpoint):
     base_serializer_class = AdminPageSerializer
+
+    # Use unrestricted filters
+    filter_backends = [
+        FieldsFilter,
+        ChildOfFilter,
+        DescendantOfFilter,
+        OrderingFilter,
+        SearchFilter
+    ]
 
     api_fields = [
         'title',

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -3,7 +3,7 @@ from wagtail.api.v2.endpoints import PagesAPIEndpoint, ImagesAPIEndpoint, Docume
 
 from wagtail.wagtailcore.models import Page
 
-from .serializers import AdminPageSerializer
+from .serializers import AdminPageSerializer, AdminImageSerializer
 
 
 class PagesAdminAPIEndpoint(PagesAPIEndpoint):
@@ -37,7 +37,7 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
 
 
 class ImagesAdminAPIEndpoint(ImagesAPIEndpoint):
-    pass
+    base_serializer_class = AdminImageSerializer
 
 
 class DocumentsAdminAPIEndpoint(DocumentsAPIEndpoint):

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -9,6 +9,11 @@ from .serializers import AdminPageSerializer, AdminImageSerializer
 class PagesAdminAPIEndpoint(PagesAPIEndpoint):
     base_serializer_class = AdminPageSerializer
 
+    extra_api_fields = PagesAPIEndpoint.extra_api_fields + [
+        'status',
+        'children',
+    ]
+
     def get_queryset(self):
         request = self.request
 
@@ -38,6 +43,10 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
 
 class ImagesAdminAPIEndpoint(ImagesAPIEndpoint):
     base_serializer_class = AdminImageSerializer
+
+    extra_api_fields = ImagesAPIEndpoint.extra_api_fields + [
+        'thumbnail',
+    ]
 
 
 class DocumentsAdminAPIEndpoint(DocumentsAPIEndpoint):

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -1,16 +1,15 @@
+from __future__ import absolute_import, unicode_literals
+
 from collections import OrderedDict
 
-from wagtail.api.v2.utils import BadRequestError, page_models_from_string, filter_page_type
-from wagtail.api.v2.endpoints import PagesAPIEndpoint, ImagesAPIEndpoint, DocumentsAPIEndpoint
+from wagtail.api.v2.endpoints import DocumentsAPIEndpoint, ImagesAPIEndpoint, PagesAPIEndpoint
 from wagtail.api.v2.filters import (
-    FieldsFilter, OrderingFilter, SearchFilter,
-    ChildOfFilter, DescendantOfFilter
-)
-
+    ChildOfFilter, DescendantOfFilter, FieldsFilter, OrderingFilter, SearchFilter)
+from wagtail.api.v2.utils import BadRequestError, filter_page_type, page_models_from_string
 from wagtail.wagtailcore.models import Page
 
-from .serializers import AdminPageSerializer, AdminImageSerializer
 from .filters import HasChildrenFilter
+from .serializers import AdminImageSerializer, AdminPageSerializer
 
 
 class PagesAdminAPIEndpoint(PagesAPIEndpoint):

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -9,10 +9,17 @@ from .serializers import AdminPageSerializer, AdminImageSerializer
 class PagesAdminAPIEndpoint(PagesAPIEndpoint):
     base_serializer_class = AdminPageSerializer
 
-    extra_api_fields = PagesAPIEndpoint.extra_api_fields + [
+    api_fields = [
+        'title',
+        'slug',
+        'first_published_at',
         'status',
         'children',
+        'title',
     ]
+
+    def get_available_fields(self, model):
+        return self.api_fields
 
     def get_queryset(self):
         request = self.request
@@ -44,10 +51,23 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
 class ImagesAdminAPIEndpoint(ImagesAPIEndpoint):
     base_serializer_class = AdminImageSerializer
 
-    extra_api_fields = ImagesAPIEndpoint.extra_api_fields + [
+    api_fields = [
+        'title',
+        'tags',
+        'width',
+        'height',
         'thumbnail',
     ]
 
+    def get_available_fields(self, model):
+        return self.api_fields
+
 
 class DocumentsAdminAPIEndpoint(DocumentsAPIEndpoint):
-    pass
+    api_fields = [
+        'title',
+        'tags',
+    ]
+
+    def get_available_fields(self, model):
+        return self.api_fields

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -22,7 +22,12 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
         SearchFilter
     ]
 
-    extra_api_fields = PagesAPIEndpoint.extra_api_fields + [
+    extra_meta_fields = PagesAPIEndpoint.extra_meta_fields + [
+        'status',
+        'children',
+    ]
+
+    default_fields = PagesAPIEndpoint.default_fields + [
         'status',
         'children',
     ]
@@ -57,9 +62,16 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
 class ImagesAdminAPIEndpoint(ImagesAPIEndpoint):
     base_serializer_class = AdminImageSerializer
 
-    extra_api_fields = ImagesAPIEndpoint.extra_api_fields + [
+    extra_body_fields = ImagesAPIEndpoint.extra_body_fields + [
         'thumbnail',
     ]
+
+    default_fields = ImagesAPIEndpoint.default_fields + [
+        'width',
+        'height',
+        'thumbnail',
+    ]
+
 
 
 class DocumentsAdminAPIEndpoint(DocumentsAPIEndpoint):

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -25,11 +25,13 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
     ]
 
     extra_meta_fields = PagesAPIEndpoint.extra_meta_fields + [
+        'latest_revision_created_at',
         'status',
         'children',
     ]
 
     default_fields = PagesAPIEndpoint.default_fields + [
+        'latest_revision_created_at',
         'status',
         'children',
     ]

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -22,17 +22,10 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
         SearchFilter
     ]
 
-    api_fields = [
-        'title',
-        'slug',
-        'first_published_at',
+    extra_api_fields = PagesAPIEndpoint.extra_api_fields + [
         'status',
         'children',
-        'title',
     ]
-
-    def get_available_fields(self, model):
-        return self.api_fields
 
     def get_queryset(self):
         request = self.request
@@ -64,23 +57,10 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
 class ImagesAdminAPIEndpoint(ImagesAPIEndpoint):
     base_serializer_class = AdminImageSerializer
 
-    api_fields = [
-        'title',
-        'tags',
-        'width',
-        'height',
+    extra_api_fields = ImagesAPIEndpoint.extra_api_fields + [
         'thumbnail',
     ]
 
-    def get_available_fields(self, model):
-        return self.api_fields
-
 
 class DocumentsAdminAPIEndpoint(DocumentsAPIEndpoint):
-    api_fields = [
-        'title',
-        'tags',
-    ]
-
-    def get_available_fields(self, model):
-        return self.api_fields
+    pass

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -31,6 +31,7 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
         'latest_revision_created_at',
         'status',
         'children',
+        'parent',
     ]
 
     default_fields = PagesAPIEndpoint.default_fields + [

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -1,4 +1,3 @@
-from wagtail.api.shared.router import WagtailAPIRouter
 from wagtail.api.shared.utils import BadRequestError, page_models_from_string, filter_page_type
 from wagtail.api.v2.endpoints import PagesAPIEndpoint, ImagesAPIEndpoint, DocumentsAPIEndpoint
 
@@ -39,9 +38,3 @@ class ImagesAdminAPIEndpoint(ImagesAPIEndpoint):
 
 class DocumentsAdminAPIEndpoint(DocumentsAPIEndpoint):
     pass
-
-
-admin_api_v1 = WagtailAPIRouter('wagtailadmin_api_v1')
-admin_api_v1.register_endpoint('pages', PagesAdminAPIEndpoint)
-admin_api_v1.register_endpoint('images', ImagesAdminAPIEndpoint)
-admin_api_v1.register_endpoint('documents', DocumentsAdminAPIEndpoint)

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -3,8 +3,12 @@ from wagtail.api.v2.endpoints import PagesAPIEndpoint, ImagesAPIEndpoint, Docume
 
 from wagtail.wagtailcore.models import Page
 
+from .serializers import AdminPageSerializer
+
 
 class PagesAdminAPIEndpoint(PagesAPIEndpoint):
+    base_serializer_class = AdminPageSerializer
+
     def get_queryset(self):
         request = self.request
 

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -1,4 +1,4 @@
-from wagtail.api.shared.utils import BadRequestError, page_models_from_string, filter_page_type
+from wagtail.api.v2.utils import BadRequestError, page_models_from_string, filter_page_type
 from wagtail.api.v2.endpoints import PagesAPIEndpoint, ImagesAPIEndpoint, DocumentsAPIEndpoint
 
 from wagtail.wagtailcore.models import Page

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from wagtail.api.v2.utils import BadRequestError, page_models_from_string, filter_page_type
 from wagtail.api.v2.endpoints import PagesAPIEndpoint, ImagesAPIEndpoint, DocumentsAPIEndpoint
 from wagtail.api.v2.filters import (
@@ -57,6 +59,27 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
         queryset = queryset.exclude(depth=1)
 
         return queryset
+
+    def get_type_info(self):
+        types = OrderedDict()
+
+        for name, model in self.seen_types.items():
+            types[name] = OrderedDict([
+                ('verbose_name', model._meta.verbose_name),
+                ('verbose_name_plural', model._meta.verbose_name_plural),
+            ])
+
+        return types
+
+    def listing_view(self, request):
+        response = super(PagesAdminAPIEndpoint, self).listing_view(request)
+        response.data['__types'] = self.get_type_info()
+        return response
+
+    def detail_view(self, request, pk):
+        response = super(PagesAdminAPIEndpoint, self).detail_view(request, pk)
+        response.data['__types'] = self.get_type_info()
+        return response
 
 
 class ImagesAdminAPIEndpoint(ImagesAPIEndpoint):

--- a/wagtail/wagtailadmin/api/filters.py
+++ b/wagtail/wagtailadmin/api/filters.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from rest_framework.filters import BaseFilterBackend
 
 from wagtail.api.v2.utils import BadRequestError

--- a/wagtail/wagtailadmin/api/filters.py
+++ b/wagtail/wagtailadmin/api/filters.py
@@ -1,0 +1,24 @@
+from rest_framework.filters import BaseFilterBackend
+
+from wagtail.api.v2.utils import BadRequestError
+
+
+class HasChildrenFilter(BaseFilterBackend):
+    """
+    Filters the queryset by checking if the pages have children or not.
+    This is useful when you want to get just the branches or just the leaves.
+    """
+    def filter_queryset(self, request, queryset, view):
+        if 'has_children' in request.GET:
+            try:
+                has_children_filter = int(request.GET['has_children'])
+                assert has_children_filter is 1 or has_children_filter is 0
+            except (ValueError, AssertionError):
+                raise BadRequestError("has_children must be 1 or 0")
+
+            if has_children_filter == 1:
+                return queryset.filter(numchild__gt=0)
+            else:
+                return queryset.filter(numchild=0)
+
+        return queryset

--- a/wagtail/wagtailadmin/api/serializers.py
+++ b/wagtail/wagtailadmin/api/serializers.py
@@ -18,6 +18,7 @@ class AdminPageMetaField(PageMetaField):
     def to_representation(self, page):
         data = super(AdminPageMetaField, self).to_representation(page)
         data['status'] = page.status_string
+        data['has_children'] = page.numchild > 0
         return data
 
 

--- a/wagtail/wagtailadmin/api/serializers.py
+++ b/wagtail/wagtailadmin/api/serializers.py
@@ -1,9 +1,11 @@
+from __future__ import absolute_import, unicode_literals
+
 from collections import OrderedDict
 
 from rest_framework.fields import Field
 
+from wagtail.api.v2.serializers import ImageSerializer, PageSerializer
 from wagtail.api.v2.utils import get_full_url
-from wagtail.api.v2.serializers import PageSerializer, ImageSerializer
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailimages.models import SourceImageIOError
 

--- a/wagtail/wagtailadmin/api/serializers.py
+++ b/wagtail/wagtailadmin/api/serializers.py
@@ -19,13 +19,22 @@ class AdminPageMetaField(PageMetaField):
     "meta": {
         ...
 
-        "status": "live",
+        "status": {
+            "status": "live",
+            "live": true,
+            "has_unpublished_changes": false
+        },
         "has_children": true
     }
     """
     def to_representation(self, page):
         data = super(AdminPageMetaField, self).to_representation(page)
-        data['status'] = page.status_string
+        data['status'] = OrderedDict([
+            ('status', page.status_string),
+            ('live', page.live),
+            ('has_unpublished_changes', page.has_unpublished_changes),
+        ])
+
         data['has_children'] = page.numchild > 0
         return data
 

--- a/wagtail/wagtailadmin/api/serializers.py
+++ b/wagtail/wagtailadmin/api/serializers.py
@@ -12,14 +12,15 @@ class AdminPageMetaField(PageMetaField):
     """
     A subclass of PageMetaField for the admin API.
 
-    This adds the "status" field to the representation
+    This adds the "status" and "has_children" fields
 
     Example:
 
     "meta": {
         ...
 
-        "status": "live"
+        "status": "live",
+        "has_children": true
     }
     """
     def to_representation(self, page):

--- a/wagtail/wagtailadmin/api/serializers.py
+++ b/wagtail/wagtailadmin/api/serializers.py
@@ -1,0 +1,25 @@
+from wagtail.api.v2.serializers import PageMetaField, PageSerializer
+
+
+class AdminPageMetaField(PageMetaField):
+    """
+    A subclass of PageMetaField for the admin API.
+
+    This adds the "status" field to the representation
+
+    Example:
+
+    "meta": {
+        ...
+
+        "status": "live"
+    }
+    """
+    def to_representation(self, page):
+        data = super(AdminPageMetaField, self).to_representation(page)
+        data['status'] = page.status_string
+        return data
+
+
+class AdminPageSerializer(PageSerializer):
+    meta = AdminPageMetaField()

--- a/wagtail/wagtailadmin/api/serializers.py
+++ b/wagtail/wagtailadmin/api/serializers.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-from wagtail.api.shared.utils import get_full_url
+from wagtail.api.v2.utils import get_full_url
 from wagtail.api.v2.serializers import (
     PageMetaField, PageSerializer,
     MetaField, ImageSerializer,

--- a/wagtail/wagtailadmin/api/serializers.py
+++ b/wagtail/wagtailadmin/api/serializers.py
@@ -1,4 +1,11 @@
-from wagtail.api.v2.serializers import PageMetaField, PageSerializer
+from collections import OrderedDict
+
+from wagtail.api.v2.serializers import (
+    PageMetaField, PageSerializer,
+    MetaField, ImageSerializer,
+)
+
+from wagtail.wagtailimages.models import SourceImageIOError
 
 
 class AdminPageMetaField(PageMetaField):
@@ -24,3 +31,54 @@ class AdminPageMetaField(PageMetaField):
 
 class AdminPageSerializer(PageSerializer):
     meta = AdminPageMetaField()
+
+
+class AdminImageMetaField(MetaField):
+    """
+    A subclass of ImageMetaField for the admin API.
+
+    This adds the "thumbnail" field contain a URL/width/height of a max-165x165
+    rendition of the image.
+
+    Example:
+    "meta": {
+        ...
+
+        "thumbnail": {
+            "url": "/media/images/myimage.max-165x165.jpg",
+            "width": 165,
+            "height": 100
+        }
+    }
+
+    If there is an error with the source image. The "thumbnail" field will be
+    set to null and a new field "source_image_error" will be added and set to
+    true.
+
+    "meta": {
+        ...
+
+        "thumbnail": null,
+        "source_image_error": true
+    }
+    """
+    def to_representation(self, image):
+        data = super(AdminImageMetaField, self).to_representation(image)
+
+        try:
+            thumbnail = image.get_rendition('max-165x165')
+
+            data['thumbnail'] = OrderedDict([
+                ('url', thumbnail.url),
+                ('width', thumbnail.width),
+                ('height', thumbnail.height),
+            ])
+        except SourceImageIOError:
+            data['thumbnail'] = None
+            data['source_image_error'] = True
+
+        return data
+
+
+class AdminImageSerializer(ImageSerializer):
+    meta = AdminImageMetaField()

--- a/wagtail/wagtailadmin/api/urls.py
+++ b/wagtail/wagtailadmin/api/urls.py
@@ -13,5 +13,5 @@ v1.register_endpoint('images', ImagesAdminAPIEndpoint)
 v1.register_endpoint('documents', DocumentsAdminAPIEndpoint)
 
 urlpatterns = [
-    url(r'^v1beta/', v1.urls),
+    url(r'^v2beta/', v1.urls),
 ]

--- a/wagtail/wagtailadmin/api/urls.py
+++ b/wagtail/wagtailadmin/api/urls.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.conf.urls import url
 
-from wagtail.api.shared.router import WagtailAPIRouter
+from wagtail.api.v2.router import WagtailAPIRouter
 
 from .endpoints import PagesAdminAPIEndpoint, ImagesAdminAPIEndpoint, DocumentsAdminAPIEndpoint
 

--- a/wagtail/wagtailadmin/api/urls.py
+++ b/wagtail/wagtailadmin/api/urls.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+from django.conf.urls import url
+
+from wagtail.api.shared.router import WagtailAPIRouter
+
+from .endpoints import PagesAdminAPIEndpoint, ImagesAdminAPIEndpoint, DocumentsAdminAPIEndpoint
+
+
+v1 = WagtailAPIRouter('wagtailadmin_api_v1')
+v1.register_endpoint('pages', PagesAdminAPIEndpoint)
+v1.register_endpoint('images', ImagesAdminAPIEndpoint)
+v1.register_endpoint('documents', DocumentsAdminAPIEndpoint)
+
+urlpatterns = [
+    url(r'^v1beta/', v1.urls),
+]

--- a/wagtail/wagtailadmin/api/urls.py
+++ b/wagtail/wagtailadmin/api/urls.py
@@ -1,11 +1,10 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import url
 
 from wagtail.api.v2.router import WagtailAPIRouter
 
-from .endpoints import PagesAdminAPIEndpoint, ImagesAdminAPIEndpoint, DocumentsAdminAPIEndpoint
-
+from .endpoints import DocumentsAdminAPIEndpoint, ImagesAdminAPIEndpoint, PagesAdminAPIEndpoint
 
 v1 = WagtailAPIRouter('wagtailadmin_api_v1')
 v1.register_endpoint('pages', PagesAdminAPIEndpoint)

--- a/wagtail/wagtailadmin/tests/api/test_documents.py
+++ b/wagtail/wagtailadmin/tests/api/test_documents.py
@@ -46,7 +46,7 @@ class TestDocumentListing(AdminAPITestCase):
         for document in content['items']:
             self.assertIn('meta', document)
             self.assertIsInstance(document['meta'], dict)
-            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url'})
+            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url', 'tags'})
 
             # Type should always be wagtaildocs.Document
             self.assertEqual(document['meta']['type'], 'wagtaildocs.Document')
@@ -65,7 +65,8 @@ class TestDocumentListing(AdminAPITestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         for document in content['items']:
-            self.assertEqual(set(document.keys()), {'id', 'meta', 'title', 'tags'})
+            self.assertEqual(set(document.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url', 'tags'})
 
     def test_fields(self):
         response = self.get_response(fields='title')
@@ -73,13 +74,14 @@ class TestDocumentListing(AdminAPITestCase):
 
         for document in content['items']:
             self.assertEqual(set(document.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url'})
 
     def test_fields_tags(self):
         response = self.get_response(fields='tags')
         content = json.loads(response.content.decode('UTF-8'))
 
         for document in content['items']:
-            self.assertIsInstance(document['tags'], list)
+            self.assertIsInstance(document['meta']['tags'], list)
 
     def test_fields_which_are_not_in_api_fields_gives_error(self):
         response = self.get_response(fields='uploaded_by_user')
@@ -327,8 +329,8 @@ class TestDocumentDetail(AdminAPITestCase):
         self.assertEqual(content['title'], "Wagtail by mark Harkin")
 
         # Check the tags field
-        self.assertIn('tags', content)
-        self.assertEqual(content['tags'], [])
+        self.assertIn('tags', content['meta'])
+        self.assertEqual(content['meta']['tags'], [])
 
     def test_tags(self):
         Document.objects.get(id=1).tags.add('hello')
@@ -337,8 +339,8 @@ class TestDocumentDetail(AdminAPITestCase):
         response = self.get_response(1)
         content = json.loads(response.content.decode('UTF-8'))
 
-        self.assertIn('tags', content)
-        self.assertEqual(content['tags'], ['hello', 'world'])
+        self.assertIn('tags', content['meta'])
+        self.assertEqual(content['meta']['tags'], ['hello', 'world'])
 
     @override_settings(WAGTAILAPI_BASE_URL='http://api.example.com/')
     def test_download_url_with_custom_base_url(self):

--- a/wagtail/wagtailadmin/tests/api/test_documents.py
+++ b/wagtail/wagtailadmin/tests/api/test_documents.py
@@ -42,11 +42,11 @@ class TestDocumentListing(AdminAPITestCase):
         self.assertIn('items', content)
         self.assertIsInstance(content['items'], list)
 
-        # Check that each document has a meta section with type and detail_url attributes
+        # Check that each document has a meta section with type, detail_url and tags attributes
         for document in content['items']:
             self.assertIn('meta', document)
             self.assertIsInstance(document['meta'], dict)
-            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url', 'tags'})
+            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url', 'tags'})  # ADMINAPI CHANGE
 
             # Type should always be wagtaildocs.Document
             self.assertEqual(document['meta']['type'], 'wagtaildocs.Document')
@@ -60,7 +60,7 @@ class TestDocumentListing(AdminAPITestCase):
 
     # FIELDS
 
-    def test_fields_default(self):
+    def test_fields_default(self):  # ADMINAPI CHANGE
         response = self.get_response()
         content = json.loads(response.content.decode('UTF-8'))
 

--- a/wagtail/wagtailadmin/tests/api/test_documents.py
+++ b/wagtail/wagtailadmin/tests/api/test_documents.py
@@ -15,7 +15,7 @@ class TestDocumentListing(AdminAPITestCase):
         return self.client.get(reverse('wagtailadmin_api_v1:documents:listing'), params)
 
     def get_document_id_list(self, content):
-        return [document['id'] for document in content['results']]
+        return [document['id'] for document in content['items']]
 
 
     # BASIC TESTS
@@ -34,12 +34,12 @@ class TestDocumentListing(AdminAPITestCase):
         self.assertIsInstance(content['total_count'], int)
         self.assertEqual(content['total_count'], Document.objects.count())
 
-        # Check that the results section is there
-        self.assertIn('results', content)
-        self.assertIsInstance(content['results'], list)
+        # Check that the items section is there
+        self.assertIn('items', content)
+        self.assertIsInstance(content['items'], list)
 
         # Check that each document has a meta section with type and detail_url attributes
-        for document in content['results']:
+        for document in content['items']:
             self.assertIn('meta', document)
             self.assertIsInstance(document['meta'], dict)
             self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url'})
@@ -60,21 +60,21 @@ class TestDocumentListing(AdminAPITestCase):
         response = self.get_response()
         content = json.loads(response.content.decode('UTF-8'))
 
-        for document in content['results']:
+        for document in content['items']:
             self.assertEqual(set(document.keys()), {'id', 'meta', 'title', 'tags'})
 
     def test_fields(self):
         response = self.get_response(fields='title')
         content = json.loads(response.content.decode('UTF-8'))
 
-        for document in content['results']:
+        for document in content['items']:
             self.assertEqual(set(document.keys()), {'id', 'meta', 'title'})
 
     def test_fields_tags(self):
         response = self.get_response(fields='tags')
         content = json.loads(response.content.decode('UTF-8'))
 
-        for document in content['results']:
+        for document in content['items']:
             self.assertIsInstance(document['tags'], list)
 
     def test_fields_which_are_not_in_api_fields_gives_error(self):
@@ -176,11 +176,11 @@ class TestDocumentListing(AdminAPITestCase):
 
     # LIMIT
 
-    def test_limit_only_two_results_returned(self):
+    def test_limit_only_two_items_returned(self):
         response = self.get_response(limit=2)
         content = json.loads(response.content.decode('UTF-8'))
 
-        self.assertEqual(len(content['results']), 2)
+        self.assertEqual(len(content['items']), 2)
 
     def test_limit_total_count(self):
         response = self.get_response(limit=2)
@@ -218,7 +218,7 @@ class TestDocumentListing(AdminAPITestCase):
         response = self.get_response()
         content = json.loads(response.content.decode('UTF-8'))
 
-        self.assertEqual(len(content['results']), 2)
+        self.assertEqual(len(content['items']), 2)
 
 
     # OFFSET

--- a/wagtail/wagtailadmin/tests/api/test_documents.py
+++ b/wagtail/wagtailadmin/tests/api/test_documents.py
@@ -1,0 +1,345 @@
+import json
+
+from django.test.utils import override_settings
+from django.core.urlresolvers import reverse
+
+from wagtail.wagtaildocs.models import Document
+
+from .utils import AdminAPITestCase
+
+
+class TestDocumentListing(AdminAPITestCase):
+    fixtures = ['demosite.json']
+
+    def get_response(self, **params):
+        return self.client.get(reverse('wagtailadmin_api_v1:documents:listing'), params)
+
+    def get_document_id_list(self, content):
+        return [document['id'] for document in content['results']]
+
+
+    # BASIC TESTS
+
+    def test_basic(self):
+        response = self.get_response()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-type'], 'application/json')
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Check that the total count is there and correct
+        self.assertIn('total_count', content)
+        self.assertIsInstance(content['total_count'], int)
+        self.assertEqual(content['total_count'], Document.objects.count())
+
+        # Check that the results section is there
+        self.assertIn('results', content)
+        self.assertIsInstance(content['results'], list)
+
+        # Check that each document has a meta section with type and detail_url attributes
+        for document in content['results']:
+            self.assertIn('meta', document)
+            self.assertIsInstance(document['meta'], dict)
+            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url'})
+
+            # Type should always be wagtaildocs.Document
+            self.assertEqual(document['meta']['type'], 'wagtaildocs.Document')
+
+            # Check detail_url
+            self.assertEqual(document['meta']['detail_url'], 'http://localhost/admin/api/v1beta/documents/%d/' % document['id'])
+
+            # Check download_url
+            self.assertTrue(document['meta']['download_url'].startswith('http://localhost/documents/%d/' % document['id']))
+
+
+    # FIELDS
+
+    def test_fields_default(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['results']:
+            self.assertEqual(set(document.keys()), {'id', 'meta', 'title', 'tags'})
+
+    def test_fields(self):
+        response = self.get_response(fields='title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['results']:
+            self.assertEqual(set(document.keys()), {'id', 'meta', 'title'})
+
+    def test_fields_tags(self):
+        response = self.get_response(fields='tags')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['results']:
+            self.assertIsInstance(document['tags'], list)
+
+    def test_fields_which_are_not_in_api_fields_gives_error(self):
+        response = self.get_response(fields='uploaded_by_user')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: uploaded_by_user"})
+
+    def test_fields_unknown_field_gives_error(self):
+        response = self.get_response(fields='123,title,abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+
+    # FILTERING
+
+    def test_filtering_exact_filter(self):
+        response = self.get_response(title='James Joyce')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        document_id_list = self.get_document_id_list(content)
+        self.assertEqual(document_id_list, [2])
+
+    def test_filtering_on_id(self):
+        response = self.get_response(id=10)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        document_id_list = self.get_document_id_list(content)
+        self.assertEqual(document_id_list, [10])
+
+    def test_filtering_tags(self):
+        Document.objects.get(id=3).tags.add('test')
+
+        response = self.get_response(tags='test')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        document_id_list = self.get_document_id_list(content)
+        self.assertEqual(document_id_list, [3])
+
+    def test_filtering_unknown_field_gives_error(self):
+        response = self.get_response(not_a_field='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "query parameter is not an operation or a recognised field: not_a_field"})
+
+
+    # ORDERING
+
+    def test_ordering_by_title(self):
+        response = self.get_response(order='title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        document_id_list = self.get_document_id_list(content)
+        self.assertEqual(document_id_list, [3, 12, 10, 2, 7, 8, 5, 4, 1, 11, 9, 6])
+
+    def test_ordering_by_title_backwards(self):
+        response = self.get_response(order='-title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        document_id_list = self.get_document_id_list(content)
+        self.assertEqual(document_id_list, [6, 9, 11, 1, 4, 5, 8, 7, 2, 10, 12, 3])
+
+    def test_ordering_by_random(self):
+        response_1 = self.get_response(order='random')
+        content_1 = json.loads(response_1.content.decode('UTF-8'))
+        document_id_list_1 = self.get_document_id_list(content_1)
+
+        response_2 = self.get_response(order='random')
+        content_2 = json.loads(response_2.content.decode('UTF-8'))
+        document_id_list_2 = self.get_document_id_list(content_2)
+
+        self.assertNotEqual(document_id_list_1, document_id_list_2)
+
+    def test_ordering_by_random_backwards_gives_error(self):
+        response = self.get_response(order='-random')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "cannot order by 'random' (unknown field)"})
+
+    def test_ordering_by_random_with_offset_gives_error(self):
+        response = self.get_response(order='random', offset=10)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "random ordering with offset is not supported"})
+
+    def test_ordering_by_unknown_field_gives_error(self):
+        response = self.get_response(order='not_a_field')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "cannot order by 'not_a_field' (unknown field)"})
+
+
+    # LIMIT
+
+    def test_limit_only_two_results_returned(self):
+        response = self.get_response(limit=2)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(len(content['results']), 2)
+
+    def test_limit_total_count(self):
+        response = self.get_response(limit=2)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # The total count must not be affected by "limit"
+        self.assertEqual(content['total_count'], Document.objects.count())
+
+    def test_limit_not_integer_gives_error(self):
+        response = self.get_response(limit='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit must be a positive integer"})
+
+    def test_limit_too_high_gives_error(self):
+        response = self.get_response(limit=1000)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit cannot be higher than 20"})
+
+    @override_settings(WAGTAILAPI_LIMIT_MAX=10)
+    def test_limit_maximum_can_be_changed(self):
+        response = self.get_response(limit=20)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit cannot be higher than 10"})
+
+    @override_settings(WAGTAILAPI_LIMIT_MAX=2)
+    def test_limit_default_changes_with_max(self):
+        # The default limit is 20. If WAGTAILAPI_LIMIT_MAX is less than that,
+        # the default should change accordingly.
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(len(content['results']), 2)
+
+
+    # OFFSET
+
+    def test_offset_5_usually_appears_5th_in_list(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+        document_id_list = self.get_document_id_list(content)
+        self.assertEqual(document_id_list.index(5), 4)
+
+    def test_offset_5_moves_after_offset(self):
+        response = self.get_response(offset=4)
+        content = json.loads(response.content.decode('UTF-8'))
+        document_id_list = self.get_document_id_list(content)
+        self.assertEqual(document_id_list.index(5), 0)
+
+    def test_offset_total_count(self):
+        response = self.get_response(offset=10)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # The total count must not be affected by "offset"
+        self.assertEqual(content['total_count'], Document.objects.count())
+
+    def test_offset_not_integer_gives_error(self):
+        response = self.get_response(offset='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "offset must be a positive integer"})
+
+
+    # SEARCH
+
+    def test_search_for_james_joyce(self):
+        response = self.get_response(search='james')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        document_id_list = self.get_document_id_list(content)
+
+        self.assertEqual(set(document_id_list), set([2]))
+
+    def test_search_when_ordering_gives_error(self):
+        response = self.get_response(search='james', order='title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "ordering with a search query is not supported"})
+
+    @override_settings(WAGTAILAPI_SEARCH_ENABLED=False)
+    def test_search_when_disabled_gives_error(self):
+        response = self.get_response(search='james')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "search is disabled"})
+
+    def test_search_when_filtering_by_tag_gives_error(self):
+        response = self.get_response(search='james', tags='wagtail')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "filtering by tag with a search query is not supported"})
+
+
+class TestDocumentDetail(AdminAPITestCase):
+    fixtures = ['demosite.json']
+
+    def get_response(self, image_id, **params):
+        return self.client.get(reverse('wagtailadmin_api_v1:documents:detail', args=(image_id, )), params)
+
+    def test_basic(self):
+        response = self.get_response(1)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-type'], 'application/json')
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Check the id field
+        self.assertIn('id', content)
+        self.assertEqual(content['id'], 1)
+
+        # Check that the meta section is there
+        self.assertIn('meta', content)
+        self.assertIsInstance(content['meta'], dict)
+
+        # Check the meta type
+        self.assertIn('type', content['meta'])
+        self.assertEqual(content['meta']['type'], 'wagtaildocs.Document')
+
+        # Check the meta detail_url
+        self.assertIn('detail_url', content['meta'])
+        self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v1beta/documents/1/')
+
+        # Check the meta download_url
+        self.assertIn('download_url', content['meta'])
+        self.assertEqual(content['meta']['download_url'], 'http://localhost/documents/1/wagtail_by_markyharky.jpg')
+
+        # Check the title field
+        self.assertIn('title', content)
+        self.assertEqual(content['title'], "Wagtail by mark Harkin")
+
+        # Check the tags field
+        self.assertIn('tags', content)
+        self.assertEqual(content['tags'], [])
+
+    def test_tags(self):
+        Document.objects.get(id=1).tags.add('hello')
+        Document.objects.get(id=1).tags.add('world')
+
+        response = self.get_response(1)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('tags', content)
+        self.assertEqual(content['tags'], ['hello', 'world'])
+
+    @override_settings(WAGTAILAPI_BASE_URL='http://api.example.com/')
+    def test_download_url_with_custom_base_url(self):
+        response = self.get_response(1)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('download_url', content['meta'])
+        self.assertEqual(content['meta']['download_url'], 'http://api.example.com/documents/1/wagtail_by_markyharky.jpg')

--- a/wagtail/wagtailadmin/tests/api/test_documents.py
+++ b/wagtail/wagtailadmin/tests/api/test_documents.py
@@ -29,10 +29,14 @@ class TestDocumentListing(AdminAPITestCase):
         # Will crash if the JSON is invalid
         content = json.loads(response.content.decode('UTF-8'))
 
+        # Check that the meta section is there
+        self.assertIn('meta', content)
+        self.assertIsInstance(content['meta'], dict)
+
         # Check that the total count is there and correct
-        self.assertIn('total_count', content)
-        self.assertIsInstance(content['total_count'], int)
-        self.assertEqual(content['total_count'], Document.objects.count())
+        self.assertIn('total_count', content['meta'])
+        self.assertIsInstance(content['meta']['total_count'], int)
+        self.assertEqual(content['meta']['total_count'], Document.objects.count())
 
         # Check that the items section is there
         self.assertIn('items', content)
@@ -187,7 +191,7 @@ class TestDocumentListing(AdminAPITestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         # The total count must not be affected by "limit"
-        self.assertEqual(content['total_count'], Document.objects.count())
+        self.assertEqual(content['meta']['total_count'], Document.objects.count())
 
     def test_limit_not_integer_gives_error(self):
         response = self.get_response(limit='abc')
@@ -240,7 +244,7 @@ class TestDocumentListing(AdminAPITestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         # The total count must not be affected by "offset"
-        self.assertEqual(content['total_count'], Document.objects.count())
+        self.assertEqual(content['meta']['total_count'], Document.objects.count())
 
     def test_offset_not_integer_gives_error(self):
         response = self.get_response(offset='abc')

--- a/wagtail/wagtailadmin/tests/api/test_documents.py
+++ b/wagtail/wagtailadmin/tests/api/test_documents.py
@@ -1,14 +1,14 @@
 import json
 
-from django.test.utils import override_settings
 from django.core.urlresolvers import reverse
 
+from wagtail.api.v2.tests.test_documents import TestDocumentDetail, TestDocumentListing
 from wagtail.wagtaildocs.models import Document
 
 from .utils import AdminAPITestCase
 
 
-class TestDocumentListing(AdminAPITestCase):
+class TestAdminDocumentListing(AdminAPITestCase, TestDocumentListing):
     fixtures = ['demosite.json']
 
     def get_response(self, **params):
@@ -46,7 +46,7 @@ class TestDocumentListing(AdminAPITestCase):
         for document in content['items']:
             self.assertIn('meta', document)
             self.assertIsInstance(document['meta'], dict)
-            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url', 'tags'})  # ADMINAPI CHANGE
+            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url', 'tags'})
 
             # Type should always be wagtaildocs.Document
             self.assertEqual(document['meta']['type'], 'wagtaildocs.Document')
@@ -60,7 +60,7 @@ class TestDocumentListing(AdminAPITestCase):
 
     # FIELDS
 
-    def test_fields_default(self):  # ADMINAPI CHANGE
+    def test_fields_default(self):
         response = self.get_response()
         content = json.loads(response.content.decode('UTF-8'))
 
@@ -68,228 +68,8 @@ class TestDocumentListing(AdminAPITestCase):
             self.assertEqual(set(document.keys()), {'id', 'meta', 'title'})
             self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url', 'tags'})
 
-    def test_fields(self):
-        response = self.get_response(fields='title')
-        content = json.loads(response.content.decode('UTF-8'))
 
-        for document in content['items']:
-            self.assertEqual(set(document.keys()), {'id', 'meta', 'title'})
-            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url'})
-
-    def test_fields_tags(self):
-        response = self.get_response(fields='tags')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        for document in content['items']:
-            self.assertIsInstance(document['meta']['tags'], list)
-
-    def test_fields_which_are_not_in_api_fields_gives_error(self):
-        response = self.get_response(fields='uploaded_by_user')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "unknown fields: uploaded_by_user"})
-
-    def test_fields_unknown_field_gives_error(self):
-        response = self.get_response(fields='123,title,abc')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
-
-
-    # FILTERING
-
-    def test_filtering_exact_filter(self):
-        response = self.get_response(title='James Joyce')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        document_id_list = self.get_document_id_list(content)
-        self.assertEqual(document_id_list, [2])
-
-    def test_filtering_on_id(self):
-        response = self.get_response(id=10)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        document_id_list = self.get_document_id_list(content)
-        self.assertEqual(document_id_list, [10])
-
-    def test_filtering_tags(self):
-        Document.objects.get(id=3).tags.add('test')
-
-        response = self.get_response(tags='test')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        document_id_list = self.get_document_id_list(content)
-        self.assertEqual(document_id_list, [3])
-
-    def test_filtering_unknown_field_gives_error(self):
-        response = self.get_response(not_a_field='abc')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "query parameter is not an operation or a recognised field: not_a_field"})
-
-
-    # ORDERING
-
-    def test_ordering_by_title(self):
-        response = self.get_response(order='title')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        document_id_list = self.get_document_id_list(content)
-        self.assertEqual(document_id_list, [3, 12, 10, 2, 7, 8, 5, 4, 1, 11, 9, 6])
-
-    def test_ordering_by_title_backwards(self):
-        response = self.get_response(order='-title')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        document_id_list = self.get_document_id_list(content)
-        self.assertEqual(document_id_list, [6, 9, 11, 1, 4, 5, 8, 7, 2, 10, 12, 3])
-
-    def test_ordering_by_random(self):
-        response_1 = self.get_response(order='random')
-        content_1 = json.loads(response_1.content.decode('UTF-8'))
-        document_id_list_1 = self.get_document_id_list(content_1)
-
-        response_2 = self.get_response(order='random')
-        content_2 = json.loads(response_2.content.decode('UTF-8'))
-        document_id_list_2 = self.get_document_id_list(content_2)
-
-        self.assertNotEqual(document_id_list_1, document_id_list_2)
-
-    def test_ordering_by_random_backwards_gives_error(self):
-        response = self.get_response(order='-random')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "cannot order by 'random' (unknown field)"})
-
-    def test_ordering_by_random_with_offset_gives_error(self):
-        response = self.get_response(order='random', offset=10)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "random ordering with offset is not supported"})
-
-    def test_ordering_by_unknown_field_gives_error(self):
-        response = self.get_response(order='not_a_field')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "cannot order by 'not_a_field' (unknown field)"})
-
-
-    # LIMIT
-
-    def test_limit_only_two_items_returned(self):
-        response = self.get_response(limit=2)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(len(content['items']), 2)
-
-    def test_limit_total_count(self):
-        response = self.get_response(limit=2)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        # The total count must not be affected by "limit"
-        self.assertEqual(content['meta']['total_count'], Document.objects.count())
-
-    def test_limit_not_integer_gives_error(self):
-        response = self.get_response(limit='abc')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "limit must be a positive integer"})
-
-    def test_limit_too_high_gives_error(self):
-        response = self.get_response(limit=1000)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "limit cannot be higher than 20"})
-
-    @override_settings(WAGTAILAPI_LIMIT_MAX=10)
-    def test_limit_maximum_can_be_changed(self):
-        response = self.get_response(limit=20)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "limit cannot be higher than 10"})
-
-    @override_settings(WAGTAILAPI_LIMIT_MAX=2)
-    def test_limit_default_changes_with_max(self):
-        # The default limit is 20. If WAGTAILAPI_LIMIT_MAX is less than that,
-        # the default should change accordingly.
-        response = self.get_response()
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(len(content['items']), 2)
-
-
-    # OFFSET
-
-    def test_offset_5_usually_appears_5th_in_list(self):
-        response = self.get_response()
-        content = json.loads(response.content.decode('UTF-8'))
-        document_id_list = self.get_document_id_list(content)
-        self.assertEqual(document_id_list.index(5), 4)
-
-    def test_offset_5_moves_after_offset(self):
-        response = self.get_response(offset=4)
-        content = json.loads(response.content.decode('UTF-8'))
-        document_id_list = self.get_document_id_list(content)
-        self.assertEqual(document_id_list.index(5), 0)
-
-    def test_offset_total_count(self):
-        response = self.get_response(offset=10)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        # The total count must not be affected by "offset"
-        self.assertEqual(content['meta']['total_count'], Document.objects.count())
-
-    def test_offset_not_integer_gives_error(self):
-        response = self.get_response(offset='abc')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "offset must be a positive integer"})
-
-
-    # SEARCH
-
-    def test_search_for_james_joyce(self):
-        response = self.get_response(search='james')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        document_id_list = self.get_document_id_list(content)
-
-        self.assertEqual(set(document_id_list), set([2]))
-
-    def test_search_when_ordering_gives_error(self):
-        response = self.get_response(search='james', order='title')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "ordering with a search query is not supported"})
-
-    @override_settings(WAGTAILAPI_SEARCH_ENABLED=False)
-    def test_search_when_disabled_gives_error(self):
-        response = self.get_response(search='james')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "search is disabled"})
-
-    def test_search_when_filtering_by_tag_gives_error(self):
-        response = self.get_response(search='james', tags='wagtail')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "filtering by tag with a search query is not supported"})
-
-
-class TestDocumentDetail(AdminAPITestCase):
+class TestAdminDocumentDetail(AdminAPITestCase, TestDocumentDetail):
     fixtures = ['demosite.json']
 
     def get_response(self, image_id, **params):
@@ -331,21 +111,3 @@ class TestDocumentDetail(AdminAPITestCase):
         # Check the tags field
         self.assertIn('tags', content['meta'])
         self.assertEqual(content['meta']['tags'], [])
-
-    def test_tags(self):
-        Document.objects.get(id=1).tags.add('hello')
-        Document.objects.get(id=1).tags.add('world')
-
-        response = self.get_response(1)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertIn('tags', content['meta'])
-        self.assertEqual(content['meta']['tags'], ['hello', 'world'])
-
-    @override_settings(WAGTAILAPI_BASE_URL='http://api.example.com/')
-    def test_download_url_with_custom_base_url(self):
-        response = self.get_response(1)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertIn('download_url', content['meta'])
-        self.assertEqual(content['meta']['download_url'], 'http://api.example.com/documents/1/wagtail_by_markyharky.jpg')

--- a/wagtail/wagtailadmin/tests/api/test_documents.py
+++ b/wagtail/wagtailadmin/tests/api/test_documents.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import json
 
 from django.core.urlresolvers import reverse

--- a/wagtail/wagtailadmin/tests/api/test_documents.py
+++ b/wagtail/wagtailadmin/tests/api/test_documents.py
@@ -48,7 +48,7 @@ class TestDocumentListing(AdminAPITestCase):
             self.assertEqual(document['meta']['type'], 'wagtaildocs.Document')
 
             # Check detail_url
-            self.assertEqual(document['meta']['detail_url'], 'http://localhost/admin/api/v1beta/documents/%d/' % document['id'])
+            self.assertEqual(document['meta']['detail_url'], 'http://localhost/admin/api/v2beta/documents/%d/' % document['id'])
 
             # Check download_url
             self.assertTrue(document['meta']['download_url'].startswith('http://localhost/documents/%d/' % document['id']))
@@ -312,7 +312,7 @@ class TestDocumentDetail(AdminAPITestCase):
 
         # Check the meta detail_url
         self.assertIn('detail_url', content['meta'])
-        self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v1beta/documents/1/')
+        self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v2beta/documents/1/')
 
         # Check the meta download_url
         self.assertIn('download_url', content['meta'])

--- a/wagtail/wagtailadmin/tests/api/test_images.py
+++ b/wagtail/wagtailadmin/tests/api/test_images.py
@@ -49,7 +49,7 @@ class TestImageListing(AdminAPITestCase):
             self.assertEqual(image['meta']['type'], 'wagtailimages.Image')
 
             # Check detail url
-            self.assertEqual(image['meta']['detail_url'], 'http://localhost/admin/api/v1beta/images/%d/' % image['id'])
+            self.assertEqual(image['meta']['detail_url'], 'http://localhost/admin/api/v2beta/images/%d/' % image['id'])
 
 
     #  FIELDS
@@ -312,7 +312,7 @@ class TestImageDetail(AdminAPITestCase):
 
         # Check the meta detail_url
         self.assertIn('detail_url', content['meta'])
-        self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v1beta/images/5/')
+        self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v2beta/images/5/')
 
         # Check the meta thumbnail
         # ADMINAPI CHANGE

--- a/wagtail/wagtailadmin/tests/api/test_images.py
+++ b/wagtail/wagtailadmin/tests/api/test_images.py
@@ -16,7 +16,7 @@ class TestImageListing(AdminAPITestCase):
         return self.client.get(reverse('wagtailadmin_api_v1:images:listing'), params)
 
     def get_image_id_list(self, content):
-        return [image['id'] for image in content['results']]
+        return [image['id'] for image in content['items']]
 
 
     # BASIC TESTS
@@ -35,12 +35,12 @@ class TestImageListing(AdminAPITestCase):
         self.assertIsInstance(content['total_count'], int)
         self.assertEqual(content['total_count'], get_image_model().objects.count())
 
-        # Check that the results section is there
-        self.assertIn('results', content)
-        self.assertIsInstance(content['results'], list)
+        # Check that the items section is there
+        self.assertIn('items', content)
+        self.assertIsInstance(content['items'], list)
 
         # Check that each image has a meta section with type, detail_url, thumbnail and source_image_error attributes
-        for image in content['results']:
+        for image in content['items']:
             self.assertIn('meta', image)
             self.assertIsInstance(image['meta'], dict)
             self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'thumbnail', 'source_image_error'})  # ADMINAPI CHANGE
@@ -58,21 +58,21 @@ class TestImageListing(AdminAPITestCase):
         response = self.get_response()
         content = json.loads(response.content.decode('UTF-8'))
 
-        for image in content['results']:
+        for image in content['items']:
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'tags'})
 
     def test_fields(self):
         response = self.get_response(fields='title,width,height')
         content = json.loads(response.content.decode('UTF-8'))
 
-        for image in content['results']:
+        for image in content['items']:
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height'})
 
     def test_fields_tags(self):
         response = self.get_response(fields='tags')
         content = json.loads(response.content.decode('UTF-8'))
 
-        for image in content['results']:
+        for image in content['items']:
             self.assertEqual(set(image.keys()), {'id', 'meta', 'tags'})
             self.assertIsInstance(image['tags'], list)
 
@@ -175,11 +175,11 @@ class TestImageListing(AdminAPITestCase):
 
     # LIMIT
 
-    def test_limit_only_two_results_returned(self):
+    def test_limit_only_two_items_returned(self):
         response = self.get_response(limit=2)
         content = json.loads(response.content.decode('UTF-8'))
 
-        self.assertEqual(len(content['results']), 2)
+        self.assertEqual(len(content['items']), 2)
 
     def test_limit_total_count(self):
         response = self.get_response(limit=2)
@@ -217,7 +217,7 @@ class TestImageListing(AdminAPITestCase):
         response = self.get_response()
         content = json.loads(response.content.decode('UTF-8'))
 
-        self.assertEqual(len(content['results']), 2)
+        self.assertEqual(len(content['items']), 2)
 
 
     # OFFSET

--- a/wagtail/wagtailadmin/tests/api/test_images.py
+++ b/wagtail/wagtailadmin/tests/api/test_images.py
@@ -1,15 +1,15 @@
 import json
 
-from django.test.utils import override_settings
 from django.core.urlresolvers import reverse
 
+from wagtail.api.v2.tests.test_images import TestImageDetail, TestImageListing
 from wagtail.wagtailimages.models import get_image_model
 from wagtail.wagtailimages.tests.utils import get_test_image_file
 
 from .utils import AdminAPITestCase
 
 
-class TestImageListing(AdminAPITestCase):
+class TestAdminImageListing(AdminAPITestCase, TestImageListing):
     fixtures = ['demosite.json']
 
     def get_response(self, **params):
@@ -47,7 +47,7 @@ class TestImageListing(AdminAPITestCase):
         for image in content['items']:
             self.assertIn('meta', image)
             self.assertIsInstance(image['meta'], dict)
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})  # ADMINAPI CHANGE
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
 
             # Type should always be wagtailimages.Image
             self.assertEqual(image['meta']['type'], 'wagtailimages.Image')
@@ -58,7 +58,7 @@ class TestImageListing(AdminAPITestCase):
 
     #  FIELDS
 
-    def test_fields_default(self):  # ADMINAPI CHANGE
+    def test_fields_default(self):
         response = self.get_response()
         content = json.loads(response.content.decode('UTF-8'))
 
@@ -66,230 +66,8 @@ class TestImageListing(AdminAPITestCase):
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
             self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
 
-    def test_fields(self):
-        response = self.get_response(fields='title,width,height')
-        content = json.loads(response.content.decode('UTF-8'))
 
-        for image in content['items']:
-            self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url'})
-
-    def test_fields_tags(self):
-        response = self.get_response(fields='tags')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        for image in content['items']:
-            self.assertEqual(set(image.keys()), {'id', 'meta'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
-            self.assertIsInstance(image['meta']['tags'], list)
-
-    def test_fields_which_are_not_in_api_fields_gives_error(self):
-        response = self.get_response(fields='uploaded_by_user')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "unknown fields: uploaded_by_user"})
-
-    def test_fields_unknown_field_gives_error(self):
-        response = self.get_response(fields='123,title,abc')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
-
-
-    # FILTERING
-
-    def test_filtering_exact_filter(self):
-        response = self.get_response(title='James Joyce')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        image_id_list = self.get_image_id_list(content)
-        self.assertEqual(image_id_list, [5])
-
-    def test_filtering_on_id(self):
-        response = self.get_response(id=10)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        image_id_list = self.get_image_id_list(content)
-        self.assertEqual(image_id_list, [10])
-
-    def test_filtering_tags(self):
-        get_image_model().objects.get(id=6).tags.add('test')
-
-        response = self.get_response(tags='test')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        image_id_list = self.get_image_id_list(content)
-        self.assertEqual(image_id_list, [6])
-
-    def test_filtering_unknown_field_gives_error(self):
-        response = self.get_response(not_a_field='abc')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "query parameter is not an operation or a recognised field: not_a_field"})
-
-
-    # ORDERING
-
-    def test_ordering_by_title(self):
-        response = self.get_response(order='title')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        image_id_list = self.get_image_id_list(content)
-        self.assertEqual(image_id_list, [6, 15, 13, 5, 10, 11, 8, 7, 4, 14, 12, 9])
-
-    def test_ordering_by_title_backwards(self):
-        response = self.get_response(order='-title')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        image_id_list = self.get_image_id_list(content)
-        self.assertEqual(image_id_list, [9, 12, 14, 4, 7, 8, 11, 10, 5, 13, 15, 6])
-
-    def test_ordering_by_random(self):
-        response_1 = self.get_response(order='random')
-        content_1 = json.loads(response_1.content.decode('UTF-8'))
-        image_id_list_1 = self.get_image_id_list(content_1)
-
-        response_2 = self.get_response(order='random')
-        content_2 = json.loads(response_2.content.decode('UTF-8'))
-        image_id_list_2 = self.get_image_id_list(content_2)
-
-        self.assertNotEqual(image_id_list_1, image_id_list_2)
-
-    def test_ordering_by_random_backwards_gives_error(self):
-        response = self.get_response(order='-random')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "cannot order by 'random' (unknown field)"})
-
-    def test_ordering_by_random_with_offset_gives_error(self):
-        response = self.get_response(order='random', offset=10)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "random ordering with offset is not supported"})
-
-    def test_ordering_by_unknown_field_gives_error(self):
-        response = self.get_response(order='not_a_field')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "cannot order by 'not_a_field' (unknown field)"})
-
-
-    # LIMIT
-
-    def test_limit_only_two_items_returned(self):
-        response = self.get_response(limit=2)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(len(content['items']), 2)
-
-    def test_limit_total_count(self):
-        response = self.get_response(limit=2)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        # The total count must not be affected by "limit"
-        self.assertEqual(content['meta']['total_count'], get_image_model().objects.count())
-
-    def test_limit_not_integer_gives_error(self):
-        response = self.get_response(limit='abc')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "limit must be a positive integer"})
-
-    def test_limit_too_high_gives_error(self):
-        response = self.get_response(limit=1000)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "limit cannot be higher than 20"})
-
-    @override_settings(WAGTAILAPI_LIMIT_MAX=10)
-    def test_limit_maximum_can_be_changed(self):
-        response = self.get_response(limit=20)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "limit cannot be higher than 10"})
-
-    @override_settings(WAGTAILAPI_LIMIT_MAX=2)
-    def test_limit_default_changes_with_max(self):
-        # The default limit is 20. If WAGTAILAPI_LIMIT_MAX is less than that,
-        # the default should change accordingly.
-        response = self.get_response()
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(len(content['items']), 2)
-
-
-    # OFFSET
-
-    def test_offset_10_usually_appears_7th_in_list(self):
-        response = self.get_response()
-        content = json.loads(response.content.decode('UTF-8'))
-        image_id_list = self.get_image_id_list(content)
-        self.assertEqual(image_id_list.index(10), 6)
-
-    def test_offset_10_moves_after_offset(self):
-        response = self.get_response(offset=4)
-        content = json.loads(response.content.decode('UTF-8'))
-        image_id_list = self.get_image_id_list(content)
-        self.assertEqual(image_id_list.index(10), 2)
-
-    def test_offset_total_count(self):
-        response = self.get_response(offset=10)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        # The total count must not be affected by "offset"
-        self.assertEqual(content['meta']['total_count'], get_image_model().objects.count())
-
-    def test_offset_not_integer_gives_error(self):
-        response = self.get_response(offset='abc')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "offset must be a positive integer"})
-
-
-    # SEARCH
-
-    def test_search_for_james_joyce(self):
-        response = self.get_response(search='james')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        image_id_list = self.get_image_id_list(content)
-
-        self.assertEqual(set(image_id_list), set([5]))
-
-    def test_search_when_ordering_gives_error(self):
-        response = self.get_response(search='james', order='title')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "ordering with a search query is not supported"})
-
-    @override_settings(WAGTAILAPI_SEARCH_ENABLED=False)
-    def test_search_when_disabled_gives_error(self):
-        response = self.get_response(search='james')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "search is disabled"})
-
-    def test_search_when_filtering_by_tag_gives_error(self):
-        response = self.get_response(search='james', tags='wagtail')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "filtering by tag with a search query is not supported"})
-
-
-class TestImageDetail(AdminAPITestCase):
+class TestAdminImageDetail(AdminAPITestCase, TestImageDetail):
     fixtures = ['demosite.json']
 
     def get_response(self, image_id, **params):
@@ -322,7 +100,7 @@ class TestImageDetail(AdminAPITestCase):
         self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v2beta/images/5/')
 
         # Check the thumbnail
-        # ADMINAPI CHANGE
+
         # Note: This is None because the source image doesn't exist
         #       See test_thumbnail below for working example
         self.assertIn('thumbnail', content)
@@ -342,18 +120,7 @@ class TestImageDetail(AdminAPITestCase):
         self.assertIn('tags', content['meta'])
         self.assertEqual(content['meta']['tags'], [])
 
-    def test_tags(self):
-        image = get_image_model().objects.get(id=5)
-        image.tags.add('hello')
-        image.tags.add('world')
-
-        response = self.get_response(5)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertIn('tags', content['meta'])
-        self.assertEqual(content['meta']['tags'], ['hello', 'world'])
-
-    def test_thumbnail(self):  # ADMINAPI CHANGE
+    def test_thumbnail(self):
         # Add a new image with source file
         image = get_image_model().objects.create(
             title="Test image",

--- a/wagtail/wagtailadmin/tests/api/test_images.py
+++ b/wagtail/wagtailadmin/tests/api/test_images.py
@@ -30,10 +30,14 @@ class TestImageListing(AdminAPITestCase):
         # Will crash if the JSON is invalid
         content = json.loads(response.content.decode('UTF-8'))
 
+        # Check that the meta section is there
+        self.assertIn('meta', content)
+        self.assertIsInstance(content['meta'], dict)
+
         # Check that the total count is there and correct
-        self.assertIn('total_count', content)
-        self.assertIsInstance(content['total_count'], int)
-        self.assertEqual(content['total_count'], get_image_model().objects.count())
+        self.assertIn('total_count', content['meta'])
+        self.assertIsInstance(content['meta']['total_count'], int)
+        self.assertEqual(content['meta']['total_count'], get_image_model().objects.count())
 
         # Check that the items section is there
         self.assertIn('items', content)
@@ -186,7 +190,7 @@ class TestImageListing(AdminAPITestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         # The total count must not be affected by "limit"
-        self.assertEqual(content['total_count'], get_image_model().objects.count())
+        self.assertEqual(content['meta']['total_count'], get_image_model().objects.count())
 
     def test_limit_not_integer_gives_error(self):
         response = self.get_response(limit='abc')
@@ -239,7 +243,7 @@ class TestImageListing(AdminAPITestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         # The total count must not be affected by "offset"
-        self.assertEqual(content['total_count'], get_image_model().objects.count())
+        self.assertEqual(content['meta']['total_count'], get_image_model().objects.count())
 
     def test_offset_not_integer_gives_error(self):
         response = self.get_response(offset='abc')

--- a/wagtail/wagtailadmin/tests/api/test_images.py
+++ b/wagtail/wagtailadmin/tests/api/test_images.py
@@ -58,7 +58,7 @@ class TestImageListing(AdminAPITestCase):
 
     #  FIELDS
 
-    def test_fields_default(self):
+    def test_fields_default(self):  # ADMINAPI CHANGE
         response = self.get_response()
         content = json.loads(response.content.decode('UTF-8'))
 

--- a/wagtail/wagtailadmin/tests/api/test_images.py
+++ b/wagtail/wagtailadmin/tests/api/test_images.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import json
 
 from django.core.urlresolvers import reverse

--- a/wagtail/wagtailadmin/tests/api/test_images.py
+++ b/wagtail/wagtailadmin/tests/api/test_images.py
@@ -1,0 +1,339 @@
+import json
+
+from django.test.utils import override_settings
+from django.core.urlresolvers import reverse
+
+from wagtail.wagtailimages.models import get_image_model
+
+from .utils import AdminAPITestCase
+
+
+class TestImageListing(AdminAPITestCase):
+    fixtures = ['demosite.json']
+
+    def get_response(self, **params):
+        return self.client.get(reverse('wagtailadmin_api_v1:images:listing'), params)
+
+    def get_image_id_list(self, content):
+        return [image['id'] for image in content['results']]
+
+
+    # BASIC TESTS
+
+    def test_basic(self):
+        response = self.get_response()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-type'], 'application/json')
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Check that the total count is there and correct
+        self.assertIn('total_count', content)
+        self.assertIsInstance(content['total_count'], int)
+        self.assertEqual(content['total_count'], get_image_model().objects.count())
+
+        # Check that the results section is there
+        self.assertIn('results', content)
+        self.assertIsInstance(content['results'], list)
+
+        # Check that each image has a meta section with type and detail_url attributes
+        for image in content['results']:
+            self.assertIn('meta', image)
+            self.assertIsInstance(image['meta'], dict)
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url'})
+
+            # Type should always be wagtailimages.Image
+            self.assertEqual(image['meta']['type'], 'wagtailimages.Image')
+
+            # Check detail url
+            self.assertEqual(image['meta']['detail_url'], 'http://localhost/admin/api/v1beta/images/%d/' % image['id'])
+
+
+    #  FIELDS
+
+    def test_fields_default(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['results']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'tags'})
+
+    def test_fields(self):
+        response = self.get_response(fields='title,width,height')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['results']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height'})
+
+    def test_fields_tags(self):
+        response = self.get_response(fields='tags')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['results']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'tags'})
+            self.assertIsInstance(image['tags'], list)
+
+    def test_fields_which_are_not_in_api_fields_gives_error(self):
+        response = self.get_response(fields='uploaded_by_user')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: uploaded_by_user"})
+
+    def test_fields_unknown_field_gives_error(self):
+        response = self.get_response(fields='123,title,abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+
+    # FILTERING
+
+    def test_filtering_exact_filter(self):
+        response = self.get_response(title='James Joyce')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        image_id_list = self.get_image_id_list(content)
+        self.assertEqual(image_id_list, [5])
+
+    def test_filtering_on_id(self):
+        response = self.get_response(id=10)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        image_id_list = self.get_image_id_list(content)
+        self.assertEqual(image_id_list, [10])
+
+    def test_filtering_tags(self):
+        get_image_model().objects.get(id=6).tags.add('test')
+
+        response = self.get_response(tags='test')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        image_id_list = self.get_image_id_list(content)
+        self.assertEqual(image_id_list, [6])
+
+    def test_filtering_unknown_field_gives_error(self):
+        response = self.get_response(not_a_field='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "query parameter is not an operation or a recognised field: not_a_field"})
+
+
+    # ORDERING
+
+    def test_ordering_by_title(self):
+        response = self.get_response(order='title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        image_id_list = self.get_image_id_list(content)
+        self.assertEqual(image_id_list, [6, 15, 13, 5, 10, 11, 8, 7, 4, 14, 12, 9])
+
+    def test_ordering_by_title_backwards(self):
+        response = self.get_response(order='-title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        image_id_list = self.get_image_id_list(content)
+        self.assertEqual(image_id_list, [9, 12, 14, 4, 7, 8, 11, 10, 5, 13, 15, 6])
+
+    def test_ordering_by_random(self):
+        response_1 = self.get_response(order='random')
+        content_1 = json.loads(response_1.content.decode('UTF-8'))
+        image_id_list_1 = self.get_image_id_list(content_1)
+
+        response_2 = self.get_response(order='random')
+        content_2 = json.loads(response_2.content.decode('UTF-8'))
+        image_id_list_2 = self.get_image_id_list(content_2)
+
+        self.assertNotEqual(image_id_list_1, image_id_list_2)
+
+    def test_ordering_by_random_backwards_gives_error(self):
+        response = self.get_response(order='-random')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "cannot order by 'random' (unknown field)"})
+
+    def test_ordering_by_random_with_offset_gives_error(self):
+        response = self.get_response(order='random', offset=10)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "random ordering with offset is not supported"})
+
+    def test_ordering_by_unknown_field_gives_error(self):
+        response = self.get_response(order='not_a_field')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "cannot order by 'not_a_field' (unknown field)"})
+
+
+    # LIMIT
+
+    def test_limit_only_two_results_returned(self):
+        response = self.get_response(limit=2)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(len(content['results']), 2)
+
+    def test_limit_total_count(self):
+        response = self.get_response(limit=2)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # The total count must not be affected by "limit"
+        self.assertEqual(content['total_count'], get_image_model().objects.count())
+
+    def test_limit_not_integer_gives_error(self):
+        response = self.get_response(limit='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit must be a positive integer"})
+
+    def test_limit_too_high_gives_error(self):
+        response = self.get_response(limit=1000)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit cannot be higher than 20"})
+
+    @override_settings(WAGTAILAPI_LIMIT_MAX=10)
+    def test_limit_maximum_can_be_changed(self):
+        response = self.get_response(limit=20)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit cannot be higher than 10"})
+
+    @override_settings(WAGTAILAPI_LIMIT_MAX=2)
+    def test_limit_default_changes_with_max(self):
+        # The default limit is 20. If WAGTAILAPI_LIMIT_MAX is less than that,
+        # the default should change accordingly.
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(len(content['results']), 2)
+
+
+    # OFFSET
+
+    def test_offset_10_usually_appears_7th_in_list(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+        image_id_list = self.get_image_id_list(content)
+        self.assertEqual(image_id_list.index(10), 6)
+
+    def test_offset_10_moves_after_offset(self):
+        response = self.get_response(offset=4)
+        content = json.loads(response.content.decode('UTF-8'))
+        image_id_list = self.get_image_id_list(content)
+        self.assertEqual(image_id_list.index(10), 2)
+
+    def test_offset_total_count(self):
+        response = self.get_response(offset=10)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # The total count must not be affected by "offset"
+        self.assertEqual(content['total_count'], get_image_model().objects.count())
+
+    def test_offset_not_integer_gives_error(self):
+        response = self.get_response(offset='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "offset must be a positive integer"})
+
+
+    # SEARCH
+
+    def test_search_for_james_joyce(self):
+        response = self.get_response(search='james')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        image_id_list = self.get_image_id_list(content)
+
+        self.assertEqual(set(image_id_list), set([5]))
+
+    def test_search_when_ordering_gives_error(self):
+        response = self.get_response(search='james', order='title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "ordering with a search query is not supported"})
+
+    @override_settings(WAGTAILAPI_SEARCH_ENABLED=False)
+    def test_search_when_disabled_gives_error(self):
+        response = self.get_response(search='james')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "search is disabled"})
+
+    def test_search_when_filtering_by_tag_gives_error(self):
+        response = self.get_response(search='james', tags='wagtail')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "filtering by tag with a search query is not supported"})
+
+
+class TestImageDetail(AdminAPITestCase):
+    fixtures = ['demosite.json']
+
+    def get_response(self, image_id, **params):
+        return self.client.get(reverse('wagtailadmin_api_v1:images:detail', args=(image_id, )), params)
+
+
+    def test_basic(self):
+        response = self.get_response(5)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-type'], 'application/json')
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Check the id field
+        self.assertIn('id', content)
+        self.assertEqual(content['id'], 5)
+
+        # Check that the meta section is there
+        self.assertIn('meta', content)
+        self.assertIsInstance(content['meta'], dict)
+
+        # Check the meta type
+        self.assertIn('type', content['meta'])
+        self.assertEqual(content['meta']['type'], 'wagtailimages.Image')
+
+        # Check the meta detail_url
+        self.assertIn('detail_url', content['meta'])
+        self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v1beta/images/5/')
+
+        # Check the title field
+        self.assertIn('title', content)
+        self.assertEqual(content['title'], "James Joyce")
+
+        # Check the width and height fields
+        self.assertIn('width', content)
+        self.assertIn('height', content)
+        self.assertEqual(content['width'], 500)
+        self.assertEqual(content['height'], 392)
+
+        # Check the tags field
+        self.assertIn('tags', content)
+        self.assertEqual(content['tags'], [])
+
+    def test_tags(self):
+        image = get_image_model().objects.get(id=5)
+        image.tags.add('hello')
+        image.tags.add('world')
+
+        response = self.get_response(5)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('tags', content)
+        self.assertEqual(content['tags'], ['hello', 'world'])

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -394,6 +394,37 @@ class TestPageListing(AdminAPITestCase):
         self.assertEqual(content, {'message': "filtering by descendant_of with child_of is not supported"})
 
 
+    # HAS CHILDREN FILTER
+
+    def test_has_children_filter(self):  # ADMINAPI CHANGE
+        response = self.get_response(has_children=1)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [2, 4, 5, 6, 21, 20])
+
+    def test_has_children_filter_off(self):  # ADMINAPI CHANGE
+        response = self.get_response(has_children=0)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [8, 9, 16, 18, 19, 10, 15, 17, 22, 23, 13, 14, 12])
+
+    def test_has_children_filter_invalid_integer(self):  # ADMINAPI CHANGE
+        response = self.get_response(has_children=3)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "has_children must be 1 or 0"})
+
+    def test_has_children_filter_invalid_value(self):  # ADMINAPI CHANGE
+        response = self.get_response(has_children='yes')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "has_children must be 1 or 0"})
+
+
     # ORDERING
 
     def test_ordering_default(self):

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -2,10 +2,10 @@ import json
 import collections
 import datetime
 
-from django.test.utils import override_settings
 from django.core.urlresolvers import reverse
 from django.utils import timezone
 
+from wagtail.api.v2.tests.test_pages import TestPageDetail, TestPageListing
 from wagtail.wagtailcore.models import Page
 
 from wagtail.tests.demosite import models
@@ -19,7 +19,7 @@ def get_total_page_count():
     return Page.objects.count() - 1
 
 
-class TestPageListing(AdminAPITestCase):
+class TestAdminPageListing(AdminAPITestCase, TestPageListing):
     fixtures = ['demosite.json']
 
     def get_response(self, **params):
@@ -57,7 +57,7 @@ class TestPageListing(AdminAPITestCase):
         for page in content['items']:
             self.assertIn('meta', page)
             self.assertIsInstance(page['meta'], dict)
-            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'status', 'children', 'slug', 'first_published_at', 'latest_revision_created_at'})  # ADMINAPI CHANGE
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'status', 'children', 'slug', 'first_published_at', 'latest_revision_created_at'})
 
         # Check the type info
         self.assertIsInstance(content['__types'], dict)
@@ -76,7 +76,11 @@ class TestPageListing(AdminAPITestCase):
         self.assertEqual(content['__types']['demosite.EventPage']['verbose_name'], 'event page')
         self.assertEqual(content['__types']['demosite.EventPage']['verbose_name_plural'], 'event pages')
 
-    def test_unpublished_pages_appear_in_list(self):  # ADMINAPI CHANGE
+    # Not applicable to the admin API
+    test_unpublished_pages_dont_appear_in_list = None
+    test_private_pages_dont_appear_in_list = None
+
+    def test_unpublished_pages_appear_in_list(self):
         total_count = get_total_page_count()
 
         page = models.BlogEntryPage.objects.get(id=16)
@@ -86,7 +90,7 @@ class TestPageListing(AdminAPITestCase):
         content = json.loads(response.content.decode('UTF-8'))
         self.assertEqual(content['meta']['total_count'], total_count)
 
-    def test_private_pages_appear_in_list(self):  # ADMINAPI CHANGE
+    def test_private_pages_appear_in_list(self):
         total_count = get_total_page_count()
 
         page = models.BlogIndexPage.objects.get(id=5)
@@ -100,62 +104,9 @@ class TestPageListing(AdminAPITestCase):
         self.assertEqual(content['meta']['total_count'], new_total_count)
 
 
-    # TYPE FILTER
-
-    def test_type_filter_items_are_all_blog_entries(self):
-        response = self.get_response(type='demosite.BlogEntryPage')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        for page in content['items']:
-            self.assertEqual(page['meta']['type'], 'demosite.BlogEntryPage')
-
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
-
-    def test_type_filter_total_count(self):
-        response = self.get_response(type='demosite.BlogEntryPage')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        # Total count must be reduced as this filters the items
-        self.assertEqual(content['meta']['total_count'], 3)
-
-    def test_type_filter_multiple(self):
-        response = self.get_response(type='demosite.BlogEntryPage,demosite.EventPage')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        blog_page_seen = False
-        event_page_seen = False
-
-        for page in content['items']:
-            self.assertIn(page['meta']['type'], ['demosite.BlogEntryPage', 'demosite.EventPage'])
-
-            if page['meta']['type'] == 'demosite.BlogEntryPage':
-                blog_page_seen = True
-            elif page['meta']['type'] == 'demosite.EventPage':
-                event_page_seen = True
-
-            # Only generic fields available
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
-
-        self.assertTrue(blog_page_seen, "No blog pages were found in the items")
-        self.assertTrue(event_page_seen, "No event pages were found in the items")
-
-    def test_non_existant_type_gives_error(self):
-        response = self.get_response(type='demosite.IDontExist')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "type doesn't exist"})
-
-    def test_non_page_type_gives_error(self):
-        response = self.get_response(type='auth.User')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "type doesn't exist"})
-
     # FIELDS
 
-    def test_fields_default(self):  # ADMINAPI CHANGE
+    def test_fields_default(self):
         response = self.get_response(type='demosite.BlogEntryPage')
         content = json.loads(response.content.decode('UTF-8'))
 
@@ -163,22 +114,8 @@ class TestPageListing(AdminAPITestCase):
             self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
             self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'children', 'status', 'slug', 'first_published_at', 'latest_revision_created_at'})
 
-    def test_fields(self):
-        response = self.get_response(type='demosite.BlogEntryPage', fields='title,date,feed_image')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        for page in content['items']:
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'feed_image'})
-
-    def test_fields_child_relation(self):
-        response = self.get_response(type='demosite.BlogEntryPage', fields='title,related_links')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        for page in content['items']:
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'related_links'})
-            self.assertIsInstance(page['related_links'], list)
-
     def test_fields_foreign_key(self):
+        # Only the base the detail_url is different here from the public API
         response = self.get_response(type='demosite.BlogEntryPage', fields='title,date,feed_image')
         content = json.loads(response.content.decode('UTF-8'))
 
@@ -194,7 +131,8 @@ class TestPageListing(AdminAPITestCase):
                 self.assertEqual(feed_image['meta']['type'], 'wagtailimages.Image')
                 self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/admin/api/v2beta/images/%d/' % feed_image['id'])
 
-    def test_fields_parent(self):  # ADMINAPI CHANGE
+
+    def test_fields_parent(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='parent')
         content = json.loads(response.content.decode('UTF-8'))
 
@@ -211,116 +149,13 @@ class TestPageListing(AdminAPITestCase):
                 }
             })
 
-    def test_fields_tags(self):
-        response = self.get_response(type='demosite.BlogEntryPage', fields='tags')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        for page in content['items']:
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'tags'})
-            self.assertIsInstance(page['tags'], list)
-
-    def test_fields_ordering(self):
-        response = self.get_response(type='demosite.BlogEntryPage', fields='date,title,feed_image,related_links')
-
-        # Will crash if the JSON is invalid
-        content = json.loads(response.content.decode('UTF-8'))
-
-        # Test field order
-        content = json.JSONDecoder(object_pairs_hook=collections.OrderedDict).decode(response.content.decode('UTF-8'))
-        field_order = [
-            'id',
-            'meta',
-            'title',
-            'date',
-            'feed_image',
-            'related_links',
-        ]
-        self.assertEqual(list(content['items'][0].keys()), field_order)
-
-    def test_fields_without_type_gives_error(self):
-        response = self.get_response(fields='title,related_links')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "unknown fields: related_links"})
-
-    def test_fields_which_are_not_in_api_fields_gives_error(self):
-        response = self.get_response(fields='path')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "unknown fields: path"})
-
-    def test_fields_unknown_field_gives_error(self):
-        response = self.get_response(fields='123,title,abc')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
-
-
-    # FILTERING
-
-    def test_filtering_exact_filter(self):
-        response = self.get_response(title='Home page')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list, [2])
-
-    def test_filtering_exact_filter_on_specific_field(self):
-        response = self.get_response(type='demosite.BlogEntryPage', date='2013-12-02')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list, [16])
-
-    def test_filtering_on_id(self):
-        response = self.get_response(id=16)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list, [16])
-
-    def test_filtering_doesnt_work_on_specific_fields_without_type(self):
-        response = self.get_response(date='2013-12-02')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "query parameter is not an operation or a recognised field: date"})
-
-    def test_filtering_tags(self):
-        response = self.get_response(type='demosite.BlogEntryPage', tags='wagtail')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list, [16, 18])
-
-    def test_filtering_multiple_tags(self):
-        response = self.get_response(type='demosite.BlogEntryPage', tags='wagtail,bird')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list, [16])
-
-    def test_filtering_unknown_field_gives_error(self):
-        response = self.get_response(not_a_field='abc')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "query parameter is not an operation or a recognised field: not_a_field"})
-
 
     # CHILD OF FILTER
 
-    def test_child_of_filter(self):
-        response = self.get_response(child_of=5)
-        content = json.loads(response.content.decode('UTF-8'))
+    # Not applicable to the admin API
+    test_child_of_page_thats_not_in_same_site_gives_error = None
 
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list, [16, 18, 19])
-
-    def test_child_of_root(self):  # ADMINAPI CHANGE
+    def test_child_of_root(self):
         # Only return the homepage as that's the only child of the "root" node
         # in the tree. This is different to the public API which pretends the
         # homepage of the current site is the root page.
@@ -330,29 +165,8 @@ class TestPageListing(AdminAPITestCase):
         page_id_list = self.get_page_id_list(content)
         self.assertEqual(page_id_list, [2])
 
-    def test_child_of_with_type(self):
-        response = self.get_response(type='demosite.EventPage', child_of=5)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list, [])
-
-    def test_child_of_unknown_page_gives_error(self):
-        response = self.get_response(child_of=1000)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "parent page doesn't exist"})
-
-    def test_child_of_not_integer_gives_error(self):
-        response = self.get_response(child_of='abc')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "child_of must be a positive integer"})
-
-    def test_child_of_root_doesnt_give_error(self):  # ADMINAPI CHANGE
-        # Public API doesn't allow this
+    def test_child_of_page_1(self):
+        # Public API doesn't allow this, as it's the root page
         response = self.get_response(child_of=1)
         json.loads(response.content.decode('UTF-8'))
 
@@ -361,80 +175,48 @@ class TestPageListing(AdminAPITestCase):
 
     # DESCENDANT OF FILTER
 
-    def test_descendant_of_filter(self):
-        response = self.get_response(descendant_of=6)
-        content = json.loads(response.content.decode('UTF-8'))
+    # Not applicable to the admin API
+    test_descendant_of_page_thats_not_in_same_site_gives_error = None
 
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list, [10, 15, 17, 21, 22, 23])
-
-    def test_descendant_of_root(self):  # ADMINAPI CHANGE
+    def test_descendant_of_root(self):
         response = self.get_response(descendant_of='root')
         content = json.loads(response.content.decode('UTF-8'))
 
         page_id_list = self.get_page_id_list(content)
         self.assertEqual(page_id_list, [2, 4, 8, 9, 5, 16, 18, 19, 6, 10, 15, 17, 21, 22, 23, 20, 13, 14, 12])
 
-    def test_descendant_of_with_type(self):
-        response = self.get_response(type='tests.EventPage', descendant_of=6)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list, [])
-
-    def test_descendant_of_unknown_page_gives_error(self):
-        response = self.get_response(descendant_of=1000)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "ancestor page doesn't exist"})
-
-    def test_descendant_of_not_integer_gives_error(self):
-        response = self.get_response(descendant_of='abc')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "descendant_of must be a positive integer"})
-
-    def test_descendant_of_root_doesnt_give_error(self):  # ADMINAPI CHANGE
+    def test_descendant_of_root_doesnt_give_error(self):
         # Public API doesn't allow this
         response = self.get_response(descendant_of=1)
         json.loads(response.content.decode('UTF-8'))
 
         self.assertEqual(response.status_code, 200)
 
-    def test_descendant_of_when_filtering_by_child_of_gives_error(self):
-        response = self.get_response(descendant_of=6, child_of=5)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "filtering by descendant_of with child_of is not supported"})
-
 
     # HAS CHILDREN FILTER
 
-    def test_has_children_filter(self):  # ADMINAPI CHANGE
+    def test_has_children_filter(self):
         response = self.get_response(has_children=1)
         content = json.loads(response.content.decode('UTF-8'))
 
         page_id_list = self.get_page_id_list(content)
         self.assertEqual(page_id_list, [2, 4, 5, 6, 21, 20])
 
-    def test_has_children_filter_off(self):  # ADMINAPI CHANGE
+    def test_has_children_filter_off(self):
         response = self.get_response(has_children=0)
         content = json.loads(response.content.decode('UTF-8'))
 
         page_id_list = self.get_page_id_list(content)
         self.assertEqual(page_id_list, [8, 9, 16, 18, 19, 10, 15, 17, 22, 23, 13, 14, 12])
 
-    def test_has_children_filter_invalid_integer(self):  # ADMINAPI CHANGE
+    def test_has_children_filter_invalid_integer(self):
         response = self.get_response(has_children=3)
         content = json.loads(response.content.decode('UTF-8'))
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(content, {'message': "has_children must be 1 or 0"})
 
-    def test_has_children_filter_invalid_value(self):  # ADMINAPI CHANGE
+    def test_has_children_filter_invalid_value(self):
         response = self.get_response(has_children='yes')
         content = json.loads(response.content.decode('UTF-8'))
 
@@ -442,202 +224,7 @@ class TestPageListing(AdminAPITestCase):
         self.assertEqual(content, {'message': "has_children must be 1 or 0"})
 
 
-    # ORDERING
-
-    def test_ordering_default(self):
-        response = self.get_response()
-        content = json.loads(response.content.decode('UTF-8'))
-
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list, [2, 4, 8, 9, 5, 16, 18, 19, 6, 10, 15, 17, 21, 22, 23, 20, 13, 14, 12])
-
-    def test_ordering_by_title(self):
-        response = self.get_response(order='title')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list, [21, 22, 19, 23, 5, 16, 18, 12, 14, 8, 9, 4, 2, 13, 20, 17, 6, 10, 15])
-
-    def test_ordering_by_title_backwards(self):
-        response = self.get_response(order='-title')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list, [15, 10, 6, 17, 20, 13, 2, 4, 9, 8, 14, 12, 18, 16, 5, 23, 19, 22, 21])
-
-    def test_ordering_by_random(self):
-        response_1 = self.get_response(order='random')
-        content_1 = json.loads(response_1.content.decode('UTF-8'))
-        page_id_list_1 = self.get_page_id_list(content_1)
-
-        response_2 = self.get_response(order='random')
-        content_2 = json.loads(response_2.content.decode('UTF-8'))
-        page_id_list_2 = self.get_page_id_list(content_2)
-
-        self.assertNotEqual(page_id_list_1, page_id_list_2)
-
-    def test_ordering_by_random_backwards_gives_error(self):
-        response = self.get_response(order='-random')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "cannot order by 'random' (unknown field)"})
-
-    def test_ordering_by_random_with_offset_gives_error(self):
-        response = self.get_response(order='random', offset=10)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "random ordering with offset is not supported"})
-
-    def test_ordering_default_with_type(self):
-        response = self.get_response(type='demosite.BlogEntryPage')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list, [16, 18, 19])
-
-    def test_ordering_by_title_with_type(self):
-        response = self.get_response(type='demosite.BlogEntryPage', order='title')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list, [19, 16, 18])
-
-    def test_ordering_by_specific_field_with_type(self):
-        response = self.get_response(type='demosite.BlogEntryPage', order='date')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list, [16, 18, 19])
-
-    def test_ordering_by_unknown_field_gives_error(self):
-        response = self.get_response(order='not_a_field')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "cannot order by 'not_a_field' (unknown field)"})
-
-
-    # LIMIT
-
-    def test_limit_only_two_items_returned(self):
-        response = self.get_response(limit=2)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(len(content['items']), 2)
-
-    def test_limit_total_count(self):
-        response = self.get_response(limit=2)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        # The total count must not be affected by "limit"
-        self.assertEqual(content['meta']['total_count'], get_total_page_count())
-
-    def test_limit_not_integer_gives_error(self):
-        response = self.get_response(limit='abc')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "limit must be a positive integer"})
-
-    def test_limit_too_high_gives_error(self):
-        response = self.get_response(limit=1000)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "limit cannot be higher than 20"})
-
-    @override_settings(WAGTAILAPI_LIMIT_MAX=10)
-    def test_limit_maximum_can_be_changed(self):
-        response = self.get_response(limit=20)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "limit cannot be higher than 10"})
-
-    @override_settings(WAGTAILAPI_LIMIT_MAX=2)
-    def test_limit_default_changes_with_max(self):
-        # The default limit is 20. If WAGTAILAPI_LIMIT_MAX is less than that,
-        # the default should change accordingly.
-        response = self.get_response()
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(len(content['items']), 2)
-
-
-    # OFFSET
-
-    def test_offset_5_usually_appears_5th_in_list(self):
-        response = self.get_response()
-        content = json.loads(response.content.decode('UTF-8'))
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list.index(5), 4)
-
-    def test_offset_5_moves_after_offset(self):
-        response = self.get_response(offset=4)
-        content = json.loads(response.content.decode('UTF-8'))
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list.index(5), 0)
-
-    def test_offset_total_count(self):
-        response = self.get_response(offset=10)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        # The total count must not be affected by "offset"
-        self.assertEqual(content['meta']['total_count'], get_total_page_count())
-
-    def test_offset_not_integer_gives_error(self):
-        response = self.get_response(offset='abc')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "offset must be a positive integer"})
-
-
-    # SEARCH
-
-    def test_search_for_blog(self):
-        response = self.get_response(search='blog')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        page_id_list = self.get_page_id_list(content)
-
-        # Check that the items are the blog index and three blog pages
-        self.assertEqual(set(page_id_list), set([5, 16, 18, 19]))
-
-    def test_search_with_type(self):
-        response = self.get_response(type='demosite.BlogEntryPage', search='blog')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        page_id_list = self.get_page_id_list(content)
-
-        self.assertEqual(set(page_id_list), set([16, 18, 19]))
-
-    def test_search_when_ordering_gives_error(self):
-        response = self.get_response(search='blog', order='title')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "ordering with a search query is not supported"})
-
-    @override_settings(WAGTAILAPI_SEARCH_ENABLED=False)
-    def test_search_when_disabled_gives_error(self):
-        response = self.get_response(search='blog')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "search is disabled"})
-
-    def test_search_when_filtering_by_tag_gives_error(self):
-        response = self.get_response(type='demosite.BlogEntryPage', search='blog', tags='wagtail')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "filtering by tag with a search query is not supported"})
-
-
-class TestPageDetail(AdminAPITestCase):
+class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
     fixtures = ['demosite.json']
 
     def get_response(self, page_id, **params):
@@ -673,7 +260,7 @@ class TestPageDetail(AdminAPITestCase):
         self.assertEqual(content['meta']['html_url'], 'http://localhost/blog-index/blog-post/')
 
         # Check the meta status
-        # ADMINAPI CHANGE
+
         self.assertIn('status', content['meta'])
         self.assertEqual(content['meta']['status'], {
             'status': 'live',
@@ -682,7 +269,7 @@ class TestPageDetail(AdminAPITestCase):
         })
 
         # Check the meta children
-        # ADMINAPI CHANGE
+
         self.assertIn('children', content['meta'])
         self.assertEqual(content['meta']['children'], {
             'count': 0,
@@ -741,14 +328,9 @@ class TestPageDetail(AdminAPITestCase):
         self.assertEqual(content['__types']['demosite.BlogIndexPage']['verbose_name'], 'blog index page')
         self.assertEqual(content['__types']['demosite.BlogIndexPage']['verbose_name_plural'], 'blog index pages')
 
-    def test_meta_parent_id_doesnt_show_root_page(self):
-        # Root page isn't in the site so don't show it if the user is looking at the home page
-        response = self.get_response(2)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertIsNone(content['meta']['parent'])
-
     def test_field_ordering(self):
+        # Need to override this as the admin API has a __types field
+
         response = self.get_response(16)
 
         # Will crash if the JSON is invalid
@@ -770,16 +352,7 @@ class TestPageDetail(AdminAPITestCase):
         ]
         self.assertEqual(list(content.keys()), field_order)
 
-    def test_null_foreign_key(self):
-        models.BlogEntryPage.objects.filter(id=16).update(feed_image_id=None)
-
-        response = self.get_response(16)
-        content = json.loads(response.content.decode('UTF-8'))
-
-        self.assertIn('related_links', content)
-        self.assertEqual(content['feed_image'], None)
-
-    def test_meta_status_draft(self):  # ADMINAPI CHANGE
+    def test_meta_status_draft(self):
         # Unpublish the page
         Page.objects.get(id=16).unpublish()
 
@@ -793,7 +366,7 @@ class TestPageDetail(AdminAPITestCase):
             'has_unpublished_changes': True
         })
 
-    def test_meta_status_live_draft(self):  # ADMINAPI CHANGE
+    def test_meta_status_live_draft(self):
         # Save revision without republish
         Page.objects.get(id=16).save_revision()
 
@@ -807,7 +380,7 @@ class TestPageDetail(AdminAPITestCase):
             'has_unpublished_changes': True
         })
 
-    def test_meta_status_scheduled(self):  # ADMINAPI CHANGE
+    def test_meta_status_scheduled(self):
         # Unpublish and save revision with go live date in the future
         Page.objects.get(id=16).unpublish()
         tomorrow = timezone.now() + datetime.timedelta(days=1)
@@ -823,7 +396,7 @@ class TestPageDetail(AdminAPITestCase):
             'has_unpublished_changes': True
         })
 
-    def test_meta_status_expired(self):  # ADMINAPI CHANGE
+    def test_meta_status_expired(self):
         # Unpublish and set expired flag
         Page.objects.get(id=16).unpublish()
         Page.objects.filter(id=16).update(expired=True)
@@ -850,11 +423,11 @@ class TestPageDetail(AdminAPITestCase):
         })
 
 
-class TestPageDetailWithStreamField(AdminAPITestCase):
+class TestAdminPageDetailWithStreamField(AdminAPITestCase):
     fixtures = ['test.json']
 
     def setUp(self):
-        super(TestPageDetailWithStreamField, self).setUp()
+        super(TestAdminPageDetailWithStreamField, self).setUp()
 
         self.homepage = Page.objects.get(url_path='/home/')
 

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -40,10 +40,14 @@ class TestPageListing(AdminAPITestCase):
         # Will crash if the JSON is invalid
         content = json.loads(response.content.decode('UTF-8'))
 
+        # Check that the meta section is there
+        self.assertIn('meta', content)
+        self.assertIsInstance(content['meta'], dict)
+
         # Check that the total count is there and correct
-        self.assertIn('total_count', content)
-        self.assertIsInstance(content['total_count'], int)
-        self.assertEqual(content['total_count'], get_total_page_count())
+        self.assertIn('total_count', content['meta'])
+        self.assertIsInstance(content['meta']['total_count'], int)
+        self.assertEqual(content['meta']['total_count'], get_total_page_count())
 
         # Check that the items section is there
         self.assertIn('items', content)
@@ -63,7 +67,7 @@ class TestPageListing(AdminAPITestCase):
 
         response = self.get_response()
         content = json.loads(response.content.decode('UTF-8'))
-        self.assertEqual(content['total_count'], total_count)
+        self.assertEqual(content['meta']['total_count'], total_count)
 
     def test_private_pages_appear_in_list(self):  # ADMINAPI CHANGE
         total_count = get_total_page_count()
@@ -76,7 +80,7 @@ class TestPageListing(AdminAPITestCase):
 
         response = self.get_response()
         content = json.loads(response.content.decode('UTF-8'))
-        self.assertEqual(content['total_count'], new_total_count)
+        self.assertEqual(content['meta']['total_count'], new_total_count)
 
 
     # TYPE FILTER
@@ -96,7 +100,7 @@ class TestPageListing(AdminAPITestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         # Total count must be reduced as this filters the items
-        self.assertEqual(content['total_count'], 3)
+        self.assertEqual(content['meta']['total_count'], 3)
 
     def test_type_filter_multiple(self):
         response = self.get_response(type='demosite.BlogEntryPage,demosite.EventPage')
@@ -448,7 +452,7 @@ class TestPageListing(AdminAPITestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         # The total count must not be affected by "limit"
-        self.assertEqual(content['total_count'], get_total_page_count())
+        self.assertEqual(content['meta']['total_count'], get_total_page_count())
 
     def test_limit_not_integer_gives_error(self):
         response = self.get_response(limit='abc')
@@ -501,7 +505,7 @@ class TestPageListing(AdminAPITestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         # The total count must not be affected by "offset"
-        self.assertEqual(content['total_count'], get_total_page_count())
+        self.assertEqual(content['meta']['total_count'], get_total_page_count())
 
     def test_offset_not_integer_gives_error(self):
         response = self.get_response(offset='abc')

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -49,11 +49,11 @@ class TestPageListing(AdminAPITestCase):
         self.assertIn('results', content)
         self.assertIsInstance(content['results'], list)
 
-        # Check that each page has a meta section with type, detail_url, html_url, status and has_children attributes
+        # Check that each page has a meta section with type, detail_url, html_url, status and children attributes
         for page in content['results']:
             self.assertIn('meta', page)
             self.assertIsInstance(page['meta'], dict)
-            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'status', 'has_children'})  # ADMINAPI CHANGE
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'status', 'children'})  # ADMINAPI CHANGE
 
     def test_unpublished_pages_appear_in_list(self):  # ADMINAPI CHANGE
         total_count = get_total_page_count()
@@ -597,10 +597,13 @@ class TestPageDetail(AdminAPITestCase):
             'has_unpublished_changes': False
         })
 
-        # Check the meta has_children
+        # Check the meta children
         # ADMINAPI CHANGE
-        self.assertIn('has_children', content['meta'])
-        self.assertEqual(content['meta']['has_children'], False)
+        self.assertIn('children', content['meta'])
+        self.assertEqual(content['meta']['children'], {
+            'count': 0,
+            'listing_url': 'http://localhost/admin/api/v1beta/pages/?child_of=16'
+        })
 
         # Check the parent field
         self.assertIn('parent', content)
@@ -738,13 +741,16 @@ class TestPageDetail(AdminAPITestCase):
             'has_unpublished_changes': True
         })
 
-    def test_meta_has_children_is_true_for_parent(self):  # ADMINAPI CHANGE
+    def test_meta_children_for_parent(self):  # ADMINAPI CHANGE
         # Homepage should have children
         response = self.get_response(2)
         content = json.loads(response.content.decode('UTF-8'))
 
-        self.assertIn('has_children', content['meta'])
-        self.assertEqual(content['meta']['has_children'], True)
+        self.assertIn('children', content['meta'])
+        self.assertEqual(content['meta']['children'], {
+            'count': 5,
+            'listing_url': 'http://localhost/admin/api/v1beta/pages/?child_of=2'
+        })
 
 
 class TestPageDetailWithStreamField(AdminAPITestCase):

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -591,7 +591,11 @@ class TestPageDetail(AdminAPITestCase):
         # Check the meta status
         # ADMINAPI CHANGE
         self.assertIn('status', content['meta'])
-        self.assertEqual(content['meta']['status'], 'live')
+        self.assertEqual(content['meta']['status'], {
+            'status': 'live',
+            'live': True,
+            'has_unpublished_changes': False
+        })
 
         # Check the meta has_children
         # ADMINAPI CHANGE
@@ -683,7 +687,11 @@ class TestPageDetail(AdminAPITestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         self.assertIn('status', content['meta'])
-        self.assertEqual(content['meta']['status'], 'draft')
+        self.assertEqual(content['meta']['status'], {
+            'status': 'draft',
+            'live': False,
+            'has_unpublished_changes': True
+        })
 
     def test_meta_status_live_draft(self):  # ADMINAPI CHANGE
         # Save revision without republish
@@ -693,7 +701,11 @@ class TestPageDetail(AdminAPITestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         self.assertIn('status', content['meta'])
-        self.assertEqual(content['meta']['status'], 'live + draft')
+        self.assertEqual(content['meta']['status'], {
+            'status': 'live + draft',
+            'live': True,
+            'has_unpublished_changes': True
+        })
 
     def test_meta_status_scheduled(self):  # ADMINAPI CHANGE
         # Unpublish and save revision with go live date in the future
@@ -705,7 +717,11 @@ class TestPageDetail(AdminAPITestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         self.assertIn('status', content['meta'])
-        self.assertEqual(content['meta']['status'], 'scheduled')
+        self.assertEqual(content['meta']['status'], {
+            'status': 'scheduled',
+            'live': False,
+            'has_unpublished_changes': True
+        })
 
     def test_meta_status_expired(self):  # ADMINAPI CHANGE
         # Unpublish and set expired flag
@@ -716,7 +732,11 @@ class TestPageDetail(AdminAPITestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         self.assertIn('status', content['meta'])
-        self.assertEqual(content['meta']['status'], 'expired')
+        self.assertEqual(content['meta']['status'], {
+            'status': 'expired',
+            'live': False,
+            'has_unpublished_changes': True
+        })
 
     def test_meta_has_children_is_true_for_parent(self):  # ADMINAPI CHANGE
         # Homepage should have children

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -57,7 +57,7 @@ class TestPageListing(AdminAPITestCase):
         for page in content['items']:
             self.assertIn('meta', page)
             self.assertIsInstance(page['meta'], dict)
-            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'status', 'children', 'slug', 'first_published_at'})  # ADMINAPI CHANGE
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'status', 'children', 'slug', 'first_published_at', 'latest_revision_created_at'})  # ADMINAPI CHANGE
 
         # Check the type info
         self.assertIsInstance(content['__types'], dict)
@@ -161,7 +161,7 @@ class TestPageListing(AdminAPITestCase):
 
         for page in content['items']:
             self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
-            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'children', 'status', 'slug', 'first_published_at'})
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'children', 'status', 'slug', 'first_published_at', 'latest_revision_created_at'})
 
     def test_fields(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='title,date,feed_image')

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -171,7 +171,7 @@ class TestPageListing(AdminAPITestCase):
                 self.assertIsInstance(feed_image['meta'], dict)
                 self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url'})
                 self.assertEqual(feed_image['meta']['type'], 'wagtailimages.Image')
-                self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/admin/api/v1beta/images/%d/' % feed_image['id'])
+                self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/admin/api/v2beta/images/%d/' % feed_image['id'])
 
     def test_fields_tags(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='tags')
@@ -582,7 +582,7 @@ class TestPageDetail(AdminAPITestCase):
 
         # Check the meta detail_url
         self.assertIn('detail_url', content['meta'])
-        self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v1beta/pages/16/')
+        self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v2beta/pages/16/')
 
         # Check the meta html_url
         self.assertIn('html_url', content['meta'])
@@ -602,7 +602,7 @@ class TestPageDetail(AdminAPITestCase):
         self.assertIn('children', content['meta'])
         self.assertEqual(content['meta']['children'], {
             'count': 0,
-            'listing_url': 'http://localhost/admin/api/v1beta/pages/?child_of=16'
+            'listing_url': 'http://localhost/admin/api/v2beta/pages/?child_of=16'
         })
 
         # Check the parent field
@@ -613,7 +613,7 @@ class TestPageDetail(AdminAPITestCase):
         self.assertIsInstance(content['parent']['meta'], dict)
         self.assertEqual(set(content['parent']['meta'].keys()), {'type', 'detail_url', 'html_url'})
         self.assertEqual(content['parent']['meta']['type'], 'demosite.BlogIndexPage')
-        self.assertEqual(content['parent']['meta']['detail_url'], 'http://localhost/admin/api/v1beta/pages/5/')
+        self.assertEqual(content['parent']['meta']['detail_url'], 'http://localhost/admin/api/v2beta/pages/5/')
         self.assertEqual(content['parent']['meta']['html_url'], 'http://localhost/blog-index/')
 
         # Check that the custom fields are included
@@ -637,7 +637,7 @@ class TestPageDetail(AdminAPITestCase):
         self.assertIsInstance(content['feed_image']['meta'], dict)
         self.assertEqual(set(content['feed_image']['meta'].keys()), {'type', 'detail_url'})
         self.assertEqual(content['feed_image']['meta']['type'], 'wagtailimages.Image')
-        self.assertEqual(content['feed_image']['meta']['detail_url'], 'http://localhost/admin/api/v1beta/images/7/')
+        self.assertEqual(content['feed_image']['meta']['detail_url'], 'http://localhost/admin/api/v2beta/images/7/')
 
         # Check that the child relations were serialised properly
         self.assertEqual(content['related_links'], [])
@@ -749,7 +749,7 @@ class TestPageDetail(AdminAPITestCase):
         self.assertIn('children', content['meta'])
         self.assertEqual(content['meta']['children'], {
             'count': 5,
-            'listing_url': 'http://localhost/admin/api/v1beta/pages/?child_of=2'
+            'listing_url': 'http://localhost/admin/api/v2beta/pages/?child_of=2'
         })
 
 

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -194,6 +194,23 @@ class TestPageListing(AdminAPITestCase):
                 self.assertEqual(feed_image['meta']['type'], 'wagtailimages.Image')
                 self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/admin/api/v2beta/images/%d/' % feed_image['id'])
 
+    def test_fields_parent(self):  # ADMINAPI CHANGE
+        response = self.get_response(type='demosite.BlogEntryPage', fields='parent')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            parent = page['meta']['parent']
+
+            # All blog entry pages have the same parent
+            self.assertEqual(parent, {
+                'id': 5,
+                'meta': {
+                    'type': 'demosite.BlogIndexPage',
+                    'detail_url': 'http://localhost/admin/api/v2beta/pages/5/',
+                    'html_url': 'http://localhost/blog-index/',
+                }
+            })
+
     def test_fields_tags(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='tags')
         content = json.loads(response.content.decode('UTF-8'))

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -13,8 +13,8 @@ from .utils import AdminAPITestCase
 
 
 def get_total_page_count():
-    # Need to take away 1 as the root page is invisible over the API
-    return Page.objects.live().public().count() - 1
+    # Need to take away 1 as the root page is invisible over the API by default
+    return Page.objects.count() - 1
 
 
 class TestPageListing(AdminAPITestCase):
@@ -53,7 +53,7 @@ class TestPageListing(AdminAPITestCase):
             self.assertIsInstance(page['meta'], dict)
             self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url'})
 
-    def test_unpublished_pages_dont_appear_in_list(self):
+    def test_unpublished_pages_appear_in_list(self):  # ADMINAPI CHANGE
         total_count = get_total_page_count()
 
         page = models.BlogEntryPage.objects.get(id=16)
@@ -61,16 +61,16 @@ class TestPageListing(AdminAPITestCase):
 
         response = self.get_response()
         content = json.loads(response.content.decode('UTF-8'))
-        self.assertEqual(content['total_count'], total_count - 1)
+        self.assertEqual(content['total_count'], total_count)
 
-    def test_private_pages_dont_appear_in_list(self):
+    def test_private_pages_appear_in_list(self):  # ADMINAPI CHANGE
         total_count = get_total_page_count()
 
         page = models.BlogIndexPage.objects.get(id=5)
         page.view_restrictions.create(password='test')
 
         new_total_count = get_total_page_count()
-        self.assertNotEqual(total_count, new_total_count)
+        self.assertEqual(total_count, total_count)
 
         response = self.get_response()
         content = json.loads(response.content.decode('UTF-8'))

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -89,7 +89,7 @@ class TestPageListing(AdminAPITestCase):
             self.assertEqual(page['meta']['type'], 'demosite.BlogEntryPage')
 
             # All fields in specific type available
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'related_links', 'date', 'body', 'tags', 'feed_image', 'carousel_items'})
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'related_links', 'date', 'body', 'tags', 'feed_image', 'carousel_items', 'first_published_at', 'search_description', 'show_in_menus', 'slug', 'seo_title'})
 
     def test_type_filter_total_count(self):
         response = self.get_response(type='demosite.BlogEntryPage')
@@ -114,7 +114,7 @@ class TestPageListing(AdminAPITestCase):
                 event_page_seen = True
 
             # Only generic fields available
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'first_published_at', 'search_description', 'show_in_menus', 'slug', 'seo_title'})
 
         self.assertTrue(blog_page_seen, "No blog pages were found in the results")
         self.assertTrue(event_page_seen, "No event pages were found in the results")
@@ -140,7 +140,7 @@ class TestPageListing(AdminAPITestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         for page in content['results']:
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'related_links', 'feed_image', 'body', 'carousel_items', 'tags'})
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'related_links', 'feed_image', 'body', 'carousel_items', 'tags', 'first_published_at', 'search_description', 'show_in_menus', 'slug', 'seo_title'})
 
     def test_fields(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='title,date,feed_image')
@@ -664,6 +664,11 @@ class TestPageDetail(AdminAPITestCase):
             'meta',
             'parent',
             'title',
+            'slug',
+            'show_in_menus',
+            'seo_title',
+            'search_description',
+            'first_published_at',
             'body',
             'tags',
             'date',

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -286,6 +286,16 @@ class TestPageListing(AdminAPITestCase):
         page_id_list = self.get_page_id_list(content)
         self.assertEqual(page_id_list, [16, 18, 19])
 
+    def test_child_of_root(self):  # ADMINAPI CHANGE
+        # Only return the homepage as that's the only child of the "root" node
+        # in the tree. This is different to the public API which pretends the
+        # homepage of the current site is the root page.
+        response = self.get_response(child_of='root')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [2])
+
     def test_child_of_with_type(self):
         response = self.get_response(type='demosite.EventPage', child_of=5)
         content = json.loads(response.content.decode('UTF-8'))
@@ -307,13 +317,12 @@ class TestPageListing(AdminAPITestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(content, {'message': "child_of must be a positive integer"})
 
-    def test_child_of_page_thats_not_in_same_site_gives_error(self):
-        # Root page is not in any site, so pretend it doesn't exist
+    def test_child_of_root_doesnt_give_error(self):  # ADMINAPI CHANGE
+        # Public API doesn't allow this
         response = self.get_response(child_of=1)
-        content = json.loads(response.content.decode('UTF-8'))
+        json.loads(response.content.decode('UTF-8'))
 
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "parent page doesn't exist"})
+        self.assertEqual(response.status_code, 200)
 
 
     # DESCENDANT OF FILTER
@@ -324,6 +333,13 @@ class TestPageListing(AdminAPITestCase):
 
         page_id_list = self.get_page_id_list(content)
         self.assertEqual(page_id_list, [10, 15, 17, 21, 22, 23])
+
+    def test_descendant_of_root(self):  # ADMINAPI CHANGE
+        response = self.get_response(descendant_of='root')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [2, 4, 8, 9, 5, 16, 18, 19, 6, 10, 15, 17, 21, 22, 23, 20, 13, 14, 12])
 
     def test_descendant_of_with_type(self):
         response = self.get_response(type='tests.EventPage', descendant_of=6)
@@ -346,13 +362,12 @@ class TestPageListing(AdminAPITestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(content, {'message': "descendant_of must be a positive integer"})
 
-    def test_descendant_of_page_thats_not_in_same_site_gives_error(self):
-        # Root page is not in any site, so pretend it doesn't exist
+    def test_descendant_of_root_doesnt_give_error(self):  # ADMINAPI CHANGE
+        # Public API doesn't allow this
         response = self.get_response(descendant_of=1)
-        content = json.loads(response.content.decode('UTF-8'))
+        json.loads(response.content.decode('UTF-8'))
 
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "ancestor page doesn't exist"})
+        self.assertEqual(response.status_code, 200)
 
     def test_descendant_of_when_filtering_by_child_of_gives_error(self):
         response = self.get_response(descendant_of=6, child_of=5)

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -1,0 +1,707 @@
+import json
+import collections
+
+from django.test.utils import override_settings
+from django.core.urlresolvers import reverse
+
+from wagtail.wagtailcore.models import Page
+
+from wagtail.tests.demosite import models
+from wagtail.tests.testapp.models import StreamPage
+
+from .utils import AdminAPITestCase
+
+
+def get_total_page_count():
+    # Need to take away 1 as the root page is invisible over the API
+    return Page.objects.live().public().count() - 1
+
+
+class TestPageListing(AdminAPITestCase):
+    fixtures = ['demosite.json']
+
+    def get_response(self, **params):
+        return self.client.get(reverse('wagtailadmin_api_v1:pages:listing'), params)
+
+    def get_page_id_list(self, content):
+        return [page['id'] for page in content['results']]
+
+
+    # BASIC TESTS
+
+    def test_basic(self):
+        response = self.get_response()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-type'], 'application/json')
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Check that the total count is there and correct
+        self.assertIn('total_count', content)
+        self.assertIsInstance(content['total_count'], int)
+        self.assertEqual(content['total_count'], get_total_page_count())
+
+        # Check that the results section is there
+        self.assertIn('results', content)
+        self.assertIsInstance(content['results'], list)
+
+        # Check that each page has a meta section with type, detail_url and html_url attributes
+        for page in content['results']:
+            self.assertIn('meta', page)
+            self.assertIsInstance(page['meta'], dict)
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url'})
+
+    def test_unpublished_pages_dont_appear_in_list(self):
+        total_count = get_total_page_count()
+
+        page = models.BlogEntryPage.objects.get(id=16)
+        page.unpublish()
+
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+        self.assertEqual(content['total_count'], total_count - 1)
+
+    def test_private_pages_dont_appear_in_list(self):
+        total_count = get_total_page_count()
+
+        page = models.BlogIndexPage.objects.get(id=5)
+        page.view_restrictions.create(password='test')
+
+        new_total_count = get_total_page_count()
+        self.assertNotEqual(total_count, new_total_count)
+
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+        self.assertEqual(content['total_count'], new_total_count)
+
+
+    # TYPE FILTER
+
+    def test_type_filter_results_are_all_blog_entries(self):
+        response = self.get_response(type='demosite.BlogEntryPage')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['results']:
+            self.assertEqual(page['meta']['type'], 'demosite.BlogEntryPage')
+
+            # All fields in specific type available
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'related_links', 'date', 'body', 'tags', 'feed_image', 'carousel_items'})
+
+    def test_type_filter_total_count(self):
+        response = self.get_response(type='demosite.BlogEntryPage')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Total count must be reduced as this filters the results
+        self.assertEqual(content['total_count'], 3)
+
+    def test_type_filter_multiple(self):
+        response = self.get_response(type='demosite.BlogEntryPage,demosite.EventPage')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        blog_page_seen = False
+        event_page_seen = False
+
+        for page in content['results']:
+            self.assertIn(page['meta']['type'], ['demosite.BlogEntryPage', 'demosite.EventPage'])
+
+            if page['meta']['type'] == 'demosite.BlogEntryPage':
+                blog_page_seen = True
+            elif page['meta']['type'] == 'demosite.EventPage':
+                event_page_seen = True
+
+            # Only generic fields available
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
+
+        self.assertTrue(blog_page_seen, "No blog pages were found in the results")
+        self.assertTrue(event_page_seen, "No event pages were found in the results")
+
+    def test_non_existant_type_gives_error(self):
+        response = self.get_response(type='demosite.IDontExist')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "type doesn't exist"})
+
+    def test_non_page_type_gives_error(self):
+        response = self.get_response(type='auth.User')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "type doesn't exist"})
+
+    # FIELDS
+
+    def test_fields_default(self):
+        response = self.get_response(type='demosite.BlogEntryPage')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['results']:
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'related_links', 'feed_image', 'body', 'carousel_items', 'tags'})
+
+    def test_fields(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='title,date,feed_image')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['results']:
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'feed_image'})
+
+    def test_fields_child_relation(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='title,related_links')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['results']:
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'related_links'})
+            self.assertIsInstance(page['related_links'], list)
+
+    def test_fields_foreign_key(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='title,date,feed_image')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['results']:
+            feed_image = page['feed_image']
+
+            if feed_image is not None:
+                self.assertIsInstance(feed_image, dict)
+                self.assertEqual(set(feed_image.keys()), {'id', 'meta'})
+                self.assertIsInstance(feed_image['id'], int)
+                self.assertIsInstance(feed_image['meta'], dict)
+                self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url'})
+                self.assertEqual(feed_image['meta']['type'], 'wagtailimages.Image')
+                self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/admin/api/v1beta/images/%d/' % feed_image['id'])
+
+    def test_fields_tags(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='tags')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['results']:
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'tags'})
+            self.assertIsInstance(page['tags'], list)
+
+    def test_fields_ordering(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='date,title,feed_image,related_links')
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Test field order
+        content = json.JSONDecoder(object_pairs_hook=collections.OrderedDict).decode(response.content.decode('UTF-8'))
+        field_order = [
+            'id',
+            'meta',
+            'title',
+            'date',
+            'feed_image',
+            'related_links',
+        ]
+        self.assertEqual(list(content['results'][0].keys()), field_order)
+
+    def test_fields_without_type_gives_error(self):
+        response = self.get_response(fields='title,related_links')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: related_links"})
+
+    def test_fields_which_are_not_in_api_fields_gives_error(self):
+        response = self.get_response(fields='path')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: path"})
+
+    def test_fields_unknown_field_gives_error(self):
+        response = self.get_response(fields='123,title,abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+
+    # FILTERING
+
+    def test_filtering_exact_filter(self):
+        response = self.get_response(title='Home page')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [2])
+
+    def test_filtering_exact_filter_on_specific_field(self):
+        response = self.get_response(type='demosite.BlogEntryPage', date='2013-12-02')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [16])
+
+    def test_filtering_on_id(self):
+        response = self.get_response(id=16)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [16])
+
+    def test_filtering_doesnt_work_on_specific_fields_without_type(self):
+        response = self.get_response(date='2013-12-02')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "query parameter is not an operation or a recognised field: date"})
+
+    def test_filtering_tags(self):
+        response = self.get_response(type='demosite.BlogEntryPage', tags='wagtail')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [16, 18])
+
+    def test_filtering_multiple_tags(self):
+        response = self.get_response(type='demosite.BlogEntryPage', tags='wagtail,bird')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [16])
+
+    def test_filtering_unknown_field_gives_error(self):
+        response = self.get_response(not_a_field='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "query parameter is not an operation or a recognised field: not_a_field"})
+
+
+    # CHILD OF FILTER
+
+    def test_child_of_filter(self):
+        response = self.get_response(child_of=5)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [16, 18, 19])
+
+    def test_child_of_with_type(self):
+        response = self.get_response(type='demosite.EventPage', child_of=5)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [])
+
+    def test_child_of_unknown_page_gives_error(self):
+        response = self.get_response(child_of=1000)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "parent page doesn't exist"})
+
+    def test_child_of_not_integer_gives_error(self):
+        response = self.get_response(child_of='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "child_of must be a positive integer"})
+
+    def test_child_of_page_thats_not_in_same_site_gives_error(self):
+        # Root page is not in any site, so pretend it doesn't exist
+        response = self.get_response(child_of=1)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "parent page doesn't exist"})
+
+
+    # DESCENDANT OF FILTER
+
+    def test_descendant_of_filter(self):
+        response = self.get_response(descendant_of=6)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [10, 15, 17, 21, 22, 23])
+
+    def test_descendant_of_with_type(self):
+        response = self.get_response(type='tests.EventPage', descendant_of=6)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [])
+
+    def test_descendant_of_unknown_page_gives_error(self):
+        response = self.get_response(descendant_of=1000)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "ancestor page doesn't exist"})
+
+    def test_descendant_of_not_integer_gives_error(self):
+        response = self.get_response(descendant_of='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "descendant_of must be a positive integer"})
+
+    def test_descendant_of_page_thats_not_in_same_site_gives_error(self):
+        # Root page is not in any site, so pretend it doesn't exist
+        response = self.get_response(descendant_of=1)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "ancestor page doesn't exist"})
+
+    def test_descendant_of_when_filtering_by_child_of_gives_error(self):
+        response = self.get_response(descendant_of=6, child_of=5)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "filtering by descendant_of with child_of is not supported"})
+
+
+    # ORDERING
+
+    def test_ordering_default(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [2, 4, 8, 9, 5, 16, 18, 19, 6, 10, 15, 17, 21, 22, 23, 20, 13, 14, 12])
+
+    def test_ordering_by_title(self):
+        response = self.get_response(order='title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [21, 22, 19, 23, 5, 16, 18, 12, 14, 8, 9, 4, 2, 13, 20, 17, 6, 10, 15])
+
+    def test_ordering_by_title_backwards(self):
+        response = self.get_response(order='-title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [15, 10, 6, 17, 20, 13, 2, 4, 9, 8, 14, 12, 18, 16, 5, 23, 19, 22, 21])
+
+    def test_ordering_by_random(self):
+        response_1 = self.get_response(order='random')
+        content_1 = json.loads(response_1.content.decode('UTF-8'))
+        page_id_list_1 = self.get_page_id_list(content_1)
+
+        response_2 = self.get_response(order='random')
+        content_2 = json.loads(response_2.content.decode('UTF-8'))
+        page_id_list_2 = self.get_page_id_list(content_2)
+
+        self.assertNotEqual(page_id_list_1, page_id_list_2)
+
+    def test_ordering_by_random_backwards_gives_error(self):
+        response = self.get_response(order='-random')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "cannot order by 'random' (unknown field)"})
+
+    def test_ordering_by_random_with_offset_gives_error(self):
+        response = self.get_response(order='random', offset=10)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "random ordering with offset is not supported"})
+
+    def test_ordering_default_with_type(self):
+        response = self.get_response(type='demosite.BlogEntryPage')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [16, 18, 19])
+
+    def test_ordering_by_title_with_type(self):
+        response = self.get_response(type='demosite.BlogEntryPage', order='title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [19, 16, 18])
+
+    def test_ordering_by_specific_field_with_type(self):
+        response = self.get_response(type='demosite.BlogEntryPage', order='date')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [16, 18, 19])
+
+    def test_ordering_by_unknown_field_gives_error(self):
+        response = self.get_response(order='not_a_field')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "cannot order by 'not_a_field' (unknown field)"})
+
+
+    # LIMIT
+
+    def test_limit_only_two_results_returned(self):
+        response = self.get_response(limit=2)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(len(content['results']), 2)
+
+    def test_limit_total_count(self):
+        response = self.get_response(limit=2)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # The total count must not be affected by "limit"
+        self.assertEqual(content['total_count'], get_total_page_count())
+
+    def test_limit_not_integer_gives_error(self):
+        response = self.get_response(limit='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit must be a positive integer"})
+
+    def test_limit_too_high_gives_error(self):
+        response = self.get_response(limit=1000)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit cannot be higher than 20"})
+
+    @override_settings(WAGTAILAPI_LIMIT_MAX=10)
+    def test_limit_maximum_can_be_changed(self):
+        response = self.get_response(limit=20)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit cannot be higher than 10"})
+
+    @override_settings(WAGTAILAPI_LIMIT_MAX=2)
+    def test_limit_default_changes_with_max(self):
+        # The default limit is 20. If WAGTAILAPI_LIMIT_MAX is less than that,
+        # the default should change accordingly.
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(len(content['results']), 2)
+
+
+    # OFFSET
+
+    def test_offset_5_usually_appears_5th_in_list(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list.index(5), 4)
+
+    def test_offset_5_moves_after_offset(self):
+        response = self.get_response(offset=4)
+        content = json.loads(response.content.decode('UTF-8'))
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list.index(5), 0)
+
+    def test_offset_total_count(self):
+        response = self.get_response(offset=10)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # The total count must not be affected by "offset"
+        self.assertEqual(content['total_count'], get_total_page_count())
+
+    def test_offset_not_integer_gives_error(self):
+        response = self.get_response(offset='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "offset must be a positive integer"})
+
+
+    # SEARCH
+
+    def test_search_for_blog(self):
+        response = self.get_response(search='blog')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+
+        # Check that the results are the blog index and three blog pages
+        self.assertEqual(set(page_id_list), set([5, 16, 18, 19]))
+
+    def test_search_with_type(self):
+        response = self.get_response(type='demosite.BlogEntryPage', search='blog')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+
+        self.assertEqual(set(page_id_list), set([16, 18, 19]))
+
+    def test_search_when_ordering_gives_error(self):
+        response = self.get_response(search='blog', order='title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "ordering with a search query is not supported"})
+
+    @override_settings(WAGTAILAPI_SEARCH_ENABLED=False)
+    def test_search_when_disabled_gives_error(self):
+        response = self.get_response(search='blog')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "search is disabled"})
+
+    def test_search_when_filtering_by_tag_gives_error(self):
+        response = self.get_response(type='demosite.BlogEntryPage', search='blog', tags='wagtail')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "filtering by tag with a search query is not supported"})
+
+
+class TestPageDetail(AdminAPITestCase):
+    fixtures = ['demosite.json']
+
+    def get_response(self, page_id, **params):
+        return self.client.get(reverse('wagtailadmin_api_v1:pages:detail', args=(page_id, )), params)
+
+    def test_basic(self):
+        response = self.get_response(16)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-type'], 'application/json')
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Check the id field
+        self.assertIn('id', content)
+        self.assertEqual(content['id'], 16)
+
+        # Check that the meta section is there
+        self.assertIn('meta', content)
+        self.assertIsInstance(content['meta'], dict)
+
+        # Check the meta type
+        self.assertIn('type', content['meta'])
+        self.assertEqual(content['meta']['type'], 'demosite.BlogEntryPage')
+
+        # Check the meta detail_url
+        self.assertIn('detail_url', content['meta'])
+        self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v1beta/pages/16/')
+
+        # Check the meta html_url
+        self.assertIn('html_url', content['meta'])
+        self.assertEqual(content['meta']['html_url'], 'http://localhost/blog-index/blog-post/')
+
+        # Check the parent field
+        self.assertIn('parent', content)
+        self.assertIsInstance(content['parent'], dict)
+        self.assertEqual(set(content['parent'].keys()), {'id', 'meta'})
+        self.assertEqual(content['parent']['id'], 5)
+        self.assertIsInstance(content['parent']['meta'], dict)
+        self.assertEqual(set(content['parent']['meta'].keys()), {'type', 'detail_url', 'html_url'})
+        self.assertEqual(content['parent']['meta']['type'], 'demosite.BlogIndexPage')
+        self.assertEqual(content['parent']['meta']['detail_url'], 'http://localhost/admin/api/v1beta/pages/5/')
+        self.assertEqual(content['parent']['meta']['html_url'], 'http://localhost/blog-index/')
+
+        # Check that the custom fields are included
+        self.assertIn('date', content)
+        self.assertIn('body', content)
+        self.assertIn('tags', content)
+        self.assertIn('feed_image', content)
+        self.assertIn('related_links', content)
+        self.assertIn('carousel_items', content)
+
+        # Check that the date was serialised properly
+        self.assertEqual(content['date'], '2013-12-02')
+
+        # Check that the tags were serialised properly
+        self.assertEqual(content['tags'], ['bird', 'wagtail'])
+
+        # Check that the feed image was serialised properly
+        self.assertIsInstance(content['feed_image'], dict)
+        self.assertEqual(set(content['feed_image'].keys()), {'id', 'meta'})
+        self.assertEqual(content['feed_image']['id'], 7)
+        self.assertIsInstance(content['feed_image']['meta'], dict)
+        self.assertEqual(set(content['feed_image']['meta'].keys()), {'type', 'detail_url'})
+        self.assertEqual(content['feed_image']['meta']['type'], 'wagtailimages.Image')
+        self.assertEqual(content['feed_image']['meta']['detail_url'], 'http://localhost/admin/api/v1beta/images/7/')
+
+        # Check that the child relations were serialised properly
+        self.assertEqual(content['related_links'], [])
+        for carousel_item in content['carousel_items']:
+            self.assertEqual(set(carousel_item.keys()), {'embed_url', 'link', 'caption', 'image'})
+
+    def test_meta_parent_id_doesnt_show_root_page(self):
+        # Root page isn't in the site so don't show it if the user is looking at the home page
+        response = self.get_response(2)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertNotIn('parent', content['meta'])
+
+    def test_field_ordering(self):
+        response = self.get_response(16)
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Test field order
+        content = json.JSONDecoder(object_pairs_hook=collections.OrderedDict).decode(response.content.decode('UTF-8'))
+        field_order = [
+            'id',
+            'meta',
+            'parent',
+            'title',
+            'body',
+            'tags',
+            'date',
+            'feed_image',
+            'carousel_items',
+            'related_links',
+        ]
+        self.assertEqual(list(content.keys()), field_order)
+
+    def test_null_foreign_key(self):
+        models.BlogEntryPage.objects.filter(id=16).update(feed_image_id=None)
+
+        response = self.get_response(16)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('related_links', content)
+        self.assertEqual(content['feed_image'], None)
+
+
+class TestPageDetailWithStreamField(AdminAPITestCase):
+    fixtures = ['test.json']
+
+    def setUp(self):
+        super(TestPageDetailWithStreamField, self).setUp()
+
+        self.homepage = Page.objects.get(url_path='/home/')
+
+    def make_stream_page(self, body):
+        stream_page = StreamPage(
+            title='stream page',
+            slug='stream-page',
+            body=body
+        )
+        return self.homepage.add_child(instance=stream_page)
+
+    def test_can_fetch_streamfield_content(self):
+        stream_page = self.make_stream_page('[{"type": "text", "value": "foo"}]')
+
+        response_url = reverse('wagtailadmin_api_v1:pages:detail', args=(stream_page.id, ))
+        response = self.client.get(response_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['content-type'], 'application/json')
+
+        content = json.loads(response.content.decode('utf-8'))
+
+        self.assertIn('id', content)
+        self.assertEqual(content['id'], stream_page.id)
+        self.assertIn('body', content)
+        self.assertEqual(content['body'], [{'type': 'text', 'value': 'foo'}])
+
+    def test_image_block(self):
+        stream_page = self.make_stream_page('[{"type": "image", "value": 1}]')
+
+        response_url = reverse('wagtailadmin_api_v1:pages:detail', args=(stream_page.id, ))
+        response = self.client.get(response_url)
+        content = json.loads(response.content.decode('utf-8'))
+
+        # ForeignKeys in a StreamField shouldn't be translated into dictionary representation
+        self.assertEqual(content['body'], [{'type': 'image', 'value': 1}])

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -59,6 +59,23 @@ class TestPageListing(AdminAPITestCase):
             self.assertIsInstance(page['meta'], dict)
             self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'status', 'children', 'slug', 'first_published_at'})  # ADMINAPI CHANGE
 
+        # Check the type info
+        self.assertIsInstance(content['__types'], dict)
+        self.assertEqual(set(content['__types'].keys()), {
+            'demosite.EventPage',
+            'demosite.StandardIndexPage',
+            'demosite.PersonPage',
+            'demosite.HomePage',
+            'demosite.StandardPage',
+            'demosite.EventIndexPage',
+            'demosite.ContactPage',
+            'demosite.BlogEntryPage',
+            'demosite.BlogIndexPage',
+        })
+        self.assertEqual(set(content['__types']['demosite.EventPage'].keys()), {'verbose_name', 'verbose_name_plural'})
+        self.assertEqual(content['__types']['demosite.EventPage']['verbose_name'], 'event page')
+        self.assertEqual(content['__types']['demosite.EventPage']['verbose_name_plural'], 'event pages')
+
     def test_unpublished_pages_appear_in_list(self):  # ADMINAPI CHANGE
         total_count = get_total_page_count()
 
@@ -664,6 +681,18 @@ class TestPageDetail(AdminAPITestCase):
             self.assertEqual(set(carousel_item.keys()), {'id', 'meta', 'embed_url', 'link', 'caption', 'image'})
             self.assertEqual(set(carousel_item['meta'].keys()), {'type'})
 
+        # Check the type info
+        self.assertIsInstance(content['__types'], dict)
+        self.assertEqual(set(content['__types'].keys()), {
+            'demosite.BlogIndexPage',
+            'demosite.BlogEntryPageCarouselItem',
+            'demosite.BlogEntryPage',
+            'wagtailimages.Image'
+        })
+        self.assertEqual(set(content['__types']['demosite.BlogIndexPage'].keys()), {'verbose_name', 'verbose_name_plural'})
+        self.assertEqual(content['__types']['demosite.BlogIndexPage']['verbose_name'], 'blog index page')
+        self.assertEqual(content['__types']['demosite.BlogIndexPage']['verbose_name_plural'], 'blog index pages')
+
     def test_meta_parent_id_doesnt_show_root_page(self):
         # Root page isn't in the site so don't show it if the user is looking at the home page
         response = self.get_response(2)
@@ -689,6 +718,7 @@ class TestPageDetail(AdminAPITestCase):
             'feed_image',
             'carousel_items',
             'related_links',
+            '__types',
         ]
         self.assertEqual(list(content.keys()), field_order)
 

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -26,7 +26,7 @@ class TestPageListing(AdminAPITestCase):
         return self.client.get(reverse('wagtailadmin_api_v1:pages:listing'), params)
 
     def get_page_id_list(self, content):
-        return [page['id'] for page in content['results']]
+        return [page['id'] for page in content['items']]
 
 
     # BASIC TESTS
@@ -45,12 +45,12 @@ class TestPageListing(AdminAPITestCase):
         self.assertIsInstance(content['total_count'], int)
         self.assertEqual(content['total_count'], get_total_page_count())
 
-        # Check that the results section is there
-        self.assertIn('results', content)
-        self.assertIsInstance(content['results'], list)
+        # Check that the items section is there
+        self.assertIn('items', content)
+        self.assertIsInstance(content['items'], list)
 
         # Check that each page has a meta section with type, detail_url, html_url, status and children attributes
-        for page in content['results']:
+        for page in content['items']:
             self.assertIn('meta', page)
             self.assertIsInstance(page['meta'], dict)
             self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'status', 'children'})  # ADMINAPI CHANGE
@@ -81,11 +81,11 @@ class TestPageListing(AdminAPITestCase):
 
     # TYPE FILTER
 
-    def test_type_filter_results_are_all_blog_entries(self):
+    def test_type_filter_items_are_all_blog_entries(self):
         response = self.get_response(type='demosite.BlogEntryPage')
         content = json.loads(response.content.decode('UTF-8'))
 
-        for page in content['results']:
+        for page in content['items']:
             self.assertEqual(page['meta']['type'], 'demosite.BlogEntryPage')
 
             # All fields in specific type available
@@ -95,7 +95,7 @@ class TestPageListing(AdminAPITestCase):
         response = self.get_response(type='demosite.BlogEntryPage')
         content = json.loads(response.content.decode('UTF-8'))
 
-        # Total count must be reduced as this filters the results
+        # Total count must be reduced as this filters the items
         self.assertEqual(content['total_count'], 3)
 
     def test_type_filter_multiple(self):
@@ -105,7 +105,7 @@ class TestPageListing(AdminAPITestCase):
         blog_page_seen = False
         event_page_seen = False
 
-        for page in content['results']:
+        for page in content['items']:
             self.assertIn(page['meta']['type'], ['demosite.BlogEntryPage', 'demosite.EventPage'])
 
             if page['meta']['type'] == 'demosite.BlogEntryPage':
@@ -116,8 +116,8 @@ class TestPageListing(AdminAPITestCase):
             # Only generic fields available
             self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'first_published_at', 'search_description', 'show_in_menus', 'slug', 'seo_title'})
 
-        self.assertTrue(blog_page_seen, "No blog pages were found in the results")
-        self.assertTrue(event_page_seen, "No event pages were found in the results")
+        self.assertTrue(blog_page_seen, "No blog pages were found in the items")
+        self.assertTrue(event_page_seen, "No event pages were found in the items")
 
     def test_non_existant_type_gives_error(self):
         response = self.get_response(type='demosite.IDontExist')
@@ -139,21 +139,21 @@ class TestPageListing(AdminAPITestCase):
         response = self.get_response(type='demosite.BlogEntryPage')
         content = json.loads(response.content.decode('UTF-8'))
 
-        for page in content['results']:
+        for page in content['items']:
             self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'related_links', 'feed_image', 'body', 'carousel_items', 'tags', 'first_published_at', 'search_description', 'show_in_menus', 'slug', 'seo_title'})
 
     def test_fields(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='title,date,feed_image')
         content = json.loads(response.content.decode('UTF-8'))
 
-        for page in content['results']:
+        for page in content['items']:
             self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'feed_image'})
 
     def test_fields_child_relation(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='title,related_links')
         content = json.loads(response.content.decode('UTF-8'))
 
-        for page in content['results']:
+        for page in content['items']:
             self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'related_links'})
             self.assertIsInstance(page['related_links'], list)
 
@@ -161,7 +161,7 @@ class TestPageListing(AdminAPITestCase):
         response = self.get_response(type='demosite.BlogEntryPage', fields='title,date,feed_image')
         content = json.loads(response.content.decode('UTF-8'))
 
-        for page in content['results']:
+        for page in content['items']:
             feed_image = page['feed_image']
 
             if feed_image is not None:
@@ -177,7 +177,7 @@ class TestPageListing(AdminAPITestCase):
         response = self.get_response(type='demosite.BlogEntryPage', fields='tags')
         content = json.loads(response.content.decode('UTF-8'))
 
-        for page in content['results']:
+        for page in content['items']:
             self.assertEqual(set(page.keys()), {'id', 'meta', 'tags'})
             self.assertIsInstance(page['tags'], list)
 
@@ -197,7 +197,7 @@ class TestPageListing(AdminAPITestCase):
             'feed_image',
             'related_links',
         ]
-        self.assertEqual(list(content['results'][0].keys()), field_order)
+        self.assertEqual(list(content['items'][0].keys()), field_order)
 
     def test_fields_without_type_gives_error(self):
         response = self.get_response(fields='title,related_links')
@@ -437,11 +437,11 @@ class TestPageListing(AdminAPITestCase):
 
     # LIMIT
 
-    def test_limit_only_two_results_returned(self):
+    def test_limit_only_two_items_returned(self):
         response = self.get_response(limit=2)
         content = json.loads(response.content.decode('UTF-8'))
 
-        self.assertEqual(len(content['results']), 2)
+        self.assertEqual(len(content['items']), 2)
 
     def test_limit_total_count(self):
         response = self.get_response(limit=2)
@@ -479,7 +479,7 @@ class TestPageListing(AdminAPITestCase):
         response = self.get_response()
         content = json.loads(response.content.decode('UTF-8'))
 
-        self.assertEqual(len(content['results']), 2)
+        self.assertEqual(len(content['items']), 2)
 
 
     # OFFSET
@@ -519,7 +519,7 @@ class TestPageListing(AdminAPITestCase):
 
         page_id_list = self.get_page_id_list(content)
 
-        # Check that the results are the blog index and three blog pages
+        # Check that the items are the blog index and three blog pages
         self.assertEqual(set(page_id_list), set([5, 16, 18, 19]))
 
     def test_search_with_type(self):

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -49,11 +49,11 @@ class TestPageListing(AdminAPITestCase):
         self.assertIn('results', content)
         self.assertIsInstance(content['results'], list)
 
-        # Check that each page has a meta section with type, detail_url, html_url and status attributes
+        # Check that each page has a meta section with type, detail_url, html_url, status and has_children attributes
         for page in content['results']:
             self.assertIn('meta', page)
             self.assertIsInstance(page['meta'], dict)
-            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'status'})  # ADMINAPI CHANGE
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'status', 'has_children'})  # ADMINAPI CHANGE
 
     def test_unpublished_pages_appear_in_list(self):  # ADMINAPI CHANGE
         total_count = get_total_page_count()
@@ -593,6 +593,11 @@ class TestPageDetail(AdminAPITestCase):
         self.assertIn('status', content['meta'])
         self.assertEqual(content['meta']['status'], 'live')
 
+        # Check the meta has_children
+        # ADMINAPI CHANGE
+        self.assertIn('has_children', content['meta'])
+        self.assertEqual(content['meta']['has_children'], False)
+
         # Check the parent field
         self.assertIn('parent', content)
         self.assertIsInstance(content['parent'], dict)
@@ -712,6 +717,14 @@ class TestPageDetail(AdminAPITestCase):
 
         self.assertIn('status', content['meta'])
         self.assertEqual(content['meta']['status'], 'expired')
+
+    def test_meta_has_children_is_true_for_parent(self):  # ADMINAPI CHANGE
+        # Homepage should have children
+        response = self.get_response(2)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('has_children', content['meta'])
+        self.assertEqual(content['meta']['has_children'], True)
 
 
 class TestPageDetailWithStreamField(AdminAPITestCase):

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -57,7 +57,7 @@ class TestPageListing(AdminAPITestCase):
         for page in content['items']:
             self.assertIn('meta', page)
             self.assertIsInstance(page['meta'], dict)
-            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'status', 'children', 'seo_title', 'slug', 'show_in_menus', 'first_published_at', 'search_description'})  # ADMINAPI CHANGE
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'status', 'children', 'slug', 'first_published_at'})  # ADMINAPI CHANGE
 
     def test_unpublished_pages_appear_in_list(self):  # ADMINAPI CHANGE
         total_count = get_total_page_count()
@@ -92,8 +92,7 @@ class TestPageListing(AdminAPITestCase):
         for page in content['items']:
             self.assertEqual(page['meta']['type'], 'demosite.BlogEntryPage')
 
-            # All fields in specific type available
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'related_links', 'date', 'body', 'tags', 'feed_image', 'carousel_items'})
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
 
     def test_type_filter_total_count(self):
         response = self.get_response(type='demosite.BlogEntryPage')
@@ -139,12 +138,13 @@ class TestPageListing(AdminAPITestCase):
 
     # FIELDS
 
-    def test_fields_default(self):
+    def test_fields_default(self):  # ADMINAPI CHANGE
         response = self.get_response(type='demosite.BlogEntryPage')
         content = json.loads(response.content.decode('UTF-8'))
 
         for page in content['items']:
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'related_links', 'feed_image', 'body', 'carousel_items', 'tags'})
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'children', 'status', 'slug', 'first_published_at'})
 
     def test_fields(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='title,date,feed_image')

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -1,15 +1,16 @@
-import json
+from __future__ import absolute_import, unicode_literals
+
 import collections
 import datetime
+import json
 
 from django.core.urlresolvers import reverse
 from django.utils import timezone
 
 from wagtail.api.v2.tests.test_pages import TestPageDetail, TestPageListing
-from wagtail.wagtailcore.models import Page
-
 from wagtail.tests.demosite import models
 from wagtail.tests.testapp.models import StreamPage
+from wagtail.wagtailcore.models import Page
 
 from .utils import AdminAPITestCase
 

--- a/wagtail/wagtailadmin/tests/api/utils.py
+++ b/wagtail/wagtailadmin/tests/api/utils.py
@@ -1,0 +1,8 @@
+from django.test import TestCase
+
+from wagtail.tests.utils import WagtailTestUtils
+
+
+class AdminAPITestCase(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.login()

--- a/wagtail/wagtailadmin/tests/api/utils.py
+++ b/wagtail/wagtailadmin/tests/api/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.test import TestCase
 
 from wagtail.tests.utils import WagtailTestUtils

--- a/wagtail/wagtailadmin/urls/__init__.py
+++ b/wagtail/wagtailadmin/urls/__init__.py
@@ -5,6 +5,7 @@ from wagtail.wagtailadmin.urls import pages as wagtailadmin_pages_urls
 from wagtail.wagtailadmin.urls import collections as wagtailadmin_collections_urls
 from wagtail.wagtailadmin.urls import password_reset as wagtailadmin_password_reset_urls
 from wagtail.wagtailadmin.views import account, chooser, home, pages, tags, userbar
+from wagtail.wagtailadmin.api import admin_api_v1
 from wagtail.wagtailcore import hooks
 from wagtail.utils.urlpatterns import decorate_urlpatterns
 from wagtail.wagtailadmin.decorators import require_admin_access
@@ -12,6 +13,8 @@ from wagtail.wagtailadmin.decorators import require_admin_access
 
 urlpatterns = [
     url(r'^$', home.home, name='wagtailadmin_home'),
+
+    url(r'api/v1beta/', include(admin_api_v1.urls)),
 
     url(r'^failwhale/$', home.error_test, name='wagtailadmin_error_test'),
 

--- a/wagtail/wagtailadmin/urls/__init__.py
+++ b/wagtail/wagtailadmin/urls/__init__.py
@@ -5,7 +5,7 @@ from wagtail.wagtailadmin.urls import pages as wagtailadmin_pages_urls
 from wagtail.wagtailadmin.urls import collections as wagtailadmin_collections_urls
 from wagtail.wagtailadmin.urls import password_reset as wagtailadmin_password_reset_urls
 from wagtail.wagtailadmin.views import account, chooser, home, pages, tags, userbar
-from wagtail.wagtailadmin.api import admin_api_v1
+from wagtail.wagtailadmin.api import urls as api_urls
 from wagtail.wagtailcore import hooks
 from wagtail.utils.urlpatterns import decorate_urlpatterns
 from wagtail.wagtailadmin.decorators import require_admin_access
@@ -14,7 +14,7 @@ from wagtail.wagtailadmin.decorators import require_admin_access
 urlpatterns = [
     url(r'^$', home.home, name='wagtailadmin_home'),
 
-    url(r'api/v1beta/', include(admin_api_v1.urls)),
+    url(r'api/', include(api_urls)),
 
     url(r'^failwhale/$', home.error_test, name='wagtailadmin_error_test'),
 


### PR DESCRIPTION
Note: These commits were already on the torchbox/admin-api branch. I'm just using a pull request to squash them in a way that we can refer back to the original commits.

This pull request implements the admin API in wagtail admin, based on the v2 API with the following changes:

 - All pages from all sites visible in the same API (except for the root page)
 - All draft pages are visible
 - ``status`` meta field added to indicate the state of each page
 - ``children`` field added giving a count of the number of children and a link to the listing view for them
 - ``child_of`` and ``descendant_of`` can be used on any page, including root (by passing it a special value: ``root``)
 - Append ``__types`` to each response, giving information about all the types used in the response
 - Added ``latest_revision_created_at`` field to ``meta
 - Added ``has_children`` filter
 - Added ``parent`` field to listings