### PR TITLE
Remove useless get_indexed_objects method from TagSearchable

### DIFF
--- a/wagtail/wagtailadmin/taggable.py
+++ b/wagtail/wagtailadmin/taggable.py
@@ -22,10 +22,6 @@ class TagSearchable(index.Indexed):
     ], name='search_fields on TagSearchable subclasses')
 
     @classmethod
-    def get_indexed_objects(cls):
-        return super(TagSearchable, cls).get_indexed_objects().prefetch_related('tagged_items__tag')
-
-    @classmethod
     def popular_tags(cls):
         content_type = ContentType.objects.get_for_model(cls)
         return Tag.objects.filter(

--- a/wagtail/wagtailimages/tests/test_models.py
+++ b/wagtail/wagtailimages/tests/test_models.py
@@ -132,6 +132,21 @@ class TestImageQuerySet(TestCase):
         results = Image.objects.order_by('-title').search("Test")
         self.assertEqual(list(results), [zzz_image, aaa_image])
 
+    def test_search_indexing_prefetches_tags(self):
+        for i in range(0, 10):
+            image = Image.objects.create(
+                title="Test image %d" % i,
+                file=get_test_image_file(),
+            )
+            image.tags.add('aardvark', 'artichoke', 'armadillo')
+
+        with self.assertNumQueries(2):
+            results = {
+                image.title: [tag.name for tag in image.tags.all()]
+                for image in Image.get_indexed_objects()
+            }
+            self.assertTrue('aardvark' in results['Test image 0'])
+
 
 class TestImagePermissions(TestCase):
     def setUp(self):


### PR DESCRIPTION
Related: #2436

Indexing the tags of TagSearchable subclasses (such as wagtailimages.Image) is done by following
the model's 'tags' relation, and wagtailsearch is smart enough to prefetch that automatically
(as the test demonstrates). Prefetching 'tagged_items__tag' just adds two useless queries :-)