### PR TITLE
Remove 'perspective' declarations from explorer CSS

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_explorer.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_explorer.scss
@@ -10,12 +10,6 @@ $explorer-z-index: 500;
     top: 0;
     left: 0;
     display: none;
-    -webkit-perspective: 1000px;
-    -moz-perspective: 1000px;
-    perspective: 1000px;
-    -webkit-perspective-origin: 50% 200%;
-    -moz-perspective-origin: 50% 200%;
-    perspective-origin: 50% 200%;
 
     ul {
         background: $color-grey-1;


### PR DESCRIPTION
Fixes #2549

I'm guessing these rules were in place to enable hardware acceleration, but removing them doesn't visibly affect the rendering. Either way, I figure that making Wagtail usable again on Firefox is more important than the performance boost...