### PR TITLE
Refactor: remove Filter as a Django model.

### DIFF
--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -74,8 +74,7 @@ class ThumbnailMixin(object):
             'class': self.thumb_classname,
         }
         if image:
-            fltr, _ = Filter.objects.get_or_create(
-                spec=self.thumb_image_filter_spec)
+            fltr = Filter(spec=self.thumb_image_filter_spec)
             img_attrs.update({'src': image.get_rendition(fltr).url})
             return mark_safe('<img{}>'.format(flatatt(img_attrs)))
         elif self.thumb_default:

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -872,7 +872,7 @@ class InspectView(InstanceSpecificView):
         """ Render an image """
         image = getattr(self.instance, field_name)
         if image:
-            fltr, _ = Filter.objects.get_or_create(spec='max-400x400')
+            fltr = Filter(spec='max-400x400')
             rendition = image.get_rendition(fltr)
             return rendition.img_tag
         return self.model_admin.get_empty_value_display(field_name)

--- a/wagtail/wagtailimages/migrations/0014_remove_filter_model.py
+++ b/wagtail/wagtailimages/migrations/0014_remove_filter_model.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def forwards_data_migration(apps, schema_editor):
+    Rendition = apps.get_model('wagtailimages', 'Rendition')
+    db_alias = schema_editor.connection.alias
+    # update doesn't work during migration, we have to do it one by one
+    for rendition in Rendition.objects.using(db_alias).select_related('filter').all():
+        rendition.filter2 = rendition.filter.spec
+        rendition.save()
+
+
+def reverse_data_migration(apps, schema_editor):
+    Rendition = apps.get_model('wagtailimages', 'Rendition')
+    Filter = apps.get_model('wagtailimages', 'Filter')
+    db_alias = schema_editor.connection.alias
+    renditions = Rendition.objects.using(db_alias).all()
+    for rendition in renditions:
+        # Ensure we don't create the same Filter twice
+        rendition.filter, _ = Filter.objects.get_or_create(spec=rendition.filter2)
+        rendition.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailimages', '0013_make_rendition_upload_callable'),
+    ]
+
+    operations = [
+        # We create a new attribute to allow the data migration (filter -> filter2).
+        migrations.AddField(
+            model_name='Rendition',
+            name='filter2',
+            field=models.CharField(max_length=255, default=''),
+            preserve_default=False,
+        ),
+        # Allow NULL for backward operation to work (no temporary default value possible as the `spec` attribute is not null but also unique).
+        migrations.AlterField('rendition', 'filter', models.ForeignKey(on_delete=models.CASCADE, related_name='+', to='wagtailimages.Filter', null=True)),
+        # Remove unique constraint to allow the removal of `filter` field.
+        migrations.AlterUniqueTogether('rendition', set([])),
+        # Migrate data.
+        migrations.RunPython(forwards_data_migration, reverse_data_migration),
+        # We can now delete Filter for good.
+        migrations.RemoveField(model_name='Rendition', name='filter'),
+        migrations.DeleteModel('Filter'),
+        # And we can finally set the new attribute as `filter`.
+        migrations.RenameField(model_name='Rendition', old_name='filter2', new_name='filter'),
+        # Bug with mysql and postgresql, we need to add the index after the renaming (https://code.djangoproject.com/ticket/25530).
+        migrations.AlterField('rendition', 'filter', models.CharField(max_length=255, db_index=True)),
+        # We can now set back the unique constraint.
+        migrations.AlterUniqueTogether('rendition', set([('image', 'filter', 'focal_point_key')])),
+    ]

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -251,14 +251,14 @@ class AbstractImage(CollectionMember, TagSearchable):
 
     def get_rendition(self, filter):
         if isinstance(filter, string_types):
-            filter, created = Filter.objects.get_or_create(spec=filter)
+            filter = Filter(spec=filter)
 
         cache_key = filter.get_cache_key(self)
         Rendition = self.get_rendition_model()
 
         try:
             rendition = self.renditions.get(
-                filter=filter,
+                filter=filter.spec,
                 focal_point_key=cache_key,
             )
         except Rendition.DoesNotExist:
@@ -285,7 +285,7 @@ class AbstractImage(CollectionMember, TagSearchable):
             output_filename = output_filename_without_extension + '.' + output_extension
 
             rendition, created = self.renditions.get_or_create(
-                filter=filter,
+                filter=filter.spec,
                 focal_point_key=cache_key,
                 defaults={'file': File(generated_image.f, name=output_filename)}
             )
@@ -367,15 +367,16 @@ def get_image_model():
     return image_model
 
 
-class Filter(models.Model):
+class Filter(object):
     """
     Represents one or more operations that can be applied to an Image to produce a rendition
     appropriate for final display on the website. Usually this would be a resize operation,
     but could potentially involve colour processing, etc.
     """
 
-    # The spec pattern is operation1-var1-var2|operation2-var1
-    spec = models.CharField(max_length=255, unique=True)
+    def __init__(self, spec):
+        # The spec pattern is operation1-var1-var2|operation2-var1
+        self.spec = spec
 
     @cached_property
     def operations(self):
@@ -455,7 +456,7 @@ class Filter(models.Model):
 
 
 class AbstractRendition(models.Model):
-    filter = models.ForeignKey(Filter, related_name='+')
+    filter = models.CharField(max_length=255, db_index=True)
     file = models.ImageField(upload_to=get_rendition_upload_to, width_field='width', height_field='height')
     width = models.IntegerField(editable=False)
     height = models.IntegerField(editable=False)

--- a/wagtail/wagtailimages/templatetags/wagtailimages_tags.py
+++ b/wagtail/wagtailimages/templatetags/wagtailimages_tags.py
@@ -74,8 +74,7 @@ class ImageNode(template.Node):
 
     @cached_property
     def filter(self):
-        _filter, _ = Filter.objects.get_or_create(spec=self.filter_spec)
-        return _filter
+        return Filter(spec=self.filter_spec)
 
     def render(self, context):
         try:


### PR DESCRIPTION
As seen with @gasman in the mailing list and in #2090 , Filter should no longer be a model. I have a few questions though.

I'm not sure if Filter should stay in the `models.py` file or be moved elsewhere. 

Also, I have some issue writing the migration. I tried something to keep the existing renditions but I have some issue such as:

     django.core.exceptions.FieldDoesNotExist: Rendition has no field named u'filter'

I'm not really use to writing data migration for Django so I'm not quite sure what's wrong with it. Any help would be appreciated, thanks :smile: .