### PR TITLE
Fix chosen image disappearing, upload button not working and 'This field is required.' message

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -48,29 +48,35 @@ function initTagField(id, autocompleteUrl) {
  *    - ignoredButtonsSelector - A CSS selector to find buttons to ignore within
  *      the form. If the navigation was triggered by one of these buttons, The
  *      check will be ignored. defaults to: input[type="submit"].
+ *    - ignoredButtonsGlobalSelector - same as ignoredButtonsSelector, but will
+ *      take effect whether or not the buttons are contained within the form.
  *    - confirmationMessage - The message to display in the prompt.
  *    - alwaysDirty - When set to true the form will always be considered dirty,
  *      prompting the user even when nothing has been changed.
 */
 function enableDirtyFormCheck(formSelector, options) {
     var $form = $(formSelector);
-    var $ignoredButtons = $form.find(
-        options.ignoredButtonsSelector || 'input[type="submit"],button[type="submit"]'
-    );
+    var ignoredButtonsSelector = options.ignoredButtonsSelector || 'input[type="submit"],button[type="submit"]';
+    var ignoredButtonsGlobalSelector = options.ignoredButtonsGlobalSelector || 'a.download';
     var confirmationMessage = options.confirmationMessage || ' ';
     var alwaysDirty = options.alwaysDirty || false;
     var initialData = $form.serialize();
 
     window.addEventListener('beforeunload', function(event) {
         // Ignore if the user clicked on an ignored element
+        var $ignoredButtons = $form.find(ignoredButtonsSelector);
         var triggeredByIgnoredButton = false;
-        var $trigger = $(event.target.activeElement);
+        var $trigger = $(event.target.activeElement)
 
         $ignoredButtons.each(function() {
             if ($(this).is($trigger)) {
                 triggeredByIgnoredButton = true;
             }
         });
+
+        if ($trigger.is(ignoredButtonsGlobalSelector)) {
+            triggeredByIgnoredButton = true;
+        }
 
         if (!triggeredByIgnoredButton && (alwaysDirty || $form.serialize() != initialData)) {
             event.returnValue = confirmationMessage;
@@ -216,9 +222,16 @@ $(function() {
         var reEnableAfter = 30;
         var dataName = 'disabledtimeout'
 
+        window.cancelSpinner = function() {
+            $self.prop('disabled', '').removeData(dataName).removeClass('button-longrunning-active')
+
+            if ($self.data('clicked-text')) {
+                $replacementElem.text($self.data('original-text'));
+            }
+        }
+
         // Disabling a button prevents it submitting the form, so disabling
         // must occur on a brief timeout only after this function returns.
-
         var timeout = setTimeout(function() {
             if (!$self.data(dataName)) {
                 // Button re-enables after a timeout to prevent button becoming
@@ -226,11 +239,7 @@ $(function() {
                 $self.data(dataName, setTimeout(function() {
                     clearTimeout($self.data(dataName));
 
-                    $self.prop('disabled', '').removeData(dataName).removeClass('button-longrunning-active')
-
-                    if ($self.data('clicked-text')) {
-                        $replacementElem.text($self.data('original-text'));
-                    }
+                    cancelSpinner();
 
                 }, reEnableAfter * 1000));
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -226,6 +226,7 @@ $(function() {
 
         // Disabling a button prevents it submitting the form, so disabling
         // must occur on a brief timeout only after this function returns.
+        
         var timeout = setTimeout(function() {
             if (!$self.data(dataName)) {
                 // Button re-enables after a timeout to prevent button becoming

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -226,7 +226,7 @@ $(function() {
 
         // Disabling a button prevents it submitting the form, so disabling
         // must occur on a brief timeout only after this function returns.
-        
+
         var timeout = setTimeout(function() {
             if (!$self.data(dataName)) {
                 // Button re-enables after a timeout to prevent button becoming

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -48,35 +48,29 @@ function initTagField(id, autocompleteUrl) {
  *    - ignoredButtonsSelector - A CSS selector to find buttons to ignore within
  *      the form. If the navigation was triggered by one of these buttons, The
  *      check will be ignored. defaults to: input[type="submit"].
- *    - ignoredButtonsGlobalSelector - same as ignoredButtonsSelector, but will
- *      take effect whether or not the buttons are contained within the form.
  *    - confirmationMessage - The message to display in the prompt.
  *    - alwaysDirty - When set to true the form will always be considered dirty,
  *      prompting the user even when nothing has been changed.
 */
 function enableDirtyFormCheck(formSelector, options) {
     var $form = $(formSelector);
-    var ignoredButtonsSelector = options.ignoredButtonsSelector || 'input[type="submit"],button[type="submit"]';
-    var ignoredButtonsGlobalSelector = options.ignoredButtonsGlobalSelector || 'a.download';
+    var $ignoredButtons = $form.find(
+        options.ignoredButtonsSelector || 'input[type="submit"],button[type="submit"]'
+    );
     var confirmationMessage = options.confirmationMessage || ' ';
     var alwaysDirty = options.alwaysDirty || false;
     var initialData = $form.serialize();
 
     window.addEventListener('beforeunload', function(event) {
         // Ignore if the user clicked on an ignored element
-        var $ignoredButtons = $form.find(ignoredButtonsSelector);
         var triggeredByIgnoredButton = false;
-        var $trigger = $(event.target.activeElement)
+        var $trigger = $(event.target.activeElement);
 
         $ignoredButtons.each(function() {
             if ($(this).is($trigger)) {
                 triggeredByIgnoredButton = true;
             }
         });
-
-        if ($trigger.is(ignoredButtonsGlobalSelector)) {
-            triggeredByIgnoredButton = true;
-        }
 
         if (!triggeredByIgnoredButton && (alwaysDirty || $form.serialize() != initialData)) {
             event.returnValue = confirmationMessage;

--- a/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.js
+++ b/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.js
@@ -59,25 +59,27 @@ function(modal) {
     $('form.image-upload', modal.body).submit(function() {
         var formdata = new FormData(this);
 
-        $.ajax({
-            url: this.action,
-            data: formdata,
-            processData: false,
-            contentType: false,
-            type: 'POST',
-            dataType: 'text',
-            success: function(response){
-                modal.loadResponseText(response);
-            },
-            error: function(response, textStatus, errorThrown) {
-                {% trans "Server Error" as error_label %}
-                {% trans "Report this error to your webmaster with the following information:" as error_message %}
-                message = '{{ error_message|escapejs }}<br />' + errorThrown + ' - ' + response.status;
-                $('#upload').append(
-                    '<div class="help-block help-critical">' +
-                    '<strong>{{ error_label|escapejs }}: </strong>' + message + '</div>');
+        if ($('#id_title', modal.body).val() == '') {
+            var li = $('#id_title', modal.body).closest('li');
+            if (!li.hasClass('error')) {
+                li.addClass('error');
+                $('#id_title', modal.body).closest('.field-content').append('<p class="error-message"><span>This field is required.</span></p>')
             }
-        });
+            setTimeout("cancelSpinner()", 500);
+        } else {
+            $.ajax({
+                url: this.action,
+                data: formdata,
+                processData: false,
+                contentType: false,
+                type: 'POST',
+                dataType: 'text',
+                success: function(response){
+                    modal.loadResponseText(response);
+                }
+                
+            });
+        }
 
         return false;
     });


### PR DESCRIPTION
Working on top of @serzans' code from #2007 which fixed chosen images from disappearing if the title was left blank, however this introduced two new bugs. The first was that the 'loading' spinner broke (wouldn't know to stop spinning); I fixed this by creating a `cancelSpinner()` function, which cancels the spinner animation and returns the button to its regular clickable state. The second bug was that the 'This field is required.' message would duplicate itself if the button was clicked repeatedly, which was fixed by checking that there was no error message before displaying a new one.