### PR TITLE
Fixes and improvements for #2444

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,7 +22,7 @@ Changelog
  * Added `--schema-only` option to `update_index` management command
  * Added meaningful default icons to `StreamField` blocks (Benjamin Bach)
  * Added title text to action buttons in the page explorer (Liam Brenner)
- * Improved L10N and I18N for revisions list. (Roel Bruggink)
+ * Improved L10N and I18N for revisions list (Roel Bruggink)
  * Fix: The currently selected day is now highlighted only in the correct month in date pickers (Jonas Lergell)
  * Fix: Fixed crash when an image without a source file was resized with the "dynamic serve view"
  * Fix: Registered settings admin menu items now show active correctly (Matthew Downey)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Changelog
  * Added `--schema-only` option to `update_index` management command
  * Added meaningful default icons to `StreamField` blocks (Benjamin Bach)
  * Added title text to action buttons in the page explorer (Liam Brenner)
+ * Improved L10N and I18N for revisions list. (Roel Bruggink)
  * Fix: The currently selected day is now highlighted only in the correct month in date pickers (Jonas Lergell)
  * Fix: Fixed crash when an image without a source file was resized with the "dynamic serve view"
  * Fix: Registered settings admin menu items now show active correctly (Matthew Downey)

--- a/docs/releases/1.5.rst
+++ b/docs/releases/1.5.rst
@@ -47,6 +47,7 @@ Minor features
  * Added ``--schema-only`` option to ``update_index`` management command
  * Added meaningful default icons to ``StreamField`` blocks (Benjamin Bach)
  * Added title text to action buttons in the page explorer (Liam Brenner)
+ * Improved L10N and I18N for revisions list (Roel Bruggink)
 
 Bug fixes
 ~~~~~~~~~

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -90,7 +90,7 @@
                                     <span class="avatar small icon icon-user"><img src="{% gravatar_url page.get_latest_revision.user.email 25 %}" /></span>
                                 {% endif %}
                             {% endif %}
-                            <a href="{% url 'wagtailadmin_pages:revisions_index' page.id %}" class="underlined">Revisions</a>
+                            <a href="{% url 'wagtailadmin_pages:revisions_index' page.id %}" class="underlined">{% trans 'Revisions' %}</a>
                         {% endif %}
                     </p>
                 </li>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/revisions/list.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/revisions/list.html
@@ -1,11 +1,12 @@
 {% load i18n wagtailadmin_tags gravatar %}
+{% load l10n %}
 
 <table class="listing">
     <col width="100%" />
 
     <thead>
         <tr>
-            <th><a href="{% url 'wagtailadmin_pages:revisions_index' page.id %}?ordering={% if ordering == "created_at" %}-{% endif %}created_at" class="icon icon-arrow-{% if ordering == "created_at" %}up-after{% elif ordering == "-created_at" %}down-after{% else %}down-after{% endif %} {% if ordering == "created_at" or ordering == "-created_at" %}teal{% endif %}">Revision date</a></th>
+            <th><a href="{% url 'wagtailadmin_pages:revisions_index' page.id %}?ordering={% if ordering == "created_at" %}-{% endif %}created_at" class="icon icon-arrow-{% if ordering == "created_at" %}up-after{% elif ordering == "-created_at" %}down-after{% else %}down-after{% endif %} {% if ordering == "created_at" or ordering == "-created_at" %}teal{% endif %}">{% trans 'Revision date' %}</a></th>
         </tr>
     </thead>
     <tbody>
@@ -13,7 +14,7 @@
             {% for revision in revisions %}
                 <tr {% if revision == page.get_latest_revision %}class="index"{% endif %}>
                     <td class="title">
-                        <h2><a href="{% url 'wagtailadmin_pages:revisions_revert' page.id revision.id %}">{{ revision.created_at|date:"d M Y H:i" }}</a> <span class="unbold">by<span class="avatar small icon icon-user"><img src="{% gravatar_url revision.user.email 25 %}" /></span>{{ revision.user }}</span> {% if revision == page.get_latest_revision %}({% trans 'Current draft' %}){% endif %}</h2>
+                        <h2><a href="{% url 'wagtailadmin_pages:revisions_revert' page.id revision.id %}">{{ revision.created_at }}</a> <span class="unbold">{% trans 'by' %}<span class="avatar small icon icon-user"><img src="{% gravatar_url revision.user.email 25 %}" /></span>{{ revision.user }}</span> {% if revision == page.get_latest_revision %}({% trans 'Current draft' %}){% endif %}</h2>
 
                         <ul class="actions">
                             <li><a href="{% url 'wagtailadmin_pages:revisions_view' page.id revision.id %}" class="button button-small button-secondary" target="_blank">{% trans 'Preview' %}</a></li>
