### PR TITLE
Display username in password reset email

### DIFF
--- a/wagtail/tests/testapp/fixtures/test.json
+++ b/wagtail/tests/testapp/fixtures/test.json
@@ -661,6 +661,23 @@
         "email": "admin_only_user@example.com"
     }
 },
+{
+    "pk": 5,
+    "model": "customuser.emailuser",
+    "fields": {
+        "first_name": "",
+        "last_name": "",
+        "is_active": true,
+        "is_superuser": false,
+        "is_staff": false,
+        "groups": [
+            ["Site-wide editors"]
+        ],
+        "user_permissions": [],
+        "password": "md5$seasalt$1e9bf2bf5606aa5c39852cc30f0f6f22",
+        "email": "siteeditor@example.com"
+    }
+},
 
 {
     "pk": 1,

--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/email.txt
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/email.txt
@@ -1,3 +1,7 @@
 {% load i18n wagtailadmin_tags %}{% base_url_setting as base_url %}
-{% trans "Please follow the link below to reset your password" %}
+{% trans "Please follow the link below to reset your password:" %}
 {% if base_url %}{{ base_url }}{% else %}{{ protocol }}://{{ domain }}{% endif %}{% url 'wagtailadmin_password_reset_confirm' uidb64=uid token=token %}
+
+{% if user.USERNAME_FIELD != "email" %}
+{% trans "Your username (in case you've forgotten):" %} {% username user %}
+{% endif %}

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -298,3 +298,12 @@ def page_listing_buttons(context, page, page_perms, is_parent=False):
         hook(page, page_perms, is_parent)
         for hook in button_hooks))
     return {'page': page, 'buttons': buttons}
+
+
+@register.simple_tag
+def username(user):
+    """
+    Output the username of the given user (this accounts for user models that
+    give this field a name other than 'username').
+    """
+    return getattr(user, user.USERNAME_FIELD)

--- a/wagtail/wagtailadmin/tests/test_password_reset.py
+++ b/wagtail/wagtailadmin/tests/test_password_reset.py
@@ -58,3 +58,20 @@ class TestUserPasswordReset(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn("mysite.com", mail.outbox[0].body)
+
+    def test_password_reset_email_contains_username(self):
+        self.client.post(
+            reverse('wagtailadmin_password_reset'), {'email': 'siteeditor@example.com'}
+        )
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("Your username (in case you've forgotten): siteeditor", mail.outbox[0].body)
+
+    @override_settings(AUTH_USER_MODEL='customuser.EmailUser')
+    def test_password_reset_no_username_when_email_is_username(self):
+        # When the user model is using email as the username, the password reset email
+        # should not contain "Your username (in case you've forgotten)..."
+        self.client.post(
+            reverse('wagtailadmin_password_reset'), {'email': 'siteeditor@example.com'}
+        )
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertNotIn("Your username (in case you've forgotten)", mail.outbox[0].body)


### PR DESCRIPTION
Fixes #2240

Add "Your username (in case you've forgotten):" to the bottom of the password reset email (but only if there's actually a username field that's distinct from email).