### PR TITLE
Do not get message classes from MESSAGE_TAGS

### DIFF
--- a/wagtail/tests/testapp/urls.py
+++ b/wagtail/tests/testapp/urls.py
@@ -2,8 +2,9 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import url
 
-from wagtail.tests.testapp.views import bob_only_zone
+from wagtail.tests.testapp.views import bob_only_zone, message_test
 
 urlpatterns = [
     url(r'^bob-only-zone$', bob_only_zone, name='testapp_bob_only_zone'),
+    url(r'^messages/$', message_test, name='testapp_message_test')
 ]

--- a/wagtail/tests/testapp/views.py
+++ b/wagtail/tests/testapp/views.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.http import HttpResponse
+from django.shortcuts import redirect
+from django.template.response import TemplateResponse
 
+from wagtail.wagtailadmin import messages
 from wagtail.wagtailadmin.utils import user_passes_test
 
 
@@ -12,3 +15,12 @@ def user_is_called_bob(user):
 @user_passes_test(user_is_called_bob)
 def bob_only_zone(request):
     return HttpResponse("Bobs of the world unite!")
+
+
+def message_test(request):
+    if request.method == 'POST':
+        fn = getattr(messages, request.POST['level'])
+        fn(request, request.POST['message'])
+        return redirect('testapp_message_test')
+    else:
+        return TemplateResponse(request, 'wagtailadmin/base.html')

--- a/wagtail/wagtailadmin/templates/wagtailadmin/base.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/base.html
@@ -34,7 +34,7 @@
                 {% if messages %}
                     <ul>
                         {% for message in messages %}
-                            <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message|safe }}</li>
+                            <li class="{% message_tags message %}">{{ message|safe }}</li>
                         {% endfor %}
                     </ul>
                 {% endif %}

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -6,6 +6,7 @@ import django
 from django import template
 from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import intcomma
+from django.contrib.messages.constants import DEFAULT_TAGS as MESSAGE_TAGS
 from django.template.defaultfilters import stringfilter
 from django.utils.safestring import mark_safe
 
@@ -298,3 +299,16 @@ def page_listing_buttons(context, page, page_perms, is_parent=False):
         hook(page, page_perms, is_parent)
         for hook in button_hooks))
     return {'page': page, 'buttons': buttons}
+
+
+@register.simple_tag
+def message_tags(message):
+    level_tag = MESSAGE_TAGS.get(message.level)
+    if message.extra_tags and level_tag:
+        return message.extra_tags + ' ' + level_tag
+    elif message.extra_tags:
+        return message.extra_tags
+    elif level_tag:
+        return level_tag
+    else:
+        return ''

--- a/wagtail/wagtailadmin/tests/test_messages.py
+++ b/wagtail/wagtailadmin/tests/test_messages.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.contrib import messages
+from django.core.urlresolvers import reverse
+from django.test import TestCase, override_settings
+
+
+class TestPageExplorer(TestCase):
+    @override_settings(MESSAGE_TAGS={
+        messages.DEBUG: 'my-custom-tag',
+        messages.INFO: 'my-custom-tag',
+        messages.SUCCESS: 'my-custom-tag',
+        messages.WARNING: 'my-custom-tag',
+        messages.ERROR: 'my-custom-tag',
+    })
+    def test_message_tag_classes(self):
+        url = reverse('testapp_message_test')
+
+        response = self.client.post(url, {'level': 'success', 'message': 'A message'},
+                                    follow=True)
+        # Make sure the message appears
+        self.assertContains(response, 'A message')
+        # Make sure the Wagtail-require CSS tag appears
+        self.assertContains(response, 'success')
+        # Make sure the classes set in the settings do *not* appear
+        self.assertNotContains(response, 'my-custom-tag')
+
+        response = self.client.post(url, {'level': 'error', 'message': 'Danger danger!'},
+                                    follow=True)
+        self.assertContains(response, 'Danger danger!')
+        self.assertContains(response, 'error')
+        self.assertNotContains(response, 'my-custom-tag')


### PR DESCRIPTION
If the developer had overridden MESSAGE_TAGS in their site, Wagtail messages used these classes in the admin. This caused the messages to lose their styles.

Wagtail now ignores the MESSAGE_TAGS setting, using the default classes defined in `django.contrib.messages.constants.LEVEL_TAGS`.

Fixes #2551