### PR TITLE
Make migrations in project_template home app + wagtailadmin reversible

### DIFF
--- a/wagtail/project_template/home/migrations/0002_create_homepage.py
+++ b/wagtail/project_template/home/migrations/0002_create_homepage.py
@@ -12,7 +12,8 @@ def create_homepage(apps, schema_editor):
     HomePage = apps.get_model('home.HomePage')
 
     # Delete the default homepage
-    Page.objects.get(id=2).delete()
+    # If migration is run multiple times, it may have already been deleted
+    Page.objects.filter(id=2).delete()
 
     # Create content type for homepage model
     homepage_content_type, __ = ContentType.objects.get_or_create(

--- a/wagtail/project_template/home/migrations/0002_create_homepage.py
+++ b/wagtail/project_template/home/migrations/0002_create_homepage.py
@@ -15,7 +15,7 @@ def create_homepage(apps, schema_editor):
     Page.objects.get(id=2).delete()
 
     # Create content type for homepage model
-    homepage_content_type, created = ContentType.objects.get_or_create(
+    homepage_content_type, __ = ContentType.objects.get_or_create(
         model='homepage', app_label='home')
 
     # Create a new homepage
@@ -34,6 +34,19 @@ def create_homepage(apps, schema_editor):
         hostname='localhost', root_page=homepage, is_default_site=True)
 
 
+def remove_homepage(apps, schema_editor):
+    # Get models
+    ContentType = apps.get_model('contenttypes.ContentType')
+    HomePage = apps.get_model('home.HomePage')
+
+    # Delete the default homepage
+    # Page and Site objects CASCADE
+    HomePage.objects.filter(slug='home', depth=2).delete()
+
+    # Delete content type for homepage model
+    ContentType.objects.filter(model='homepage', app_label='home').delete()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -41,5 +54,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(create_homepage),
+        migrations.RunPython(create_homepage, remove_homepage),
     ]

--- a/wagtail/wagtailadmin/migrations/0001_create_admin_access_permissions.py
+++ b/wagtail/wagtailadmin/migrations/0001_create_admin_access_permissions.py
@@ -46,8 +46,9 @@ def remove_admin_access_permissions(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        # Need to run wagtailcores initial data migration to make sure the groups are created
-        ('wagtailcore', '0002_initial_data'),
+        # We cannot apply and unapply this migration unless GroupCollectionPermission
+        # is created. #2529
+        ('wagtailcore', '0026_group_collection_permission'),
     ]
 
     operations = [


### PR DESCRIPTION
This is why I needed it:

1. I created a new Wagtail project and migrated
1. I decided that `home` was a bad name for the example app and did  `python manage.py migrate home zero`

This command now works by removing both example homepage and site. It makes it easier to sketch and go back to zero.

But it's of course also a little dangerous.. but I can hardly think that someone would do `python manage.py migrate home zero` without considering the various possible cascading consequences.

**BONUS**

Now that we're already doing reverse migrations, I had a stab at #2529, too.