### PR TITLE
[Elasticsearch 2] Renamed search backend classes

### DIFF
--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -179,7 +179,7 @@ class BaseSearchResults(object):
         return '<SearchResults %r>' % data
 
 
-class BaseSearch(object):
+class BaseSearchBackend(object):
     query_class = None
     results_class = None
 

--- a/wagtail/wagtailsearch/backends/db.py
+++ b/wagtail/wagtailsearch/backends/db.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import, unicode_literals
 
 from django.db import models
 
-from wagtail.wagtailsearch.backends.base import BaseSearch, BaseSearchQuery, BaseSearchResults
+from wagtail.wagtailsearch.backends.base import (
+    BaseSearchBackend, BaseSearchQuery, BaseSearchResults)
 
 
 class DBSearchQuery(BaseSearchQuery):
@@ -78,12 +79,12 @@ class DBSearchResults(BaseSearchResults):
         return self.get_queryset().count()
 
 
-class DBSearch(BaseSearch):
+class DBSearchBackend(BaseSearchBackend):
     query_class = DBSearchQuery
     results_class = DBSearchResults
 
     def __init__(self, params):
-        super(DBSearch, self).__init__(params)
+        super(DBSearchBackend, self).__init__(params)
 
     def reset_index(self):
         pass  # Not needed
@@ -103,5 +104,7 @@ class DBSearch(BaseSearch):
     def delete(self, obj):
         pass  # Not needed
 
+# Backwards compatibility
+DBSearch = DBSearchBackend
 
-SearchBackend = DBSearch
+SearchBackend = DBSearchBackend

--- a/wagtail/wagtailsearch/backends/db.py
+++ b/wagtail/wagtailsearch/backends/db.py
@@ -1,12 +1,15 @@
 from __future__ import absolute_import, unicode_literals
 
+import warnings
+
 from django.db import models
 
+from wagtail.utils.deprecation import RemovedInWagtail18Warning
 from wagtail.wagtailsearch.backends.base import (
     BaseSearchBackend, BaseSearchQuery, BaseSearchResults)
 
 
-class DBSearchQuery(BaseSearchQuery):
+class DatabaseSearchQuery(BaseSearchQuery):
     DEFAULT_OPERATOR = 'and'
 
     def _process_lookup(self, field, lookup, value):
@@ -65,7 +68,7 @@ class DBSearchQuery(BaseSearchQuery):
         return q
 
 
-class DBSearchResults(BaseSearchResults):
+class DatabaseSearchResults(BaseSearchResults):
     def get_queryset(self):
         queryset = self.query.queryset
         q = self.query.get_extra_q()
@@ -79,12 +82,12 @@ class DBSearchResults(BaseSearchResults):
         return self.get_queryset().count()
 
 
-class DBSearchBackend(BaseSearchBackend):
-    query_class = DBSearchQuery
-    results_class = DBSearchResults
+class DatabaseSearchBackend(BaseSearchBackend):
+    query_class = DatabaseSearchQuery
+    results_class = DatabaseSearchResults
 
     def __init__(self, params):
-        super(DBSearchBackend, self).__init__(params)
+        super(DatabaseSearchBackend, self).__init__(params)
 
     def reset_index(self):
         pass  # Not needed
@@ -104,7 +107,17 @@ class DBSearchBackend(BaseSearchBackend):
     def delete(self, obj):
         pass  # Not needed
 
-# Backwards compatibility
-DBSearch = DBSearchBackend
 
-SearchBackend = DBSearchBackend
+
+class DBSearch(DatabaseSearchBackend):
+    def __init__(self, params):
+        warnings.warn(
+            "The wagtail.wagtailsearch.backends.db.DBSearch has "
+            "been moved to wagtail.wagtailsearch.backends.db.DatabaseSearchBackend",
+            category=RemovedInWagtail18Warning, stacklevel=2
+        )
+
+        super(DBSearch, self).__init__(params)
+
+
+SearchBackend = DatabaseSearchBackend

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -8,7 +8,8 @@ from django.utils.six.moves.urllib.parse import urlparse
 from elasticsearch import Elasticsearch, NotFoundError
 from elasticsearch.helpers import bulk
 
