### PR TITLE
Set default values if not present

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -558,6 +558,10 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
             )
 
         from wagtail.wagtailadmin.forms import WagtailAdminPageForm
+
+        if not hasattr(cls, 'base_form_class'):
+            cls.base_form_class = WagtailAdminPageForm
+
         if not issubclass(cls.base_form_class, WagtailAdminPageForm):
             errors.append(checks.Error(
                 "{}.base_form_class does not extend WagtailAdminPageForm".format(
@@ -567,6 +571,10 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
                     cls.base_form_class.__name__),
                 obj=cls,
                 id='wagtailcore.E002'))
+
+        if not hasattr(cls, 'get_edit_handler'):
+            from wagtail.wagtailadmin.edit_handlers import get_edit_handler
+            cls.get_edit_handler = get_edit_handler
 
         edit_handler = cls.get_edit_handler()
         if not issubclass(edit_handler.get_form_class(cls), WagtailAdminPageForm):

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -1169,3 +1169,19 @@ class TestIssue2024(TestCase):
 
         # Check that the content_type changed to Page
         self.assertEqual(event_index.content_type, ContentType.objects.get_for_model(Page))
+
+
+class TestPageModelCheck(TestCase):
+    def setUp(self):
+        self.base_form_class = Page.base_form_class
+        self.get_edit_handler = Page.get_edit_handler
+
+    def tearDown(self):
+        Page.base_form_class = self.base_form_class
+        Page.get_edit_handler = self.get_edit_handler
+
+    def test_set_default_value_if_not_present(self):
+        del Page.base_form_class
+        del Page.get_edit_handler
+
+        self.assertEqual(Page.check(), [])


### PR DESCRIPTION
If `base_form_class` and `get_edit_handler` are not present during the `Page`'s `check`, both will be set to a default value.

Before this, the `Page`'s model was dependent of an import side effect evoked by the `wagtailforms` app.