### PR TITLE
Make elasticsearch switchable in tox, allow ES failures in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,44 +6,53 @@ sudo: false
 
 matrix:
   include:
-   - env: TOXENV=py27-dj18-postgres
+   - env: TOXENV=py27-dj18-postgres-noelasticsearch
      python: 2.7
-   - env: TOXENV=py27-dj18-mysql
+   - env: TOXENV=py27-dj18-mysql-noelasticsearch
      python: 2.7
-   - env: TOXENV=py27-dj18-sqlite
+   - env: TOXENV=py27-dj18-sqlite-noelasticsearch
      python: 2.7
-   - env: TOXENV=py33-dj18-postgres
+   - env: TOXENV=py33-dj18-postgres-noelasticsearch
      python: 3.3
-   - env: TOXENV=py34-dj18-postgres
+   - env: TOXENV=py34-dj18-postgres-noelasticsearch
      python: 3.4
-   - env: TOXENV=py34-dj18-sqlite
+   - env: TOXENV=py34-dj18-sqlite-noelasticsearch
      python: 3.4
-   - env: TOXENV=py34-dj18-mysql
+   - env: TOXENV=py34-dj18-mysql-noelasticsearch
      python: 3.4
-   - env: TOXENV=py35-dj18-postgres
+   - env: TOXENV=py35-dj18-postgres-noelasticsearch
      python: 3.5
-   - env: TOXENV=py35-dj18-sqlite
+   - env: TOXENV=py35-dj18-sqlite-noelasticsearch
      python: 3.5
-   - env: TOXENV=py35-dj18-mysql
+   - env: TOXENV=py35-dj18-mysql-noelasticsearch
      python: 3.5
-   - env: TOXENV=py27-dj19-postgres
+   - env: TOXENV=py27-dj19-postgres-noelasticsearch
      python: 2.7
-#   - env: TOXENV=py27-dj19-mysql
-#   - env: TOXENV=py27-dj19-sqlite
-#  - env: TOXENV=py33-dj19-postgres
-   - env: TOXENV=py34-dj19-postgres
+   - env: TOXENV=py34-dj19-postgres-noelasticsearch
      python: 3.4
-   - env: TOXENV=py34-dj19-sqlite
+   - env: TOXENV=py34-dj19-sqlite-noelasticsearch
      python: 3.4
-   - env: TOXENV=py34-dj19-mysql
+   - env: TOXENV=py34-dj19-mysql-noelasticsearch
      python: 3.4
-   - env: TOXENV=py35-dj19-postgres
+   - env: TOXENV=py35-dj19-postgres-noelasticsearch
      python: 3.5
-   - env: TOXENV=py35-dj19-sqlite
+   - env: TOXENV=py35-dj19-sqlite-noelasticsearch
      python: 3.5
-   - env: TOXENV=py35-dj19-mysql
+   - env: TOXENV=py35-dj19-mysql-noelasticsearch
      python: 3.5
-
+   - env: TOXENV=py27-dj18-sqlite-elasticsearch
+     python: 2.7
+   - env: TOXENV=py27-dj19-postgres-elasticsearch
+     python: 2.7
+   - env: TOXENV=py35-dj18-postgres-elasticsearch
+     python: 3.5
+   - env: TOXENV=py35-dj19-sqlite-elasticsearch
+     python: 3.5
+  allow_failures:
+    - env: TOXENV=py27-dj18-sqlite-elasticsearch
+    - env: TOXENV=py27-dj19-postgres-elasticsearch
+    - env: TOXENV=py35-dj18-postgres-elasticsearch
+    - env: TOXENV=py35-dj19-sqlite-elasticsearch
 
 # Services
 services:

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = py{27,33,34,35}-dj{18,19}-{sqlite,postgres,mysql}, flake8
+envlist = py{27,33,34,35}-dj{18,19}-{sqlite,postgres,mysql}-{elasticsearch,noelasticsearch}, flake8
 
 [flake8]
 ignore = E501,E303
@@ -10,7 +10,9 @@ exclude = wagtail/project_template/*
 max-line-length = 120
 
 [testenv]
-commands=coverage run runtests.py --elasticsearch
+commands =
+    elasticsearch: coverage run runtests.py wagtail.wagtailsearch --elasticsearch
+    noelasticsearch: coverage run runtests.py
 
 basepython =
     py27: python2.7


### PR DESCRIPTION
The random Elasticsearch failures on Travis are causing way too much noise, and confusion for contributors. See https://github.com/torchbox/wagtail/pulls?utf8=%E2%9C%93&q=is%3Apr+travis for a sample...

This PR moves the Elasticsearch tests into their own Travis builds, flagged as "allow failures" - this way, they won't interfere with regular development, but we can still check that those tests succeed prior to shipping a new release.