### PR TITLE
Adds jinja2 requirement to setup testing extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ testing_extras = [
     'pytz>=2014.7',
     'Pillow>=2.7.0',
     'elasticsearch>=1.0.0',
+    'jinja2>=2.7',
 
     # For coverage and PEP8 linting
     'coverage>=3.7.0',


### PR DESCRIPTION
jinja2 is dependency of Sphinx and is installed with when using `docs`, but not when only `testing` target is used.