### PR TITLE
Omitting --elasticsearch should skip ES tests regardless of ELASTICSEARCH_URL setting

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -49,6 +49,9 @@ def runtests():
 
     if args.elasticsearch:
         os.environ.setdefault('ELASTICSEARCH_URL', 'http://localhost:9200')
+    elif 'ELASTICSEARCH_URL' in os.environ:
+        # forcibly delete the ELASTICSEARCH_URL setting to skip those tests
+        del os.environ['ELASTICSEARCH_URL']
 
     argv = [sys.argv[0], 'test'] + args.rest
     try:


### PR DESCRIPTION
#2554 didn't work as intended, evidently because something in the Travis config is still setting the ELASTICSEARCH_URL environment variable. This causes ES tests to run regardless of the presence of the --elasticsearch flag.

This PR changes the behaviour so that --elasticsearch MUST be passed to ./runtests.py in order to run ES tests (which will hopefully ensure that Travis only runs them when it's supposed to).