### PR TITLE
Make preview window work on IE11

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -329,7 +329,7 @@ wagtail = (function(document, window, wagtail) {
             return this._dropDowns;
         },
 
-        getByIndex(index) {
+        getByIndex: function(index) {
             return this._dropDowns[index];
         },
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -452,13 +452,18 @@ $(function() {
 
         previewWindow = window.open($this.data('placeholder'), $this.data('windowname'));
 
-        if (/MSIE/.test(navigator.userAgent)) {
-            // If IE, load contents immediately without fancy effects
-            submitPreview.call($this, false);
-        } else {
-            previewWindow.onload = function() {
+        if (previewWindow.addEventListener) {
+            previewWindow.addEventListener('load', function() {
                 submitPreview.call($this, true);
-            }
+            }, false);
+        } else if (previewWindow.attachEvent) {
+            // for IE
+            previewWindow.attachEvent('onload', function() {
+                submitPreview.call($this, true);
+            }, false);
+        } else {
+            // Can't trap onload event, so load contents immediately without fancy effects
+            submitPreview.call($this, false);
         }
 
         function submitPreview(enhanced) {
@@ -481,13 +486,13 @@ $(function() {
                             var hideTimeout = setTimeout(function() {
                                 previewDoc.getElementById('loading-spinner-wrapper').className += ' remove';
                                 clearTimeout(hideTimeout);
-                            })
+                            });
 
  // just enough to give effect without adding discernible slowness
                         } else {
                             previewDoc.open();
                             previewDoc.write(data);
-                            previewDoc.close()
+                            previewDoc.close();
                         }
 
                     } else {


### PR DESCRIPTION
ref: https://github.com/torchbox/wagtail/pull/2607#issuecomment-219017144

IE doesn't provide standard onload event listeners on opened windows, so this code did user-agent sniffing on the string 'MSIE' to bypass the onload animation. This failed on IE11, which drops 'MSIE' from the user agent string. The code now checks for the presence of addEventListener instead.

As a bonus, it now falls back on IE's (non-standard?) attachEvent method, so the animation now works on IE after all.

NB this PR incorporates 717ef27fbdedd3139dfb2ac65fd51e72a0f716bf (#2612) - this is 1.5-specific and should be skipped when backporting to 1.4.x