### PR TITLE
Update decorator patterns util to preserve original view method name

### DIFF
--- a/wagtail/utils/urlpatterns.py
+++ b/wagtail/utils/urlpatterns.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
+from functools import wraps
+
 
 def decorate_urlpatterns(urlpatterns, decorator):
     for pattern in urlpatterns:
@@ -7,6 +9,6 @@ def decorate_urlpatterns(urlpatterns, decorator):
             decorate_urlpatterns(pattern.url_patterns, decorator)
 
         if hasattr(pattern, '_callback'):
-            pattern._callback = decorator(pattern.callback)
+            pattern._callback = wraps(pattern.callback)(decorator(pattern.callback))
 
     return urlpatterns

--- a/wagtail/utils/urlpatterns.py
+++ b/wagtail/utils/urlpatterns.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from functools import wraps
+from functools import update_wrapper
 
 
 def decorate_urlpatterns(urlpatterns, decorator):
@@ -9,6 +9,6 @@ def decorate_urlpatterns(urlpatterns, decorator):
             decorate_urlpatterns(pattern.url_patterns, decorator)
 
         if hasattr(pattern, '_callback'):
-            pattern._callback = wraps(pattern.callback)(decorator(pattern.callback))
+            pattern._callback = update_wrapper(decorator(pattern.callback), pattern.callback)
 
     return urlpatterns


### PR DESCRIPTION
When `decorate_urlpatterns` apply a decorator to a view function it lost spec names, docs, and the module where it was imported, making it uneasy to inspect when debugging (Like getting the name view and docs when using `django-debug-toolbar`)

Using `functools.wraps` it updates the resulting function to look like the original wrapped view function.

Without the use of this decorator factory, the name of the wrapped view function would have been `decorated_view`.