### PR TITLE
Don't import dev in project template settings init

### DIFF
--- a/wagtail/project_template/manage.py
+++ b/wagtail/project_template/manage.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings.dev")
 
     from django.core.management import execute_from_command_line
 

--- a/wagtail/project_template/project_name/settings/__init__.py
+++ b/wagtail/project_template/project_name/settings/__init__.py
@@ -1,1 +1,0 @@
-from .dev import *

--- a/wagtail/project_template/project_name/wsgi.py
+++ b/wagtail/project_template/project_name/wsgi.py
@@ -13,6 +13,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings.dev")
 
 application = get_wsgi_application()


### PR DESCRIPTION
This might be as much of a discussion as a PR, but heck, here goes. :)

Developer settings were always imported whenever any portion of the
project template settings package itself was imported. Using production
settings would result in `__init__.py` importing the dev settings first,
*then* overriding those with the production settings.

This lead to somewhat counter-intuitive behaviour - dev settings that
weren't explicitly set again in production would tag along to prod.

My specific use case was appending `debug_toolbar` to `INSTALLED_APPS`
in development, which I don't install at all in production - which had me confused for a while.
With both dev and production explicitly loading base settings, I felt like the *intent* to work
like this was being communicated - but it's all just my opinion, of course. :)

My proposal is to have the settings package no longer import
dev, and use `settings.dev` explicitly in both `manage.py` and `wsgi.py`.