### PR TITLE
Avoid non-deterministic ordering on test_group_edit_loads_with_page_permissions_shown

### DIFF
--- a/wagtail/wagtailusers/tests.py
+++ b/wagtail/wagtailusers/tests.py
@@ -587,8 +587,8 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
             self.root_page.pk
         )
         self.assertEqual(
-            page_permissions_formset.forms[0]['permission_types'].value(),
-            ['add', 'edit']
+            set(page_permissions_formset.forms[0]['permission_types'].value()),
+            set(['add', 'edit'])
         )
         self.assertEqual(
             page_permissions_formset.forms[1]['page'].value(),


### PR DESCRIPTION
Currently causing sporadic test failures, e.g. https://travis-ci.org/torchbox/wagtail/jobs/129138512

Fixed an earlier occurrence of this in ab70c3c8859a2696d38971d17bdd5c753b2a0925, but missed this one...