### PR TITLE
Creates new panel for display information about submissions in pages implementing the AbstractForm class

### DIFF
--- a/docs/reference/pages/panels.rst
+++ b/docs/reference/pages/panels.rst
@@ -160,6 +160,26 @@ ImageChooserPanel
 
     Displaying ``Image`` objects in a template requires the use of a template tag. See :ref:`image_tag`.
 
+FormSubmissionsPanel
+--------------------
+
+.. module:: wagtail.wagtailforms.edit_handlers
+
+.. class:: FormSubmissionsPanel
+
+    This panel adds a single, read-only section in the edit interface for pages implementing the :class:`~wagtail.wagtailforms.models.AbstractForm` model.
+    It includes the number of total submissions for the given form and also a link to the listing of submissions.
+
+    .. code-block:: python
+
+        from wagtail.wagtailforms.models import AbstractForm
+        from wagtail.wagtailforms.edit_handlers import FormSubmissionsPanel
+
+        class ContactFormPage(AbstractForm):
+            content_panels = [
+                FormSubmissionsPanel(),
+            ]
+
 DocumentChooserPanel
 --------------------
 

--- a/wagtail/wagtailforms/edit_handlers.py
+++ b/wagtail/wagtailforms/edit_handlers.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.template.loader import render_to_string
+from django.utils.safestring import mark_safe
+from django.utils.translation import ugettext as _
+
+from wagtail.wagtailadmin.edit_handlers import EditHandler
+
+
+class BaseFormSubmissionsPanel(EditHandler):
+    template = "wagtailforms/edit_handlers/form_responses_panel.html"
+
+    def render(self):
+        from .models import FormSubmission
+        submissions = FormSubmission.objects.filter(page=self.instance)
+
+        if not submissions:
+            return ''
+
+        return mark_safe(render_to_string(self.template, {
+            'self': self,
+            'submissions': submissions
+        }))
+
+
+class FormSubmissionsPanel(object):
+    def __init__(self, heading=None):
+        self.heading = heading
+
+    def bind_to_model(self, model):
+        heading = _('{} submissions').format(model._meta.model_name)
+        return type(str('_FormResponsesPanel'), (BaseFormSubmissionsPanel,), {
+            'model': model,
+            'heading': self.heading or heading,
+        })

--- a/wagtail/wagtailforms/templates/wagtailforms/edit_handlers/form_responses_panel.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/edit_handlers/form_responses_panel.html
@@ -1,0 +1,28 @@
+{% load i18n %}
+{% trans "Total submissions" as total %}
+{% trans "Latest submission" as latest %}
+<fieldset>
+    <legend>{{ self.heading }}</legend>
+    <ul class="fields">
+        <li class="full">
+            <div class="field">
+                <label class="label">{{ total }}</label>
+                <div class="field-content">
+                    <div class="input">
+                        <a href="{% url 'wagtailforms:list_submissions' self.instance.id %}">{{ submissions.count }}</a>
+                    </div>
+                </div>
+            </div>
+        </li>
+        <li class="full">
+            <div class="field">
+                <label class="label">{{ latest }}</label>
+                <div class="field-content">
+                    <p>
+                        {{ submissions.last.submit_time }}
+                    </p>
+                </div>
+            </div>
+        </li>
+    </ul>
+</fieldset>

--- a/wagtail/wagtailforms/tests.py
+++ b/wagtail/wagtailforms/tests.py
@@ -10,7 +10,10 @@ from django.test import TestCase
 
 from wagtail.tests.testapp.models import FormField, FormPage
 from wagtail.tests.utils import WagtailTestUtils
+from wagtail.wagtailadmin.edit_handlers import get_form_for_model
+from wagtail.wagtailadmin.forms import WagtailAdminPageForm
 from wagtail.wagtailcore.models import Page
+from wagtail.wagtailforms.edit_handlers import FormSubmissionsPanel
 from wagtail.wagtailforms.forms import FormBuilder
 from wagtail.wagtailforms.models import FormSubmission
 
@@ -49,6 +52,40 @@ def make_form_page(**kwargs):
     )
 
     return form_page
