### PR TITLE
Useless return in wagtail.wagtailforms.forms.BaseForm

### DIFF
--- a/wagtail/wagtailforms/forms.py
+++ b/wagtail/wagtailforms/forms.py
@@ -8,7 +8,7 @@ import django.forms
 class BaseForm(django.forms.Form):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('label_suffix', '')
-        return super(BaseForm, self).__init__(*args, **kwargs)
+        super(BaseForm, self).__init__(*args, **kwargs)
 
 
 class FormBuilder(object):


### PR DESCRIPTION
Looks like `wagtail.wagtailforms.forms.BaseForm` have a useless return in `__init__` method.