### PR TITLE
Fixing streamfield block controls not visible

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_streamfield.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_streamfield.scss
@@ -144,7 +144,7 @@ li.sequence-member {
     position: absolute;
     top: -30px; 
     right: 0;
-    z-index: 6;
+    z-index: 1;
     overflow: visible;
     background-color: $color-input-focus;
     padding: 0 0 0 1em;
@@ -215,7 +215,6 @@ li.sequence-member {
     position: relative;
     background-color: $color-grey-1;
     opacity: 1;
-    z-index: 5;
 
     .toggle {
         @include transition(color 0.2s ease);
@@ -230,7 +229,7 @@ li.sequence-member {
         width: 1em;
         height: 1em;
         display: block;
-        z-index: 5;
+        z-index: 1;
         color: $color-grey-1;
         background-color: $color-white;
         outline: none;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_streamfield.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_streamfield.scss
@@ -144,7 +144,7 @@ li.sequence-member {
     position: absolute;
     top: -30px; 
     right: 0;
-    z-index: 1;
+    z-index: 6;
     overflow: visible;
     background-color: $color-input-focus;
     padding: 0 0 0 1em;


### PR DESCRIPTION
Fixing #2560 - changing z-index on class sequence-controls so we can see the controls on top of stream field menu