### PR TITLE
Recursive unpublish for descendant pages

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_unpublish.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_unpublish.html
@@ -10,7 +10,23 @@
         <form action="{% url 'wagtailadmin_pages:unpublish' page.id %}" method="POST">
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ next }}">
-            <input type="submit" value="{% trans 'Yes, unpublish it' %}" class="button">
+            <ul class="fields">
+                {% if live_descendant_pages %}
+                <li>
+                    <div class="field boolean_field checkbox_input">
+                        <div class="field-content">
+                            <div class="input">
+                                <input id="id_include_descendants" name="include_descendants" type="checkbox">
+                                <span>{% trans 'Unpublish all descendant pages as well.' %}</span>
+                            </div>
+                        </div>
+                    </div>
+                    </li>
+                {% endif %}
+                <li>
+                    <input type="submit" value="{% trans 'Yes, unpublish it' %}">
+                </li>
+            </ul>
         </form>
     </div>
 {% endblock %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_unpublish.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_unpublish.html
@@ -11,7 +11,7 @@
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ next }}">
             <ul class="fields">
-                {% if live_descendant_count and live_descendant_count > 0 %}
+                {% if live_descendant_count > 0 %}
                 <li>
                     <div class="field boolean_field checkbox_input">
                         <div class="field-content">

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_unpublish.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_unpublish.html
@@ -11,20 +11,24 @@
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ next }}">
             <ul class="fields">
-                {% if live_descendant_pages %}
+                {% if live_descendant_count and live_descendant_count > 0 %}
                 <li>
                     <div class="field boolean_field checkbox_input">
                         <div class="field-content">
                             <div class="input">
                                 <input id="id_include_descendants" name="include_descendants" type="checkbox">
-                                <span>{% trans 'Unpublish all descendant pages as well.' %}</span>
+                                <span>{% blocktrans count counter=live_descendant_count %}
+                    This will also unpublish one more subpage.
+                {% plural %}
+                    This will also unpublish {{ live_descendant_count }} more subpages.
+                {% endblocktrans %}</span>
                             </div>
                         </div>
                     </div>
                     </li>
                 {% endif %}
                 <li>
-                    <input type="submit" value="{% trans 'Yes, unpublish it' %}">
+                    <input type="submit" class="button" value="{% trans 'Yes, unpublish it' %}">
                 </li>
             </ul>
         </form>

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -2029,6 +2029,99 @@ class TestPageUnpublish(TestCase, WagtailTestUtils):
         self.assertEqual(mock_call['instance'], self.page)
         self.assertIsInstance(mock_call['instance'], self.page.specific_class)
 
