### PR TITLE
Fix keyboard shortcuts like Ctrl+S giving unnecessary warnings about leaving the page

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -53,7 +53,7 @@ function initTagField(id, autocompleteUrl) {
  *      prompting the user even when nothing has been changed.
 */
 
-var enableDirtyFormCheck = 1;
+var enableDirtyFormCheck = true;
 
 function enableDirtyFormCheck(formSelector, options) {
     var $form = $(formSelector);

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -53,7 +53,7 @@ function initTagField(id, autocompleteUrl) {
  *      prompting the user even when nothing has been changed.
 */
 
-var canGiveWarning = 1;
+var enableDirtyFormCheck = 1;
 
 function enableDirtyFormCheck(formSelector, options) {
     var $form = $(formSelector);
@@ -75,11 +75,11 @@ function enableDirtyFormCheck(formSelector, options) {
             }
         });
 
-        if (!canGiveWarning) {
+        if (!enableDirtyFormCheck) {
             triggeredByIgnoredButton = true;
         }
 
-        if (canGiveWarning && !triggeredByIgnoredButton && (alwaysDirty || $form.serialize() != initialData)) {
+        if (enableDirtyFormCheck && !triggeredByIgnoredButton && (alwaysDirty || $form.serialize() != initialData)) {
             event.returnValue = confirmationMessage;
             return confirmationMessage;
         }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -56,10 +56,6 @@ function initTagField(id, autocompleteUrl) {
 var canGiveWarning = 1;
 
 function enableDirtyFormCheck(formSelector, options) {
-    if (!canGiveWarning) {
-        triggeredByIgnoredButton = true;
-    }
-
     var $form = $(formSelector);
     var $ignoredButtons = $form.find(
         options.ignoredButtonsSelector || 'input[type="submit"],button[type="submit"]'
@@ -78,6 +74,10 @@ function enableDirtyFormCheck(formSelector, options) {
                 triggeredByIgnoredButton = true;
             }
         });
+
+        if (!canGiveWarning) {
+            triggeredByIgnoredButton = true;
+        }
 
         if (canGiveWarning && !triggeredByIgnoredButton && (alwaysDirty || $form.serialize() != initialData)) {
             event.returnValue = confirmationMessage;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -53,7 +53,7 @@ function initTagField(id, autocompleteUrl) {
  *      prompting the user even when nothing has been changed.
 */
 
-var enableDirtyFormCheck = true;
+var canDirtyFormCheck = true;
 
 function enableDirtyFormCheck(formSelector, options) {
     var $form = $(formSelector);
@@ -75,11 +75,11 @@ function enableDirtyFormCheck(formSelector, options) {
             }
         });
 
-        if (!enableDirtyFormCheck) {
+        if (!canDirtyFormCheck) {
             triggeredByIgnoredButton = true;
         }
 
-        if (enableDirtyFormCheck && !triggeredByIgnoredButton && (alwaysDirty || $form.serialize() != initialData)) {
+        if (canDirtyFormCheck && !triggeredByIgnoredButton && (alwaysDirty || $form.serialize() != initialData)) {
             event.returnValue = confirmationMessage;
             return confirmationMessage;
         }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -52,7 +52,14 @@ function initTagField(id, autocompleteUrl) {
  *    - alwaysDirty - When set to true the form will always be considered dirty,
  *      prompting the user even when nothing has been changed.
 */
+
+var canGiveWarning = 1;
+
 function enableDirtyFormCheck(formSelector, options) {
+    if (!canGiveWarning) {
+        triggeredByIgnoredButton = true;
+    }
+
     var $form = $(formSelector);
     var $ignoredButtons = $form.find(
         options.ignoredButtonsSelector || 'input[type="submit"],button[type="submit"]'
@@ -72,7 +79,7 @@ function enableDirtyFormCheck(formSelector, options) {
             }
         });
 
-        if (!triggeredByIgnoredButton && (alwaysDirty || $form.serialize() != initialData)) {
+        if (canGiveWarning && !triggeredByIgnoredButton && (alwaysDirty || $form.serialize() != initialData)) {
             event.returnValue = confirmationMessage;
             return confirmationMessage;
         }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -388,11 +388,13 @@ function initCollapsibleBlocks() {
 
 function initKeyboardShortcuts() {
     Mousetrap.bind(['mod+p'], function(e) {
+        canGiveWarning = 0;
         $('.action-preview').trigger('click');
         return false;
     });
 
     Mousetrap.bind(['mod+s'], function(e) {
+        canGiveWarning = 0;
         $('.action-save').trigger('click');
         return false;
     });

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -388,13 +388,13 @@ function initCollapsibleBlocks() {
 
 function initKeyboardShortcuts() {
     Mousetrap.bind(['mod+p'], function(e) {
-        enableDirtyFormCheck = 0;
+        enableDirtyFormCheck = false;
         $('.action-preview').trigger('click');
         return false;
     });
 
     Mousetrap.bind(['mod+s'], function(e) {
-        enableDirtyFormCheck = 0;
+        enableDirtyFormCheck = false;
         $('.action-save').trigger('click');
         return false;
     });

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -388,13 +388,13 @@ function initCollapsibleBlocks() {
 
 function initKeyboardShortcuts() {
     Mousetrap.bind(['mod+p'], function(e) {
-        canGiveWarning = 0;
+        enableDirtyFormCheck = 0;
         $('.action-preview').trigger('click');
         return false;
     });
 
     Mousetrap.bind(['mod+s'], function(e) {
-        canGiveWarning = 0;
+        enableDirtyFormCheck = 0;
         $('.action-save').trigger('click');
         return false;
     });

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -388,13 +388,13 @@ function initCollapsibleBlocks() {
 
 function initKeyboardShortcuts() {
     Mousetrap.bind(['mod+p'], function(e) {
-        enableDirtyFormCheck = false;
+        canDirtyFormCheck = false;
         $('.action-preview').trigger('click');
         return false;
     });
 
     Mousetrap.bind(['mod+s'], function(e) {
-        enableDirtyFormCheck = false;
+        canDirtyFormCheck = false;
         $('.action-save').trigger('click');
         return false;
     });


### PR DESCRIPTION
As described by @ptink in #2516, when saving a modified page with Ctrl+S it gives a warning confirming that you really want to leave the page. This is unnecessary as the user does not actually leave the page -- it just gets refreshed (and the edits get saved in doing this). This is easily fixed by disabling the enableDirtyFormCheck() function from running if triggered by a keyboard shortcut.