### PR TITLE
Make sure the default search backend is always defined

### DIFF
--- a/wagtail/wagtailsearch/backends/__init__.py
+++ b/wagtail/wagtailsearch/backends/__init__.py
@@ -15,6 +15,17 @@ class InvalidSearchBackendError(ImproperlyConfigured):
     pass
 
 
+def get_search_backend_config():
+    search_backends = getattr(settings, 'WAGTAILSEARCH_BACKENDS', {})
+
+    # Make sure the default backend is always defined
+    search_backends.setdefault('default', {
+        'BACKEND': 'wagtail.wagtailsearch.backends.db',
+    })
+
+    return search_backends
+
+
 def import_backend(dotted_path):
     """
     Theres two formats for the dotted_path.
@@ -39,19 +50,12 @@ def import_backend(dotted_path):
 
 
 def get_search_backend(backend='default', **kwargs):
-    # Get configuration
-    default_conf = {
-        'default': {
-            'BACKEND': 'wagtail.wagtailsearch.backends.db',
-        },
-    }
-    WAGTAILSEARCH_BACKENDS = getattr(
-        settings, 'WAGTAILSEARCH_BACKENDS', default_conf)
+    search_backends = get_search_backend_config()
 
     # Try to find the backend
     try:
         # Try to get the WAGTAILSEARCH_BACKENDS entry for the given backend name first
-        conf = WAGTAILSEARCH_BACKENDS[backend]
+        conf = search_backends[backend]
     except KeyError:
         try:
             # Trying to import the given backend, in case it's a dotted path
@@ -78,11 +82,10 @@ def get_search_backend(backend='default', **kwargs):
 
 
 def get_search_backends(with_auto_update=False):
-    if hasattr(settings, 'WAGTAILSEARCH_BACKENDS'):
-        for backend, params in settings.WAGTAILSEARCH_BACKENDS.items():
-            if with_auto_update and params.get('AUTO_UPDATE', True) is False:
-                continue
+    search_backends = get_search_backend_config()
 
-            yield get_search_backend(backend)
-    else:
-        yield get_search_backend('default')
+    for backend, params in search_backends.items():
+        if with_auto_update and params.get('AUTO_UPDATE', True) is False:
+            continue
+
+        yield get_search_backend(backend)

--- a/wagtail/wagtailsearch/tests/test_backends.py
+++ b/wagtail/wagtailsearch/tests/test_backends.py
@@ -187,6 +187,15 @@ class TestBackendLoader(TestCase):
         self.assertIsInstance(backends[0], DBSearch)
 
     @override_settings(
+        WAGTAILSEARCH_BACKENDS={}
+    )
+    def test_get_search_backends_with_no_default_defined(self):
+        backends = list(get_search_backends())
+
+        self.assertEqual(len(backends), 1)
+        self.assertIsInstance(backends[0], DBSearch)
+
+    @override_settings(
         WAGTAILSEARCH_BACKENDS={
             'default': {
                 'BACKEND': 'wagtail.wagtailsearch.backends.db'


### PR DESCRIPTION
It's common in Wagtail to want to quickly override the base search settings to disable Elasticsearch in specific environments (eg CI or running imports).

To do this, you have to manually write out Wagtail's default search configuration.

This commit changes the way the default configuration is loaded, it is now loaded whenever there is no "default" backend configured rather than only loading if the ``WAGTAILSEARCH_BACKENDS`` was not defined at all.

To override a parent settings file's search backends configuration, you can now just do:

```python
WAGTAILSEARCH_BACKENDS = {}
```

And the defaults will be restored