### PR TITLE
Fixes UnicodeEncodeError in wagtailforms.

### DIFF
--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -80,7 +80,7 @@ def list_submissions(request, page_id):
 
         writer = csv.writer(response)
 
-        header_row = ['Submission date'] + [label for name, label in data_fields]
+        header_row = ['Submission date'] + [smart_str(label) for name, label in data_fields]
 
         writer.writerow(header_row)
         for s in submissions:


### PR DESCRIPTION
~~Incorporates #2564.~~ Commit to review in this PR: f908ca1.

If you create form field entry with unicode characters in `label`, you get `UnicodeEncodeError`.