### PR TITLE
[Elasticsearch 2] Fixed bug causing nested objects to use the wrong mapping

### DIFF
--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -51,9 +51,11 @@ class ElasticsearchMapping(object):
     def get_field_mapping(self, field):
         if isinstance(field, RelatedFields):
             mapping = {'type': 'nested', 'properties': {}}
+            nested_model = field.get_field(self.model).related_model
+            nested_mapping = type(self)(nested_model)
 
             for sub_field in field.fields:
-                sub_field_name, sub_field_mapping = self.get_field_mapping(sub_field)
+                sub_field_name, sub_field_mapping = nested_mapping.get_field_mapping(sub_field)
                 mapping['properties'][sub_field_name] = sub_field_mapping
 
             return field.get_index_name(self.model), mapping


### PR DESCRIPTION
Nested objects that are defined using RelatedFields were being mapped into Elasticsearch using the parent model's mapping.

For example, if we index a page with tags, the tags were being mapped with the Page mapping instead of the Tag mapping.

This doesn't make any difference for Elasticsearch 1, but Elasticsearch 2 needs to prefix fields that have been defined on a child model but it was doing this across the related fields as well.

This fix is covered by the tests coming in the Elasticsearch 2 backend.