-from wagtail.wagtailsearch.backends.base import BaseSearch, BaseSearchQuery, BaseSearchResults
+from wagtail.wagtailsearch.backends.base import (
+    BaseSearchBackend, BaseSearchQuery, BaseSearchResults)
 from wagtail.wagtailsearch.index import FilterField, RelatedFields, SearchField, class_is_indexed
 
 
@@ -601,7 +602,7 @@ class ElasticSearchAtomicIndexRebuilder(ElasticSearchIndexRebuilder):
             self.index.put_alias(self.alias.name)
 
 
-class ElasticSearch(BaseSearch):
+class ElasticSearchBackend(BaseSearchBackend):
     index_class = ElasticSearchIndex
     query_class = ElasticSearchQuery
     results_class = ElasticSearchResults
@@ -654,7 +655,7 @@ class ElasticSearch(BaseSearch):
     }
 
     def __init__(self, params):
-        super(ElasticSearch, self).__init__(params)
+        super(ElasticSearchBackend, self).__init__(params)
 
         # Get settings
         self.hosts = params.pop('HOSTS', None)
@@ -722,5 +723,7 @@ class ElasticSearch(BaseSearch):
     def delete(self, obj):
         self.get_index().delete_item(obj)
 
+# Backwards compatibility
+ElasticSearch = ElasticSearchBackend
 
-SearchBackend = ElasticSearch
+SearchBackend = ElasticSearchBackend

--- a/wagtail/wagtailsearch/tests/test_backends.py
+++ b/wagtail/wagtailsearch/tests/test_backends.py
@@ -14,8 +14,7 @@ from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailsearch.backends import (
     InvalidSearchBackendError, get_search_backend, get_search_backends)
 from wagtail.wagtailsearch.backends.base import FieldError
-from wagtail.wagtailsearch.backends.db import DBSearch
-
+from wagtail.wagtailsearch.backends.db import DBSearchBackend
 
 
 class BackendTests(WagtailTestUtils):
@@ -181,15 +180,15 @@ class BackendTests(WagtailTestUtils):
 class TestBackendLoader(TestCase):
     def test_import_by_name(self):
         db = get_search_backend(backend='default')
-        self.assertIsInstance(db, DBSearch)
+        self.assertIsInstance(db, DBSearchBackend)
 
     def test_import_by_path(self):
         db = get_search_backend(backend='wagtail.wagtailsearch.backends.db')
-        self.assertIsInstance(db, DBSearch)
+        self.assertIsInstance(db, DBSearchBackend)
 
     def test_import_by_full_path(self):
