### PR TITLE
allow wagtailforms field choices to be as long as they want

### DIFF
--- a/wagtail/tests/testapp/migrations/0004_form_choices.py
+++ b/wagtail/tests/testapp/migrations/0004_form_choices.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tests', '0003_onetoonepage'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='formfield',
+            name='choices',
+            field=models.TextField(verbose_name='choices', help_text='Comma separated list of choices. Only applicable in checkboxes, radio and dropdown.', blank=True),
+        ),
+    ]

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -68,9 +68,8 @@ class AbstractFormField(Orderable):
     )
     field_type = models.CharField(verbose_name=_('field type'), max_length=16, choices=FORM_FIELD_CHOICES)
     required = models.BooleanField(verbose_name=_('required'), default=True)
-    choices = models.CharField(
+    choices = models.TextField(
         verbose_name=_('choices'),
-        max_length=512,
         blank=True,
         help_text=_('Comma separated list of choices. Only applicable in checkboxes, radio and dropdown.')
     )


### PR DESCRIPTION
as discussed, it would be nice to allow choices that are as long as whatever to wagtail, especially if we use the choices for complicated things (like selecting between different courses when signing up for a class)