### PR TITLE
including a search query to boost the exact match (if present) for elasticsearch

### DIFF
--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -243,31 +243,53 @@ class ElasticSearchQuery(BaseSearchQuery):
             fields = self.fields or ['_all', '_partials']
 
             if len(fields) == 1:
-                if self.operator == 'or':
-                    query = {
-                        'match': {
-                            fields[0]: self.query_string,
-                        }
+                query = {
+                    "bool": {
+                        "should": [
+                            {
+                                'match': {
+                                    fields[0]: {
+                                        'query': self.query_string,
+                                        'operator': self.operator,
+                                    }
+                                }
+                            },
+                            {
+                                'match_phrase': {
+                                    fields[0]: {
+                                        'query': self.query_string,
+                                        'operator': self.operator,
+                                        'boost': 1.5,
+                                    }
+                                }
+                            },
+                        ]
                     }
-                else:
-                    query = {
-                        'match': {
-                            fields[0]: {
-                                'query': self.query_string,
-                                'operator': self.operator,
-                            }
-                        }
-                    }
+                }
             else:
                 query = {
-                    'multi_match': {
-                        'query': self.query_string,
-                        'fields': fields,
+                    "bool": {
+                        "should": [
+                            {
+                                'multi_match': {
+                                    'query': self.query_string,
+                                    'fields': fields,
+                                }
+                            },
+                            {
+                                "multi_match": {
+                                    'query': self.query_string,
+                                    'type': 'phrase',
+                                    "fields": fields,
+                                    "boost": 1.5,
+                                }
+                            }
+                        ],
                     }
                 }
 
                 if self.operator != 'or':
-                    query['multi_match']['operator'] = self.operator
+                    query['bool']['should'][0]['multi_match']['operator'] = self.operator
         else:
             query = {
                 'match_all': {}


### PR DESCRIPTION
In regular elasticsearch queries, an occurrence of a perfect match (for a multi-term search query) is not assigned a higher relevance than any other match.

In this PR I changed the query for the elasticsearch backend so that exact matches are boosted by 1.5, thus appearing higher than regular results.

This helps in places where eg. people pages are indexed and searching for the full name brings up *less* interesting results than searching for the last name only. You can see this on http://www.rca.ac.uk/
when searching for "Teasley" vs. "Sarah Teasley".