### PR TITLE
Fix for changes not being saved in hallo editor

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -32,6 +32,14 @@ function makeRichTextEditable(id) {
         removeStylingPending = false;
     }
 
+    /* Workaround for faulty change-detection in hallo */
+    function setModified() {
+        var hallo = richText.data('IKS-hallo');
+        if (hallo) {
+            hallo.setModified();
+        }
+    }
+
     var closestObj = input.closest('.object');
 
     richText.hallo({
@@ -44,8 +52,11 @@ function makeRichTextEditable(id) {
             setTimeout(removeStyling, 100);
             removeStylingPending = true;
         }
-    }).bind('paste', function(event, data) {
-        setTimeout(removeStyling, 1);
+    }).bind('paste drop', function(event, data) {
+        setTimeout(function() {
+            removeStyling();
+            setModified();
+        }, 1);
     /* Animate the fields open when you click into them. */
     }).bind('halloactivated', function(event, data) {
         $(event.target).addClass('expanded', 200, function(e) {


### PR DESCRIPTION
My users have reported that sometimes when they paste text into the hallo editor then click _Save Draft_, the changes are not saved.  In testing this I also found that after dragging an image inside a richtext (without making any other changes), the new image position was not saved either.  In both cases this turns out to be triggered by using only the mouse; as soon as a key is pressed (e.g. pasting with Ctrl+V) the changes are saved correctly.

I've reproduced this with Firefox on Mac, Chrome on Mac, and Chrome on Windows.

Both of these issues seem to be caused by faulty change detection in `hallo.js`.  It is not setting the `isModified` class on the richtext div when the mouse alone is used to make a change.  In fact if you perform 2 pastes from a mouse right-click/paste, the first paste is saved while the second paste is not.

I've had a look at `hallo.js` and can't see anything obviously wrong with the change detection code.  So instead I've modified Wagtail's `page-editor.js` to give hallo a kick from the `paste` and `drop` events.

This workaround doesn't bother checking for whether content changes were actually made.  I think the chances of someone pasting nothing or dragging something back to where it started are fairly low.