+    def test_unpublish_descendants_view(self):
+        """
+        This tests that the unpublish view responds with an unpublish confirm page that contains the form field 'include_descendants'
+        """
+        # Get unpublish page
+        response = self.client.get(reverse('wagtailadmin_pages:unpublish', args=(self.page.id, )))
+
+        # Check that the user recieved an unpublish confirm page
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/pages/confirm_unpublish.html')
+        # Check the form does not contain the checkbox field include_descendants
+        self.assertNotContains(response, '<input id="id_include_descendants" name="include_descendants" type="checkbox">')
+
+
+class TestPageUnpublishIncludingDescendants(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.user = self.login()
+        # Find root page
+        self.root_page = Page.objects.get(id=2)
+
+        # Create a page to unpublish
+        self.test_page = self.root_page.add_child(instance=SimplePage(
+            title="Hello world!",
+            slug='hello-world',
+            content="hello",
+            live=True,
+            has_unpublished_changes=False,
+        ))
+
+        # Create a couple of child pages
+        self.test_child_page = self.test_page.add_child(instance=SimplePage(
+            title="Child page",
+            slug='child-page',
+            content="hello",
+            live=True,
+            has_unpublished_changes=True,
+        ))
+
+        self.test_another_child_page = self.test_page.add_child(instance=SimplePage(
+            title="Another Child page",
+            slug='another-child-page',
+            content="hello",
+            live=True,
+            has_unpublished_changes=True,
+        ))
+
+    def test_unpublish_descendants_view(self):
+        """
+        This tests that the unpublish view responds with an unpublish confirm page that contains the form field 'include_descendants'
+        """
+        # Get unpublish page
+        response = self.client.get(reverse('wagtailadmin_pages:unpublish', args=(self.test_page.id, )))
+
+        # Check that the user recieved an unpublish confirm page
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/pages/confirm_unpublish.html')
+        # Check the form contains the checkbox field include_descendants
+        self.assertContains(response, '<input id="id_include_descendants" name="include_descendants" type="checkbox">')
+
+    def test_unpublish_include_children_view_post(self):
+        """
+        This posts to the unpublish view and checks that the page and its descendants were unpublished
+        """
+        # Post to the unpublish page
+        response = self.client.post(reverse('wagtailadmin_pages:unpublish', args=(self.test_page.id, )), {'include_descendants': 'on'})
+
+        # Should be redirected to explorer page
+        self.assertRedirects(response, reverse('wagtailadmin_explore', args=(self.root_page.id, )))
+
+        # Check that the page was unpublished
+        self.assertFalse(SimplePage.objects.get(id=self.test_page.id).live)
+
+        # Check that the descendant pages were unpiblished as well
+        self.assertFalse(SimplePage.objects.get(id=self.test_child_page.id).live)
+        self.assertFalse(SimplePage.objects.get(id=self.test_another_child_page.id).live)
+
+    def test_unpublish_not_include_children_view_post(self):
+        """
+        This posts to the unpublish view and checks that the page was unpublished but its descendants were not
+        """
+        # Post to the unpublish page
+        response = self.client.post(reverse('wagtailadmin_pages:unpublish', args=(self.test_page.id, )), {})
+
+        # Should be redirected to explorer page
+        self.assertRedirects(response, reverse('wagtailadmin_explore', args=(self.root_page.id, )))
+
+        # Check that the page was unpublished
+        self.assertFalse(SimplePage.objects.get(id=self.test_page.id).live)
+
+        # Check that the descendant pages were not unpublished
+        self.assertTrue(SimplePage.objects.get(id=self.test_child_page.id).live)
+        self.assertTrue(SimplePage.objects.get(id=self.test_another_child_page.id).live)
+
 
 class TestApproveRejectModeration(TestCase, WagtailTestUtils):
     def setUp(self):

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -2031,7 +2031,7 @@ class TestPageUnpublish(TestCase, WagtailTestUtils):
 
     def test_unpublish_descendants_view(self):
         """
-        This tests that the unpublish view responds with an unpublish confirm page that contains the form field 'include_descendants'
+        This tests that the unpublish view responds with an unpublish confirm page that does not contain the form field 'include_descendants'
         """
         # Get unpublish page
         response = self.client.get(reverse('wagtailadmin_pages:unpublish', args=(self.page.id, )))

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -634,11 +634,12 @@ def unpublish(request, page_id):
         page.unpublish()
 
         if include_descendants == 'on':
-            live_descendant_pages = page.get_descendants().live()
+            live_descendant_pages = page.get_descendants().live().specific()
             for live_descendant_page in live_descendant_pages:
-                live_descendant_page = live_descendant_page.specific
-                if live_descendant_page.permissions_for_user(request.user).can_unpublish():
-                    live_descendant_page.unpublish()
+                if not live_descendant_page.permissions_for_user(request.user).can_unpublish():
+                    raise PermissionDenied
+            for live_descendant_page in live_descendant_pages:
+                live_descendant_page.unpublish()
 
         messages.success(request, _("Page '{0}' unpublished.").format(page.title), buttons=[
             messages.button(reverse('wagtailadmin_pages:edit', args=(page.id,)), _('Edit'))
@@ -648,11 +649,10 @@ def unpublish(request, page_id):
             return redirect(next_url)
         return redirect('wagtailadmin_explore', page.get_parent().id)
 
-    live_descendant_pages = page.get_descendants().live()
     return render(request, 'wagtailadmin/pages/confirm_unpublish.html', {
         'page': page,
         'next': next_url,
-        'live_descendant_pages': live_descendant_pages,
+        'live_descendant_count': page.get_descendants().live().count(),
     })
 
 

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -629,7 +629,16 @@ def unpublish(request, page_id):
     next_url = get_valid_next_url_from_request(request)
 
     if request.method == 'POST':
+        include_descendants = request.POST.get("include_descendants", False)
+
         page.unpublish()
+
+        if include_descendants == 'on':
+            live_descendant_pages = page.get_descendants().live()
+            for live_descendant_page in live_descendant_pages:
+                live_descendant_page = live_descendant_page.specific
+                if live_descendant_page.permissions_for_user(request.user).can_unpublish():
+                    live_descendant_page.unpublish()
 
         messages.success(request, _("Page '{0}' unpublished.").format(page.title), buttons=[
             messages.button(reverse('wagtailadmin_pages:edit', args=(page.id,)), _('Edit'))
@@ -639,9 +648,11 @@ def unpublish(request, page_id):
             return redirect(next_url)
         return redirect('wagtailadmin_explore', page.get_parent().id)
 
+    live_descendant_pages = page.get_descendants().live()
     return render(request, 'wagtailadmin/pages/confirm_unpublish.html', {
         'page': page,
         'next': next_url,
+        'live_descendant_pages': live_descendant_pages,
     })
 
 


### PR DESCRIPTION
Rebase/squash of https://github.com/torchbox/wagtail/pull/2455

Original description:

Some of our clients often demand to automatically un-publish all descendant pages of a given page when un-publishing it. I've added a checkbox to the confirmation un-publish template in order to do that. It checks for permissions and only un-publishes what the user is allowed to. Added a few tests as well