### PR TITLE
Make wagtailuserbar tag gracefully handle the absence of a 'request' variable

### DIFF
--- a/wagtail/wagtailadmin/templatetags/wagtailuserbar.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailuserbar.py
@@ -31,8 +31,10 @@ def get_page_instance(context):
 @register.simple_tag(takes_context=True)
 def wagtailuserbar(context, position='bottom-right'):
     # Find request object
-    request = context['request']
-
+    try:
+        request = context['request']
+    except KeyError:
+        return ''
 
     # Don't render if user doesn't have permission to access the admin area
     if not request.user.has_perm('wagtailadmin.access_admin'):

--- a/wagtail/wagtailadmin/tests/test_userbar.py
+++ b/wagtail/wagtailadmin/tests/test_userbar.py
@@ -36,6 +36,13 @@ class TestUserbarTag(TestCase):
 
         self.assertIn("<!-- Wagtail user bar embed code -->", content)
 
+    def test_userbar_does_not_break_without_request(self):
+        template = Template("{% load wagtailuserbar %}{% wagtailuserbar %}boom")
+        content = template.render(Context({
+        }))
+
+        self.assertEqual("boom", content)
+
     def test_userbar_tag_self(self):
         """
         Ensure the userbar renders with `self` instead of `PAGE_TEMPLATE_VAR`


### PR DESCRIPTION
Fixes #2486