### PR TITLE
Fix document chooser download links giving unnecessary warning

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -54,15 +54,15 @@ function initTagField(id, autocompleteUrl) {
 */
 function enableDirtyFormCheck(formSelector, options) {
     var $form = $(formSelector);
-    var $ignoredButtons = $form.find(
-        options.ignoredButtonsSelector || 'input[type="submit"],button[type="submit"]'
-    );
+    var ignoredButtonsSelector = options.ignoredButtonsSelector || 'input[type="submit"],button[type="submit"]';
+    var ignoredButtonsGlobalSelector = options.ignoredButtonsGlobalSelector || 'a.download';
     var confirmationMessage = options.confirmationMessage || ' ';
     var alwaysDirty = options.alwaysDirty || false;
     var initialData = $form.serialize();
 
     window.addEventListener('beforeunload', function(event) {
         // Ignore if the user clicked on an ignored element
+        var $ignoredButtons = $form.find(ignoredButtonsSelector);
         var triggeredByIgnoredButton = false;
         var $trigger = $(event.target.activeElement);
 
@@ -71,6 +71,10 @@ function enableDirtyFormCheck(formSelector, options) {
                 triggeredByIgnoredButton = true;
             }
         });
+
+        if ($trigger.is(ignoredButtonsGlobalSelector)) {
+           triggeredByIgnoredButton = true;
+        }
 
         if (!triggeredByIgnoredButton && (alwaysDirty || $form.serialize() != initialData)) {
             event.returnValue = confirmationMessage;

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/list.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/list.html
@@ -36,7 +36,7 @@
                         <h2><a href="{% url 'wagtaildocs:edit' doc.id %}">{{ doc.title }}</a></h2>
                     {% endif %}
                 </td>
-                <td><a href="{{ doc.url }}" class="nolink">{{ doc.filename }}</a></td>
+                <td><a href="{{ doc.url }}" class="nolink download">{{ doc.filename }}</a></td>
                 <td><div class="human-readable-date" title="{{ doc.created_at|date:"d M Y H:i" }}">{{ doc.created_at|timesince }} ago</div></td>
             </tr>
         {% endfor %}


### PR DESCRIPTION
As @m1kola said in #2513, attempting to download a page from the document chooser produces an unnecessary warning about 'leaving the page'. This is fixed by making links in the document chooser generate with a 'download' class and making the `enableDirtyFormCheck()` function check that the trigger doesn't have this class.