### PR TITLE
Move checks for Page.base_form_class / get_form_class to wagtailadmin

### DIFF
--- a/wagtail/wagtailadmin/checks.py
+++ b/wagtail/wagtailadmin/checks.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 
-from django.core.checks import Warning, register
+from django.core.checks import Error, Warning, register
 
 
 @register()
@@ -29,4 +29,46 @@ def css_install_check(app_configs, **kwargs):
                 id='wagtailadmin.W001',
             )
         )
+    return errors
+
+
+@register()
+def base_form_class_check(app_configs, **kwargs):
+    from wagtail.wagtailadmin.forms import WagtailAdminPageForm
+    from wagtail.wagtailcore.models import get_page_models
+
+    errors = []
+
+    for cls in get_page_models():
+        if not issubclass(cls.base_form_class, WagtailAdminPageForm):
+            errors.append(Error(
+                "{}.base_form_class does not extend WagtailAdminPageForm".format(
+                    cls.__name__),
+                hint="Ensure that {}.{} extends WagtailAdminPageForm".format(
+                    cls.base_form_class.__module__,
+                    cls.base_form_class.__name__),
+                obj=cls,
+                id='wagtailadmin.E001'))
+
+    return errors
+
+
+@register()
+def get_form_class_check(app_configs, **kwargs):
+    from wagtail.wagtailadmin.forms import WagtailAdminPageForm
+    from wagtail.wagtailcore.models import get_page_models
+
+    errors = []
+
+    for cls in get_page_models():
+        edit_handler = cls.get_edit_handler()
+        if not issubclass(edit_handler.get_form_class(cls), WagtailAdminPageForm):
+            errors.append(Error(
+                "{cls}.get_edit_handler().get_form_class({cls}) does not extend WagtailAdminPageForm".format(
+                    cls=cls.__name__),
+                hint="Ensure that the EditHandler for {cls} creates a subclass of WagtailAdminPageForm".format(
+                    cls=cls.__name__),
+                obj=cls,
+                id='wagtailadmin.E002'))
+
     return errors

--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -50,7 +50,7 @@ class SearchForm(forms.Form):
         super(SearchForm, self).__init__(*args, **kwargs)
         self.fields['q'].widget.attrs = {'placeholder': placeholder}
 
-    q = forms.CharField(label=_("Search term"), widget=forms.TextInput())
+    q = forms.CharField(label=ugettext_lazy("Search term"), widget=forms.TextInput())
 
 
 class ExternalLinkChooserForm(forms.Form):

--- a/wagtail/wagtailadmin/models.py
+++ b/wagtail/wagtailadmin/models.py
@@ -1,3 +1,11 @@
 from __future__ import absolute_import, unicode_literals
 
 # Create your models here.
+
+
+# The edit_handlers module extends Page with some additional attributes required by
+# wagtailadmin (namely, base_form_class and get_edit_handler). Importing this within
+# wagtailadmin.models ensures that this happens in advance of running wagtailadmin's
+# system checks.
+
+from wagtail.wagtailadmin import edit_handlers  # NOQA

--- a/wagtail/wagtailadmin/models.py
+++ b/wagtail/wagtailadmin/models.py
@@ -1,11 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
-# Create your models here.
-
-
 # The edit_handlers module extends Page with some additional attributes required by
 # wagtailadmin (namely, base_form_class and get_edit_handler). Importing this within
 # wagtailadmin.models ensures that this happens in advance of running wagtailadmin's
 # system checks.
-
 from wagtail.wagtailadmin import edit_handlers  # NOQA

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -159,16 +159,16 @@ class TestPageEditHandlers(TestCase):
             "ValidatedPage.base_form_class does not extend WagtailAdminPageForm",
             hint="Ensure that wagtail.wagtailadmin.tests.test_edit_handlers.BadFormClass extends WagtailAdminPageForm",
             obj=ValidatedPage,
-            id='wagtailcore.E002')
+            id='wagtailadmin.E001')
 
         invalid_edit_handler = checks.Error(
             "ValidatedPage.get_edit_handler().get_form_class(ValidatedPage) does not extend WagtailAdminPageForm",
             hint="Ensure that the EditHandler for ValidatedPage creates a subclass of WagtailAdminPageForm",
             obj=ValidatedPage,
-            id='wagtailcore.E003')
+            id='wagtailadmin.E002')
 
         with mock.patch.object(ValidatedPage, 'base_form_class', new=BadFormClass):
-            errors = ValidatedPage.check()
+            errors = checks.run_checks()
             self.assertEqual(errors, [invalid_base_form, invalid_edit_handler])
 
     @clear_edit_handler(ValidatedPage)

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -169,6 +169,11 @@ class TestPageEditHandlers(TestCase):
 
         with mock.patch.object(ValidatedPage, 'base_form_class', new=BadFormClass):
             errors = checks.run_checks()
+
+            # ignore CSS loading errors (to avoid spurious failures on CI servers that
+            # don't build the CSS)
+            errors = [e for e in errors if e.id != 'wagtailadmin.W001']
+
             self.assertEqual(errors, [invalid_base_form, invalid_edit_handler])
 
     @clear_edit_handler(ValidatedPage)

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -574,27 +574,6 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
                 )
             )
 
-        from wagtail.wagtailadmin.forms import WagtailAdminPageForm
-        if not issubclass(cls.base_form_class, WagtailAdminPageForm):
-            errors.append(checks.Error(
-                "{}.base_form_class does not extend WagtailAdminPageForm".format(
-                    cls.__name__),
-                hint="Ensure that {}.{} extends WagtailAdminPageForm".format(
-                    cls.base_form_class.__module__,
-                    cls.base_form_class.__name__),
-                obj=cls,
-                id='wagtailcore.E002'))
-
-        edit_handler = cls.get_edit_handler()
-        if not issubclass(edit_handler.get_form_class(cls), WagtailAdminPageForm):
-            errors.append(checks.Error(
-                "{cls}.get_edit_handler().get_form_class({cls}) does not extend WagtailAdminPageForm".format(
-                    cls=cls.__name__),
-                hint="Ensure that the EditHandler for {cls} creates a subclass of WagtailAdminPageForm".format(
-                    cls=cls.__name__),
-                obj=cls,
-                id='wagtailcore.E003'))
-
         return errors
 
     def _update_descendant_url_paths(self, old_url_path, new_url_path):


### PR DESCRIPTION
Fixes #2428

The `Page.check` method was validating the base_form_class / get_form_class methods, which aren't really the concern of wagtailcore (and are only defined if wagtailadmin.edit_handlers has been imported). These checks have now been moved to wagtailadmin.

(Have also fixed an incorrect use of `ugettext` at the class level in wagtailadmin.forms that prevented it from being imported in wagtailadmin.checks - although in the end I've had to put the imports in the check methods anyway, due to some other weirdness with import order)