-        db = get_search_backend(backend='wagtail.wagtailsearch.backends.db.DBSearch')
-        self.assertIsInstance(db, DBSearch)
+        db = get_search_backend(backend='wagtail.wagtailsearch.backends.db.DBSearchBackend')
+        self.assertIsInstance(db, DBSearchBackend)
 
     def test_nonexistent_backend_import(self):
         self.assertRaises(
@@ -212,7 +211,7 @@ class TestBackendLoader(TestCase):
         backends = list(get_search_backends())
 
         self.assertEqual(len(backends), 1)
-        self.assertIsInstance(backends[0], DBSearch)
+        self.assertIsInstance(backends[0], DBSearchBackend)
 
     @override_settings(
         WAGTAILSEARCH_BACKENDS={

--- a/wagtail/wagtailsearch/tests/test_backends.py
+++ b/wagtail/wagtailsearch/tests/test_backends.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import time
 import unittest
+import warnings
 
 from django.conf import settings
 from django.core import management
@@ -11,6 +12,7 @@ from django.utils.six import StringIO
 
 from wagtail.tests.search import models
 from wagtail.tests.utils import WagtailTestUtils
+from wagtail.utils.deprecation import RemovedInWagtail18Warning
 from wagtail.wagtailsearch.backends import (
     InvalidSearchBackendError, get_search_backend, get_search_backends)
 from wagtail.wagtailsearch.backends.base import FieldError
@@ -189,6 +191,23 @@ class TestBackendLoader(TestCase):
     def test_import_by_full_path(self):
         db = get_search_backend(backend='wagtail.wagtailsearch.backends.db.DatabaseSearchBackend')
         self.assertIsInstance(db, DatabaseSearchBackend)
+
+    def test_import_old_name(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+
+            db = get_search_backend(backend='wagtail.wagtailsearch.backends.db.DBSearch')
+
+        self.assertIsInstance(db, DatabaseSearchBackend)
+
+        self.assertEqual(len(w), 1)
+        self.assertIs(w[0].category, RemovedInWagtail18Warning)
+        self.assertEqual(
+            str(w[0].message),
+            "The 'wagtail.wagtailsearch.backends.db.DBSearch' search backend path has "
+            "changed to 'wagtail.wagtailsearch.backends.db'. Please update the "
+            "WAGTAILSEARCH_BACKENDS setting to use the new path."
+        )
 
     def test_nonexistent_backend_import(self):
         self.assertRaises(

--- a/wagtail/wagtailsearch/tests/test_backends.py
+++ b/wagtail/wagtailsearch/tests/test_backends.py
@@ -14,7 +14,7 @@ from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailsearch.backends import (
     InvalidSearchBackendError, get_search_backend, get_search_backends)
 from wagtail.wagtailsearch.backends.base import FieldError
-from wagtail.wagtailsearch.backends.db import DBSearchBackend
+from wagtail.wagtailsearch.backends.db import DatabaseSearchBackend
 
 
 class BackendTests(WagtailTestUtils):
@@ -180,15 +180,15 @@ class BackendTests(WagtailTestUtils):
 class TestBackendLoader(TestCase):
     def test_import_by_name(self):
         db = get_search_backend(backend='default')
-        self.assertIsInstance(db, DBSearchBackend)
+        self.assertIsInstance(db, DatabaseSearchBackend)
 
     def test_import_by_path(self):
         db = get_search_backend(backend='wagtail.wagtailsearch.backends.db')
-        self.assertIsInstance(db, DBSearchBackend)
+        self.assertIsInstance(db, DatabaseSearchBackend)
 
     def test_import_by_full_path(self):
-        db = get_search_backend(backend='wagtail.wagtailsearch.backends.db.DBSearchBackend')
-        self.assertIsInstance(db, DBSearchBackend)
+        db = get_search_backend(backend='wagtail.wagtailsearch.backends.db.DatabaseSearchBackend')
+        self.assertIsInstance(db, DatabaseSearchBackend)
 
     def test_nonexistent_backend_import(self):
         self.assertRaises(
@@ -202,7 +202,7 @@ class TestBackendLoader(TestCase):
         backends = list(get_search_backends())
 
         self.assertEqual(len(backends), 1)
-        self.assertIsInstance(backends[0], DBSearch)
+        self.assertIsInstance(backends[0], DatabaseSearchBackend)
 
     @override_settings(
         WAGTAILSEARCH_BACKENDS={}
@@ -211,7 +211,7 @@ class TestBackendLoader(TestCase):
         backends = list(get_search_backends())
 
         self.assertEqual(len(backends), 1)
-        self.assertIsInstance(backends[0], DBSearchBackend)
+        self.assertIsInstance(backends[0], DatabaseSearchBackend)
 
     @override_settings(
         WAGTAILSEARCH_BACKENDS={

--- a/wagtail/wagtailsearch/tests/test_db_backend.py
+++ b/wagtail/wagtailsearch/tests/test_db_backend.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import, unicode_literals
 
 import unittest
+import warnings
 
 from django.test import TestCase
+
+from wagtail.utils.deprecation import RemovedInWagtail18Warning
 
 from .test_backends import BackendTests
 
@@ -17,3 +20,16 @@ class TestDBBackend(BackendTests, TestCase):
     @unittest.expectedFailure
     def test_update_index_command(self):
         super(TestDBBackend, self).test_update_index_command()
+
+
+class TestOldNameDeprecationWarning(TestCase):
+    def test_old_name_deprecation(self):
+        from wagtail.wagtailsearch.backends.db import DBSearch
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+
+            DBSearch({})
+
+        self.assertEqual(len(w), 1)
+        self.assertIs(w[0].category, RemovedInWagtail18Warning)

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -6,6 +6,7 @@ import json
 import os
 import time
 import unittest
+import warnings
 
 import mock
 from django.core import management
@@ -15,13 +16,14 @@ from django.utils.six import StringIO
 from elasticsearch.serializer import JSONSerializer
 
 from wagtail.tests.search import models
+from wagtail.utils.deprecation import RemovedInWagtail18Warning
 from wagtail.wagtailsearch.backends import get_search_backend
-from wagtail.wagtailsearch.backends.elasticsearch import ElasticSearchBackend
+from wagtail.wagtailsearch.backends.elasticsearch import ElasticsearchSearchBackend
 
 from .test_backends import BackendTests
 
 
-class TestElasticSearchBackend(BackendTests, TestCase):
+class TestElasticsearchSearchBackend(BackendTests, TestCase):
     backend_path = 'wagtail.wagtailsearch.backends.elasticsearch'
 
     def test_search_with_spaces_only(self):
@@ -249,14 +251,14 @@ class TestElasticSearchBackend(BackendTests, TestCase):
         self.assertEqual(set(results), set())
 
 
-class TestElasticSearchQuery(TestCase):
+class TestElasticsearchSearchQuery(TestCase):
     def assertDictEqual(self, a, b):
         default = JSONSerializer().default
         self.assertEqual(
             json.dumps(a, sort_keys=True, default=default), json.dumps(b, sort_keys=True, default=default)
         )
 
-    query_class = ElasticSearchBackend.query_class
+    query_class = ElasticsearchSearchBackend.query_class
 
     def test_simple(self):
         # Create a query
@@ -548,7 +550,7 @@ class TestElasticSearchQuery(TestCase):
         self.assertDictEqual(query.get_sort(), expected_result)
 
 
-class TestElasticSearchResults(TestCase):
+class TestElasticsearchSearchResults(TestCase):
     def assertDictEqual(self, a, b):
         default = JSONSerializer().default
         self.assertEqual(
@@ -562,7 +564,7 @@ class TestElasticSearchResults(TestCase):
             self.objects.append(models.SearchTest.objects.create(title=str(i)))
 
     def get_results(self):
-        backend = ElasticSearchBackend({})
+        backend = ElasticsearchSearchBackend({})
         query = mock.MagicMock()
         query.queryset = models.SearchTest.objects.all()
         query.get_query.return_value = 'QUERY'
@@ -726,7 +728,7 @@ class TestElasticSearchResults(TestCase):
         self.assertEqual(results[2], self.objects[0])
 
 
-class TestElasticSearchMapping(TestCase):
+class TestElasticsearchMapping(TestCase):
     def assertDictEqual(self, a, b):
         default = JSONSerializer().default
         self.assertEqual(
@@ -735,7 +737,7 @@ class TestElasticSearchMapping(TestCase):
 
     def setUp(self):
         # Create ES mapping
-        self.es_mapping = ElasticSearchBackend.mapping_class(models.SearchTest)
+        self.es_mapping = ElasticsearchSearchBackend.mapping_class(models.SearchTest)
 
         # Create ES document
         self.obj = models.SearchTest(title="Hello")
@@ -808,7 +810,7 @@ class TestElasticSearchMapping(TestCase):
         self.assertDictEqual(document, expected_result)
 
 
-class TestElasticSearchMappingInheritance(TestCase):
+class TestElasticsearchMappingInheritance(TestCase):
     def assertDictEqual(self, a, b):
         default = JSONSerializer().default
         self.assertEqual(
@@ -817,7 +819,7 @@ class TestElasticSearchMappingInheritance(TestCase):
 
     def setUp(self):
         # Create ES mapping
-        self.es_mapping = ElasticSearchBackend.mapping_class(models.SearchTestChild)
+        self.es_mapping = ElasticsearchSearchBackend.mapping_class(models.SearchTestChild)
 
         # Create ES document
         self.obj = models.SearchTestChild(title="Hello", subtitle="World", page_id=1)
@@ -920,7 +922,7 @@ class TestElasticSearchMappingInheritance(TestCase):
 
 class TestBackendConfiguration(TestCase):
     def test_default_settings(self):
-        backend = ElasticSearchBackend(params={})
+        backend = ElasticsearchSearchBackend(params={})
 
         self.assertEqual(len(backend.hosts), 1)
         self.assertEqual(backend.hosts[0]['host'], 'localhost')
@@ -929,7 +931,7 @@ class TestBackendConfiguration(TestCase):
 
     def test_hosts(self):
         # This tests that HOSTS goes to es_hosts
-        backend = ElasticSearchBackend(params={
+        backend = ElasticsearchSearchBackend(params={
             'HOSTS': [
                 {
                     'host': '127.0.0.1',
@@ -947,7 +949,7 @@ class TestBackendConfiguration(TestCase):
 
     def test_urls(self):
         # This test backwards compatibility with old URLS setting
-        backend = ElasticSearchBackend(params={
+        backend = ElasticsearchSearchBackend(params={
             'URLS': [
                 'http://localhost:12345',
                 'https://127.0.0.1:54321',
@@ -1085,3 +1087,16 @@ class TestAtomicRebuilder(TestCase):
 
         # Index should be gone
         self.assertFalse(self.es.indices.exists(current_index_name))
+
+
+class TestOldNameDeprecationWarning(TestCase):
+    def test_old_name_deprecation(self):
+        from wagtail.wagtailsearch.backends.elasticsearch import ElasticSearch
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+
+            ElasticSearch({})
+
+        self.assertEqual(len(w), 1)
+        self.assertIs(w[0].category, RemovedInWagtail18Warning)

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -16,7 +16,7 @@ from elasticsearch.serializer import JSONSerializer
 
 from wagtail.tests.search import models
 from wagtail.wagtailsearch.backends import get_search_backend
-from wagtail.wagtailsearch.backends.elasticsearch import ElasticSearch
+from wagtail.wagtailsearch.backends.elasticsearch import ElasticSearchBackend
 
 from .test_backends import BackendTests
 
@@ -256,7 +256,7 @@ class TestElasticSearchQuery(TestCase):
             json.dumps(a, sort_keys=True, default=default), json.dumps(b, sort_keys=True, default=default)
         )
 
-    query_class = ElasticSearch.query_class
+    query_class = ElasticSearchBackend.query_class
 
     def test_simple(self):
         # Create a query
@@ -562,7 +562,7 @@ class TestElasticSearchResults(TestCase):
             self.objects.append(models.SearchTest.objects.create(title=str(i)))
 
     def get_results(self):
-        backend = ElasticSearch({})
+        backend = ElasticSearchBackend({})
         query = mock.MagicMock()
         query.queryset = models.SearchTest.objects.all()
         query.get_query.return_value = 'QUERY'
@@ -735,7 +735,7 @@ class TestElasticSearchMapping(TestCase):
 
     def setUp(self):
         # Create ES mapping
-        self.es_mapping = ElasticSearch.mapping_class(models.SearchTest)
+        self.es_mapping = ElasticSearchBackend.mapping_class(models.SearchTest)
 
         # Create ES document
         self.obj = models.SearchTest(title="Hello")
@@ -817,7 +817,7 @@ class TestElasticSearchMappingInheritance(TestCase):
 
     def setUp(self):
         # Create ES mapping
-        self.es_mapping = ElasticSearch.mapping_class(models.SearchTestChild)
+        self.es_mapping = ElasticSearchBackend.mapping_class(models.SearchTestChild)
 
         # Create ES document
         self.obj = models.SearchTestChild(title="Hello", subtitle="World", page_id=1)
@@ -920,7 +920,7 @@ class TestElasticSearchMappingInheritance(TestCase):
 
 class TestBackendConfiguration(TestCase):
     def test_default_settings(self):
-        backend = ElasticSearch(params={})
+        backend = ElasticSearchBackend(params={})
 
         self.assertEqual(len(backend.hosts), 1)
         self.assertEqual(backend.hosts[0]['host'], 'localhost')
@@ -929,7 +929,7 @@ class TestBackendConfiguration(TestCase):
 
     def test_hosts(self):
         # This tests that HOSTS goes to es_hosts
-        backend = ElasticSearch(params={
+        backend = ElasticSearchBackend(params={
             'HOSTS': [
                 {
                     'host': '127.0.0.1',
@@ -947,7 +947,7 @@ class TestBackendConfiguration(TestCase):
 
     def test_urls(self):
         # This test backwards compatibility with old URLS setting
-        backend = ElasticSearch(params={
+        backend = ElasticSearchBackend(params={
             'URLS': [
                 'http://localhost:12345',
                 'https://127.0.0.1:54321',


### PR DESCRIPTION
Suffixing them with the word ``Backend``