+
+
+class TestFormResponsesPanel(TestCase):
+    def setUp(self):
+        self.form_page = make_form_page()
+
+        self.FormPageForm = get_form_for_model(
+            FormPage, form_class=WagtailAdminPageForm
+        )
+
+        submissions_panel = FormSubmissionsPanel().bind_to_model(FormPage)
+
+        self.panel = submissions_panel(self.form_page, self.FormPageForm())
+
+    def test_render_with_submissions(self):
+        """Show the panel with the count of submission and a link to the list_submissions view."""
+        self.client.post('/contact-us/', {
+            'your-email': 'bob@example.com',
+            'your-message': 'hello world',
+            'your-choices': {'foo': '', 'bar': '', 'baz': ''}
+        })
+
+        result = self.panel.render()
+
+        url = reverse('wagtailforms:list_submissions', args=(self.form_page.id,))
+        link = '<a href="{}">1</a>'.format(url)
+
+        self.assertIn(link, result)
+
+    def test_render_without_submissions(self):
+        """The panel should not be shown if the number of submission is zero."""
+        result = self.panel.render()
+
+        self.assertEqual('', result)
 
 
 class TestFormSubmission(TestCase):
@@ -423,7 +460,7 @@ class TestFormsSubmissions(TestCase, WagtailTestUtils):
             submission.save()
 
     def test_list_submissions(self):
-        response = self.client.get(reverse('wagtailforms:list_submissions', args=(self.form_page.id, )))
+        response = self.client.get(reverse('wagtailforms:list_submissions', args=(self.form_page.id,)))
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -432,7 +469,7 @@ class TestFormsSubmissions(TestCase, WagtailTestUtils):
 
     def test_list_submissions_filtering_date_from(self):
         response = self.client.get(
-            reverse('wagtailforms:list_submissions', args=(self.form_page.id, )), {'date_from': '01/01/2014'}
+            reverse('wagtailforms:list_submissions', args=(self.form_page.id,)), {'date_from': '01/01/2014'}
         )
 
         # Check response
@@ -464,7 +501,7 @@ class TestFormsSubmissions(TestCase, WagtailTestUtils):
     def test_list_submissions_pagination(self):
         self.make_list_submissions()
 
-        response = self.client.get(reverse('wagtailforms:list_submissions', args=(self.form_page.id, )), {'p': 2})
+        response = self.client.get(reverse('wagtailforms:list_submissions', args=(self.form_page.id,)), {'p': 2})
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -477,7 +514,7 @@ class TestFormsSubmissions(TestCase, WagtailTestUtils):
         self.make_list_submissions()
 
         response = self.client.get(
-            reverse('wagtailforms:list_submissions', args=(self.form_page.id, )), {'p': 'Hello World!'}
+            reverse('wagtailforms:list_submissions', args=(self.form_page.id,)), {'p': 'Hello World!'}
         )
 
         # Check response
@@ -490,7 +527,7 @@ class TestFormsSubmissions(TestCase, WagtailTestUtils):
     def test_list_submissions_pagination_out_of_range(self):
         self.make_list_submissions()
 
-        response = self.client.get(reverse('wagtailforms:list_submissions', args=(self.form_page.id, )), {'p': 99999})
+        response = self.client.get(reverse('wagtailforms:list_submissions', args=(self.form_page.id,)), {'p': 99999})
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -564,7 +601,7 @@ class TestFormsSubmissions(TestCase, WagtailTestUtils):
         unicode_form_submission.save()
 
         response = self.client.get(
-            reverse('wagtailforms:list_submissions', args=(self.form_page.id, )),
+            reverse('wagtailforms:list_submissions', args=(self.form_page.id,)),
             {'date_from': '01/02/2014', 'action': 'CSV'}
         )
 
@@ -634,7 +671,7 @@ class TestDeleteFormSubmission(TestCase):
         # Check that the submission is gone
         self.assertEqual(FormSubmission.objects.count(), 1)
         # Should be redirected to list of submissions
-        self.assertRedirects(response, reverse("wagtailforms:list_submissions", args=(self.form_page.id, )))
+        self.assertRedirects(response, reverse("wagtailforms:list_submissions", args=(self.form_page.id,)))
 
     def test_delete_submission_bad_permissions(self):
         self.assertTrue(self.client.login(username="eventeditor", password="password"))


### PR DESCRIPTION
It should fix #406.
Also, removes the extra whitespace between `,` and `)` as seen in the Python documentation.

I didn't made any changes in the CSS and used the classes that's already used in other types of panels.
I believe I could use some guidance regards the way this information should be displayed.

So far the result is this:
![captura de tela de 2016-05-08 16-06-42](https://cloud.githubusercontent.com/assets/1988429/15099820/e513f6f0-1536-11e6-8ef5-4bc60f779d4a.png)
