### PR TITLE
[Elasticsearch 2] Make deciding index column names the responsibility of the search backend

### DIFF
--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -168,6 +168,18 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
         super(ElasticsearchSearchQuery, self).__init__(*args, **kwargs)
         self.mapping = self.mapping_class(self.queryset.model)
 
+        # Convert field names into index column names
+        if self.fields:
+            fields = []
+            searchable_fields = {f.field_name: f for f in self.queryset.model.get_searchable_search_fields()}
+            for field_name in self.fields:
+                if field_name in searchable_fields:
+                    field_name = self.mapping.get_field_column_name(searchable_fields[field_name])
+
+                fields.append(field_name)
+
+            self.fields = fields
+
     def _process_lookup(self, field, lookup, value):
         column_name = self.mapping.get_field_column_name(field)
 

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -48,6 +48,14 @@ class ElasticsearchMapping(object):
     def get_document_type(self):
         return self.model.indexed_get_content_type()
 
+    def get_field_column_name(self, field):
+        if isinstance(field, FilterField):
+            return field.get_attname(self.model) + '_filter'
+        elif isinstance(field, SearchField):
+            return field.get_attname(self.model)
+        elif isinstance(field, RelatedFields):
+            return field.field_name
+
     def get_field_mapping(self, field):
         if isinstance(field, RelatedFields):
             mapping = {'type': 'nested', 'properties': {}}
@@ -56,7 +64,7 @@ class ElasticsearchMapping(object):
                 sub_field_name, sub_field_mapping = self.get_field_mapping(sub_field)
                 mapping['properties'][sub_field_name] = sub_field_mapping
 
-            return field.get_index_name(self.model), mapping
+            return self.get_field_column_name(field), mapping
         else:
             mapping = {'type': self.type_map.get(field.get_type(self.model), 'string')}
 
@@ -77,7 +85,7 @@ class ElasticsearchMapping(object):
                 for key, value in field.kwargs['es_extra'].items():
                     mapping[key] = value
 
-            return field.get_index_name(self.model), mapping
+            return self.get_field_column_name(field), mapping
 
     def get_mapping(self):
         # Make field list
@@ -104,10 +112,11 @@ class ElasticsearchMapping(object):
         doc = {}
         partials = []
         model = type(obj)
+        mapping = type(self)(model)
 
         for field in fields:
             value = field.get_value(obj)
-            doc[field.get_index_name(model)] = value
+            doc[mapping.get_field_column_name(field)] = value
 
             # Check if this field should be added into _partials
             if isinstance(field, SearchField) and field.partial_match:
@@ -136,7 +145,7 @@ class ElasticsearchMapping(object):
                     value, extra_partials = self._get_nested_document(field.fields, value)
                     partials.extend(extra_partials)
 
-            doc[field.get_index_name(self.model)] = value
+            doc[self.get_field_column_name(field)] = value
 
             # Check if this field should be added into _partials
             if isinstance(field, SearchField) and field.partial_match:
@@ -152,23 +161,27 @@ class ElasticsearchMapping(object):
 
 
 class ElasticsearchSearchQuery(BaseSearchQuery):
+    mapping_class = ElasticsearchMapping
     DEFAULT_OPERATOR = 'or'
 
+    def __init__(self, *args, **kwargs):
+        super(ElasticsearchSearchQuery, self).__init__(*args, **kwargs)
+        self.mapping = self.mapping_class(self.queryset.model)
+
     def _process_lookup(self, field, lookup, value):
-        # Get the name of the field in the index
-        field_index_name = field.get_index_name(self.queryset.model)
+        column_name = self.mapping.get_field_column_name(field)
 
         if lookup == 'exact':
             if value is None:
                 return {
                     'missing': {
-                        'field': field_index_name,
+                        'field': column_name,
                     }
                 }
             else:
                 return {
                     'term': {
-                        field_index_name: value,
+                        column_name: value,
                     }
                 }
 
@@ -176,14 +189,14 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
             if value:
                 return {
                     'missing': {
-                        'field': field_index_name,
+                        'field': column_name,
                     }
                 }
             else:
                 return {
                     'not': {
                         'missing': {
-                            'field': field_index_name,
+                            'field': column_name,
                         }
                     }
                 }
@@ -191,14 +204,14 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
         if lookup in ['startswith', 'prefix']:
             return {
                 'prefix': {
-                    field_index_name: value,
+                    column_name: value,
                 }
             }
 
         if lookup in ['gt', 'gte', 'lt', 'lte']:
             return {
                 'range': {
-                    field_index_name: {
+                    column_name: {
                         lookup: value,
                     }
                 }
@@ -209,7 +222,7 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
 
             return {
                 'range': {
-                    field_index_name: {
+                    column_name: {
                         'gte': lower,
                         'lte': upper,
                     }
@@ -219,7 +232,7 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
         if lookup == 'in':
             return {
                 'terms': {
-                    field_index_name: list(value),
+                    column_name: list(value),
                 }
             }
 
@@ -337,10 +350,10 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
                     field_name = order_by_field[1:]
 
                 field = self._get_filterable_field(field_name)
-                field_index_name = field.get_index_name(self.queryset.model)
+                column_name = self.mapping.get_field_column_name(field)
 
                 sort.append({
-                    field_index_name: 'desc' if reverse else 'asc'
+                    column_name: 'desc' if reverse else 'asc'
                 })
 
             return sort

--- a/wagtail/wagtailsearch/index.py
+++ b/wagtail/wagtailsearch/index.py
@@ -165,8 +165,6 @@ def remove_object(instance):
 
 
 class BaseField(object):
-    suffix = ''
-
     def __init__(self, field_name, **kwargs):
         self.field_name = field_name
         self.kwargs = kwargs
@@ -180,9 +178,6 @@ class BaseField(object):
             return field.attname
         except models.fields.FieldDoesNotExist:
             return self.field_name
-
-    def get_index_name(self, cls):
-        return self.get_attname(cls) + self.suffix
 
     def get_type(self, cls):
         if 'type' in self.kwargs:
@@ -219,16 +214,13 @@ class SearchField(BaseField):
 
 
 class FilterField(BaseField):
-    suffix = '_filter'
+    pass
 
 
 class RelatedFields(object):
     def __init__(self, field_name, fields):
         self.field_name = field_name
         self.fields = fields
-
-    def get_index_name(self, cls):
-        return self.field_name
 
     def get_field(self, cls):
         return cls._meta.get_field(self.field_name)


### PR DESCRIPTION
We need to prefix some fields in Elasticsearch 2 but not Elasticsearch 1. Moving this code into the ElasticsearchMapping class allows us to override it.

It also makes sense to have this sort of thing in the backend rather than the core as other search backends we add in the future may want different behaviour as well.