### PR TITLE
[Elasticsearch 2] Rewrote update_index command to support rebuilding multiple indices in the same backend

### DIFF
--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -182,9 +182,13 @@ class BaseSearchResults(object):
 class BaseSearchBackend(object):
     query_class = None
     results_class = None
+    rebuilder_class = None
 
     def __init__(self, params):
         pass
+
+    def get_index_for_model(self, model):
+        return None
 
     def get_rebuilder(self):
         return None


### PR DESCRIPTION
Elasticsearch 2 no longer allows two different content types in the same index to both use the same column name with different mappings.

For example, images, documents and pages all have a title field. But if they're put in the same index, they must have the exact same "mapping" (so none of them can have a different boost, analyzer, etc to the others or Elasticsearch will refuse to index it).

To prevent this from happening, I plan to use separate indices for different content types. So images, pages and documents will exist in three separate indices rather than one.

All page models will continue to share an index so conflicting mappings can still happen if two page models have a column with the same name, I plan to solve this in a later pull request by prefixing the field names.

This pull request makes it possible to implement a search backend with this behaviour.

We could solve this by prefixing everything and using one index, but I think it makes more sense to use a different index for different content types.