### PR TITLE
Add back buttons to 'delete' and 'unpublish' confirmation pages

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_delete.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_delete.html
@@ -9,7 +9,7 @@
     <head>
         <style>
             #deleteForm {
-                display: inline;
+                display: inline; /* Keeps the 'take me back' button in-line */
             }
         </style>
     </head>
@@ -32,12 +32,8 @@
             <input type="submit" value="{% trans 'Yes, delete it' %}" class="serious {% if page.live %}button-secondary{% endif %}">
         </form>
         <input type="submit" onclick="history.go(-1);" value="{% trans '&#x2936 No, take me back' %}" class="button">
-         {% if page_perms.can_unpublish %}
-            <h3>
-                {% trans 'Alternatively you can ' %}<a href="{% url 'wagtailadmin_pages:unpublish' page.id %}" class="serious button-small {% if page.live %}button-secondary{% endif %}">unpublish the page</a>{% ". This removes the page from public view and you can edit or publish it again later." %}
-            </h3>
+        {% if page_perms.can_unpublish %}
+            <h3>{% trans "Alternatively you can " %} <a class="serious button-small {% if page.live %}button-secondary{% endif %}" href="{% url 'wagtailadmin_pages:unpublish' page.id %}">unpublish the page</a>{% trans ". This removes the page from public view and you can edit or publish it again later." %}</h3>
         {% endif %}
-    </div> 
-{% endif %}
     </div>
 {% endblock %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_delete.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_delete.html
@@ -6,8 +6,16 @@
     {% trans "Delete" as del_str %}
     {% include "wagtailadmin/shared/header.html" with title=del_str subtitle=page.title icon="doc-empty-inverse" %}
 
+    <head>
+        <style>
+            #deleteForm {
+                display: inline;
+            }
+        </style>
+    </head>
+
     <div class="nice-padding">
-        <p>
+        <h3>
             {% trans 'Are you sure you want to delete this page?' %}
             {% if descendant_count %}
                 {% blocktrans count counter=descendant_count %}
@@ -16,15 +24,20 @@
                     This will also delete {{ descendant_count }} more subpages.
                 {% endblocktrans %}
             {% endif %}
-        </p>
+        </h3>
         {% page_permissions page as page_perms %}
-        {% if page_perms.can_unpublish %}
-            <p>{% trans "Alternatively you can unpublish the page. This removes the page from public view and you can edit or publish it again later." %}</p>
-        {% endif %}
-        <form action="{% url 'wagtailadmin_pages:delete' page.id %}" method="POST">
+        <form id="deleteForm" action="{% url 'wagtailadmin_pages:delete' page.id %}" method="POST">
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ next }}">
-            <input type="submit" value="{% trans 'Delete it' %}" class="serious {% if page.live %}button-secondary{% endif %}"> {% if page_perms.can_unpublish %}<a href="{% url 'wagtailadmin_pages:unpublish' page.id %}" class="button">{% trans 'Unpublish it' %}</a>{% endif %}
+            <input type="submit" value="{% trans 'Yes, delete it' %}" class="serious {% if page.live %}button-secondary{% endif %}">
         </form>
+        <input type="submit" onclick="history.go(-1);" value="{% trans '&#x2936 No, take me back' %}" class="button">
+         {% if page_perms.can_unpublish %}
+            <h3>
+                {% trans 'Alternatively you can ' %}<a href="{% url 'wagtailadmin_pages:unpublish' page.id %}" class="serious button-small {% if page.live %}button-secondary{% endif %}">unpublish the page</a>{% ". This removes the page from public view and you can edit or publish it again later." %}
+            </h3>
+        {% endif %}
+    </div> 
+{% endif %}
     </div>
 {% endblock %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_unpublish.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_unpublish.html
@@ -5,12 +5,21 @@
     {% trans "Unpublish" as unpublish_str %}
     {% include "wagtailadmin/shared/header.html" with title=unpublish_str subtitle=page.title icon="doc-empty-inverse" %}
 
+    <head>
+        <style>
+            #deleteForm {
+                display: inline;
+            }
+        </style>
+    </head>
+
     <div class="nice-padding">
         <p>{% trans "Are you sure you want to unpublish this page?" %}</p>
         <form action="{% url 'wagtailadmin_pages:unpublish' page.id %}" method="POST">
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ next }}">
-            <input type="submit" value="{% trans 'Yes, unpublish it' %}">
+            <input type="submit" value="{% trans 'Yes, unpublish it' %}" class="serious {% if page.live %}button-secondary{% endif %}">
         </form>
+        <input type="submit" onclick="history.go(-1);" value="{% trans '&#x2936 No, take me back' %}" class="button">
     </div>
 {% endblock %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_unpublish.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_unpublish.html
@@ -8,17 +8,18 @@
     <head>
         <style>
             #deleteForm {
-                display: inline;
+                display: inline; /* Keeps the 'take me back' button in-line */
             }
         </style>
     </head>
 
     <div class="nice-padding">
-        <p>{% trans "Are you sure you want to unpublish this page?" %}</p>
-        <form action="{% url 'wagtailadmin_pages:unpublish' page.id %}" method="POST">
+        <h3>{% trans "Are you sure you want to unpublish this page?" %}</h3>
+	
+        <form id="deleteForm" action="{% url 'wagtailadmin_pages:unpublish' page.id %}" method="POST">
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ next }}">
-            <input type="submit" value="{% trans 'Yes, unpublish it' %}" class="serious {% if page.live %}button-secondary{% endif %}">
+            <input type="submit" class="serious {% if page.live %}button-secondary{% endif %}" value="{% trans 'Yes, unpublish it' %}">
         </form>
         <input type="submit" onclick="history.go(-1);" value="{% trans '&#x2936 No, take me back' %}" class="button">
     </div>


### PR DESCRIPTION
As suggested in #2213.

Currently, there are no back buttons for either of these pages.  Fortunately, it wasn't too hard to add a button which redirects to the previous page. I also made the "Are you sure?" text larger and changed the link for the unpublish button (as @heymonkeyriot suggested).