### PR TITLE
Fix JS syntax error in DropDownController

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -329,7 +329,7 @@ wagtail = (function(document, window, wagtail) {
             return this._dropDowns;
         },
 
-        getByIndex(index) {
+        getByIndex: function(index) {
             return this._dropDowns[index];
         },
 


### PR DESCRIPTION
IE11 chokes on this...