### PR TITLE
Fixes for some buttons (see #2582)

### DIFF
--- a/wagtail/contrib/modeladmin/templates/modeladmin/create.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/create.html
@@ -29,8 +29,10 @@
                 <ul>
                     <li class="actions">
                         {% block form_actions %}
-                            <div class="dropdown dropup match-width">
-                                <div><input type="submit" value="{% trans 'Save' %}" class="button" /></div>
+                            <div class="dropdown dropup dropdown-button match-width">
+                                <button type="submit" class="button action-save button-longrunning" tabindex="3" data-clicked-text="{% trans 'Saving...' %}">
+                                    <span class="icon icon-spinner"></span><em>{% trans 'Save' %}</em>
+                                </button>
                             </div>
                         {% endblock %}
                     </li>

--- a/wagtail/contrib/modeladmin/templates/modeladmin/edit.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/edit.html
@@ -4,13 +4,15 @@
 {% block form_action %}{{ view.edit_url }}{% endblock %}
 
 {% block form_actions %}
-    <div class="dropdown dropup match-width">
-        <div><input type="submit" value="{% trans 'Save' %}" /></div>
+    <div class="dropdown dropup dropdown-button match-width">
+        <button type="submit" class="button action-save button-longrunning" tabindex="3" data-clicked-text="{% trans 'Saving...' %}" {% if page.locked %}disabled {% endif %}>
+            <span class="icon icon-spinner"></span><em>{% trans 'Save' %}</em>
+        </button>
 
         {% if user_can_delete %}
             <div class="dropdown-toggle icon icon-arrow-up"></div>
             <ul role="menu">
-                <li><a href="{{ view.delete_url }}" class="button shortcut">{% trans "Delete" %}</a></li>
+                <li><a href="{{ view.delete_url }}" class="shortcut">{% trans "Delete" %}</a></li>
             </ul>
         {% endif %}
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/_preview_button_on_create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/_preview_button_on_create.html
@@ -1,4 +1,4 @@
-<button class="action-preview {% if icon %}icon icon-view{% endif %}"
+<button class="button action-preview {% if icon %}icon icon-view{% endif %}"
     data-action="{% url 'wagtailadmin_pages:preview_on_add' content_type.app_label content_type.model parent_page.id %}{% if mode %}?mode={{ mode|urlencode }}{% endif %}"
     data-placeholder="{% url 'wagtailadmin_pages:preview' %}"
     data-windowname="wagtail_preview_{{ parent_page.id }}_child">{{ label }}</button>

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/create.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/create.html
@@ -12,8 +12,10 @@
         <footer>
             <ul>
                 <li class="actions">
-                    <div class="dropdown dropup match-width">
-                        <div><input type="submit" value="{% trans 'Save' %}" class="button" /></div>
+                    <div class="dropdown dropup dropdown-button match-width">
+                        <button type="submit" class="button action-save button-longrunning" tabindex="3" data-clicked-text="{% trans 'Saving...' %}">
+                            <span class="icon icon-spinner"></span><em>{% trans 'Save' %}</em>
+                        </button>
                     </div>
                 </li>
             </ul>

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
@@ -12,8 +12,10 @@
         <footer>
             <ul>
                 <li class="actions">
-                    <div class="dropdown dropup match-width">
-                        <input type="submit" value="{% trans 'Save' %}" class="button" />
+                    <div class="dropdown dropup dropdown-button match-width">
+                        <button type="submit" class="button action-save button-longrunning" tabindex="3" data-clicked-text="{% trans 'Saving...' %}" {% if page.locked %}disabled {% endif %}>
+                            <span class="icon icon-spinner"></span><em>{% trans 'Save' %}</em>
+                        </button>
                         <div class="dropdown-toggle icon icon-arrow-up"></div>
                         <ul role="menu">
                             <li><a href="{% url 'wagtailsnippets:delete' model_opts.app_label model_opts.model_name instance.id %}" class="shortcut">{% trans "Delete" %}</a></li>


### PR DESCRIPTION
Ref: #2582

#### Preview button on page create view
##### Before

One preview mode:
<img width="207" alt="page-create-one-mode-before" src="https://cloud.githubusercontent.com/assets/509198/15244064/0fc162be-1908-11e6-9cf7-bab178f8de73.png">

Two preview modes:
<img width="272" alt="page-create-two-modes-before-1" src="https://cloud.githubusercontent.com/assets/509198/15244070/14f155d2-1908-11e6-8b21-78c2332c3748.png">
<img width="280" alt="page-create-two-modes-before-2" src="https://cloud.githubusercontent.com/assets/509198/15244086/2633c92e-1908-11e6-9c44-15867b0b8b1d.png">

##### After
One preview mode:
![image](https://cloud.githubusercontent.com/assets/509198/15244130/6ab87cd4-1908-11e6-9482-8afc3dafca7d.png)

Two preview modes:
![image](https://cloud.githubusercontent.com/assets/509198/15244144/731c7c40-1908-11e6-929f-89470147d4bd.png)
![image](https://cloud.githubusercontent.com/assets/509198/15244161/7a061124-1908-11e6-9a21-60e03c73e6bf.png)



#### Save button on snippet create view
##### Before (with :focus)
![image](https://cloud.githubusercontent.com/assets/509198/15244313/46e5ee08-1909-11e6-97b1-f172e5cdccab.png)

##### After (with :focus)
![image](https://cloud.githubusercontent.com/assets/509198/15244315/4925a974-1909-11e6-92c5-d83690c1e5a8.png)


##### After

#### Save button on snippet edit view
##### Before
![image](https://cloud.githubusercontent.com/assets/509198/15244205/a9ffb8d0-1908-11e6-935d-855b6a8c0997.png)
![image](https://cloud.githubusercontent.com/assets/509198/15244208/ac63726a-1908-11e6-98a1-9d30e917f412.png)

##### After
![image](https://cloud.githubusercontent.com/assets/509198/15244214/b07ac0ba-1908-11e6-8734-1fe78f742266.png)
![image](https://cloud.githubusercontent.com/assets/509198/15244219/b64d2c76-1908-11e6-810e-11a4234ed975.png)