@@ -27,7 +28,7 @@
                 </tr>
             {% endfor %}
         {% else %}
-            {% block no_results %}<tr><td class="no-results-message"><p>No revisions of this page exist</p></td></tr>{% endblock %}
+            {% block no_results %}<tr><td class="no-results-message"><p>{% trans 'No revisions of this page exist' %}</p></td></tr>{% endblock %}
         {% endif %}
     </tbody>
 </table>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/revisions/list.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/revisions/list.html
@@ -14,7 +14,7 @@
             {% for revision in revisions %}
                 <tr {% if revision == page.get_latest_revision %}class="index"{% endif %}>
                     <td class="title">
-                        <h2><a href="{% url 'wagtailadmin_pages:revisions_revert' page.id revision.id %}">{{ revision.created_at }}</a> <span class="unbold">{% trans 'by' %}<span class="avatar small icon icon-user"><img src="{% gravatar_url revision.user.email 25 %}" /></span>{{ revision.user }}</span> {% if revision == page.get_latest_revision %}({% trans 'Current draft' %}){% endif %}</h2>
+                        <h2><a href="{% url 'wagtailadmin_pages:revisions_revert' page.id revision.id %}">{{ revision.created_at }}</a> <span class="unbold">{% trans 'by' context 'points to a user who created a revision' %}<span class="avatar small icon icon-user"><img src="{% gravatar_url revision.user.email 25 %}" /></span>{{ revision.user }}</span> {% if revision == page.get_latest_revision %}({% trans 'Current draft' %}){% endif %}</h2>
 
                         <ul class="actions">
                             <li><a href="{% url 'wagtailadmin_pages:revisions_view' page.id revision.id %}" class="button button-small button-secondary" target="_blank">{% trans 'Preview' %}</a></li>

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -13,7 +13,8 @@ from django.core.files.base import ContentFile
 from django.core.urlresolvers import reverse
 from django.db.models.signals import post_delete, pre_delete
 from django.test import TestCase
-from django.utils import timezone
+from django.utils import formats, timezone
+from django.utils.dateparse import parse_date
 
 from wagtail.tests.testapp.models import (
     Advert, AdvertPlacement, BusinessChild, BusinessIndex, BusinessSubIndex, EventPage,
@@ -2858,7 +2859,7 @@ class TestRevisions(TestCase, WagtailTestUtils):
         )
         self.assertEqual(response.status_code, 200)
 
-        self.assertContains(response, "25 Dec 2013")
+        self.assertContains(response, formats.localize(parse_date('2013-12-25')))
         last_christmas_preview_url = reverse(
             'wagtailadmin_pages:revisions_view',
             args=(self.christmas_event.id, self.last_christmas_revision.id)
@@ -2870,7 +2871,7 @@ class TestRevisions(TestCase, WagtailTestUtils):
         self.assertContains(response, last_christmas_preview_url)
         self.assertContains(response, last_christmas_revert_url)
 
-        self.assertContains(response, "25 Dec 2014")
+        self.assertContains(response, formats.localize(local_datetime(2014, 12, 25)))
         this_christmas_preview_url = reverse(
             'wagtailadmin_pages:revisions_view',
             args=(self.christmas_event.id, self.this_christmas_revision.id)

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -983,7 +983,12 @@ def revisions_revert(request, page_id, revision_id):
 
     user_avatar = render_to_string('wagtailadmin/shared/user_avatar.html', {'user': revision.user})
 
-    messages.warning(request, mark_safe(_("You are viewing a previous revision of this page from <b>%s</b> by %s") % (revision.created_at.strftime("%d %b %Y %H:%M"), user_avatar)))
+    messages.warning(request, mark_safe(
+        _("You are viewing a previous revision of this page from <b>%(created_at)s</b> by %(user)s") % {
+            'created_at': revision.created_at.strftime("%d %b %Y %H:%M"),
+            'user': user_avatar,
+        }
+    ))
 
     return render(request, 'wagtailadmin/pages/edit.html', {
         'page': page,


### PR DESCRIPTION
Replaces #2444.

I have found some more issues with translatable strings in page revisions functionality. Fixed them in https://github.com/torchbox/wagtail/commit/660bbdfce92a9d52e30ca91c09d60ccdd6505fb1.

Also I have fixed tests for revisions in https://github.com/torchbox/wagtail/commit/edb924acf49450eac77c2e28a57ae23571115ca8. They were broken by removing date format in @jaroel's PR. But I agree with Roel that we need to use locale formats for dates / times.

@jaroel thanks for your work!