### PR TITLE
Fix $prop variable in userbar.scss not being declared as global

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/userbar.scss
@@ -298,11 +298,11 @@ $positions: (
             @for $i from 1 through $max-items {
 
                 @if $vertical == 'bottom' {
-                    $prop: 'nth-last-child';
+                    $prop: 'nth-last-child' !global;
                 }
 
                 @if $vertical == 'top' {
-                    $prop: 'nth-child';
+                    $prop: 'nth-child' !global;
                 }
 
                 &:#{unquote($prop)}(#{$i}) {


### PR DESCRIPTION
Original userbar.scss file left $prop as a local variable, causing machines with certain interpreters to not load the file properly (resulting in strange CSS styling when using Wagtail's interface). Adding !global to the ends of the lines that declare $prop fixes this.