### PR TITLE
Check before unregistering Group model admin

### DIFF
--- a/wagtail/wagtailcore/admin.py
+++ b/wagtail/wagtailcore/admin.py
@@ -21,5 +21,6 @@ class GroupPagePermissionInline(admin.TabularInline):
 class GroupAdminWithPagePermissions(GroupAdmin):
     inlines = GroupAdmin.inlines + [GroupPagePermissionInline]
 
-admin.site.unregister(Group)
+if admin.site.is_registered(Group):
+    admin.site.unregister(Group)
 admin.site.register(Group, GroupAdminWithPagePermissions)


### PR DESCRIPTION
Fixes exception:
    django.contrib.admin.sites.NotRegistered: The model Group is not registered