### PR TITLE
Updated Page.dummy_request() to be able to handle ALLOWED_HOSTS = ['*'].

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1186,6 +1186,10 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
             # whatever we find in ALLOWED_HOSTS
             try:
                 hostname = settings.ALLOWED_HOSTS[0]
+                if hostname == '*':
+                    # '*' is a valid value to find in ALLOWED_HOSTS[0], but it's not a valid domain name.
+                    # So we pretend it isn't there.
+                    raise IndexError
             except IndexError:
                 hostname = 'localhost'
             path = '/'


### PR DESCRIPTION
Previously, Page.dummy_request() assumed that if `ALLOWED_HOSTS[0]` exists, it's a valid hostname. But since `ALLOWED_HOSTS[0]` can be `'*'`, that led to `400 Bad Request` errors under some circumstances. This PR simply makes Page.dummy_request() treat `'*'` as an invalid hostname.