### PR TITLE
RoutablePageMixin.subpage_urls no longer used

### DIFF
--- a/wagtail/contrib/wagtailroutablepage/models.py
+++ b/wagtail/contrib/wagtailroutablepage/models.py
@@ -35,9 +35,6 @@ class RoutablePageMixin(object):
     This class can be mixed in to a Page model, allowing extra routes to be
     added to it.
     """
-    #: Set this to a tuple of ``django.conf.urls.url`` objects.
-    subpage_urls = None
-
     @classmethod
     def get_subpage_urls(cls):
         routes = []


### PR DESCRIPTION
This was deprecated in 1.0 (https://github.com/torchbox/wagtail/commit/1384129d8973fd21a463368571ce0fe7b47c7e8a) and should've been removed in 1.2