### PR TITLE
Fix #1646: applied the patch from #1911, small change to the proposed query and create a new index

### DIFF
--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -2956,3 +2956,73 @@ class TestIssue2599(TestCase, WagtailTestUtils):
         self.assertEqual(response.context['self'].depth, homepage.depth + 1)
         self.assertTrue(response.context['self'].path.startswith(homepage.path))
         self.assertEqual(response.context['self'].get_parent(), homepage)
+
+
+class TestRecentEditsPanel(TestCase, WagtailTestUtils):
+
+    def setUp(self):
+        # Find root page
+        self.root_page = Page.objects.get(id=2)
+
+        # Add child page
+        child_page = SimplePage(
+            title="Hello world!",
+            slug="hello-world",
+        )
+        self.root_page.add_child(instance=child_page)
+        child_page.save_revision().publish()
+        self.child_page = SimplePage.objects.get(id=child_page.id)
+
+        get_user_model().objects.create_superuser(username='alice', email='alice@email.com', password='password')
+        get_user_model().objects.create_superuser(username='bob', email='bob@email.com', password='password')
+
+    def change_something(self, title):
+        post_data = {'title': title, 'content': "Some content", 'slug': 'hello-world'}
+        response = self.client.post(reverse('wagtailadmin_pages:edit', args=(self.child_page.id, )), post_data)
+
+        # Should be redirected to edit page
+        self.assertRedirects(response, reverse('wagtailadmin_pages:edit', args=(self.child_page.id, )))
+
+        # The page should have "has_unpublished_changes" flag set
+        child_page_new = SimplePage.objects.get(id=self.child_page.id)
+        self.assertTrue(child_page_new.has_unpublished_changes)
+
+    def go_to_dashboard_response(self):
+        response = self.client.get(reverse('wagtailadmin_home'))
+        self.assertEqual(response.status_code, 200)
+        return response
+
+    def test_your_recent_edits(self):
+        # Login as Bob
+        self.client.login(username='bob', password='password')
+
+        # Bob hasn't edited anything yet
+        response = self.client.get(reverse('wagtailadmin_home'))
+        self.assertNotIn('Your most recent edits', response.content)
+
+        # Login as Alice
+        self.client.logout()
+        self.client.login(username='alice', password='password')
+
+        # Alice changes something
+        self.change_something("Alice's edit")
+
+        # Edit should show up on dashboard
+        response = self.go_to_dashboard_response()
+        self.assertIn('Your most recent edits', response.content)
+
+        # Bob changes something
+        self.client.login(username='bob', password='password')
+        self.change_something("Bob's edit")
+
+        # Edit shows up on Bobs dashboard
+        response = self.go_to_dashboard_response()
+        self.assertIn('Your most recent edits', response.content)
+
+        # Login as Alice again
+        self.client.logout()
+        self.client.login(username='alice', password='password')
+
+        # Alice's dashboard should still list that first edit
+        response = self.go_to_dashboard_response()
+        self.assertIn('Your most recent edits', response.content)

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -2959,7 +2959,6 @@ class TestIssue2599(TestCase, WagtailTestUtils):
 
 
 class TestRecentEditsPanel(TestCase, WagtailTestUtils):
-
     def setUp(self):
         # Find root page
         self.root_page = Page.objects.get(id=2)
@@ -2968,6 +2967,7 @@ class TestRecentEditsPanel(TestCase, WagtailTestUtils):
         child_page = SimplePage(
             title="Hello world!",
             slug="hello-world",
+            content="Some content here",
         )
         self.root_page.add_child(instance=child_page)
         child_page.save_revision().publish()

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -2998,7 +2998,7 @@ class TestRecentEditsPanel(TestCase, WagtailTestUtils):
 
         # Bob hasn't edited anything yet
         response = self.client.get(reverse('wagtailadmin_home'))
-        self.assertNotIn('Your most recent edits', response.content)
+        self.assertNotIn('Your most recent edits', response.content.decode('utf-8'))
 
         # Login as Alice
         self.client.logout()
@@ -3009,7 +3009,7 @@ class TestRecentEditsPanel(TestCase, WagtailTestUtils):
 
         # Edit should show up on dashboard
         response = self.go_to_dashboard_response()
-        self.assertIn('Your most recent edits', response.content)
+        self.assertIn('Your most recent edits', response.content.decode('utf-8'))
 
         # Bob changes something
         self.client.login(username='bob', password='password')
@@ -3017,7 +3017,7 @@ class TestRecentEditsPanel(TestCase, WagtailTestUtils):
 
         # Edit shows up on Bobs dashboard
         response = self.go_to_dashboard_response()
-        self.assertIn('Your most recent edits', response.content)
+        self.assertIn('Your most recent edits', response.content.decode('utf-8'))
 
         # Login as Alice again
         self.client.logout()
@@ -3025,4 +3025,4 @@ class TestRecentEditsPanel(TestCase, WagtailTestUtils):
 
         # Alice's dashboard should still list that first edit
         response = self.go_to_dashboard_response()
-        self.assertIn('Your most recent edits', response.content)
+        self.assertIn('Your most recent edits', response.content.decode('utf-8'))

--- a/wagtail/wagtailadmin/views/home.py
+++ b/wagtail/wagtailadmin/views/home.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
-from django.db.models import F
 from django.shortcuts import render
 from django.template.loader import render_to_string
 
@@ -53,13 +52,14 @@ class RecentEditsPanel(object):
             """
             SELECT wp.* FROM
                 wagtailcore_pagerevision wp JOIN (
-                    SELECT max(created_at) AS max_created_at, page_id FROM wagtailcore_pagerevision WHERE user_id = %s GROUP BY page_id
+                    SELECT max(created_at) AS max_created_at, page_id FROM
+                        wagtailcore_pagerevision WHERE user_id = %s GROUP BY page_id ORDER BY max_created_at DESC LIMIT %s
                 ) AS max_rev ON max_rev.max_created_at = wp.created_at ORDER BY wp.created_at DESC
-            """, [request.user.id])[:5]
+             """, [self.request.user.pk, 5])
 
     def render(self):
         return render_to_string('wagtailadmin/home/recent_edits.html', {
-            'last_edits': self.last_edits,
+            'last_edits': list(self.last_edits),
         }, request=self.request)
 
 

--- a/wagtail/wagtailadmin/views/home.py
+++ b/wagtail/wagtailadmin/views/home.py
@@ -51,10 +51,10 @@ class RecentEditsPanel(object):
         # Last n edited pages
         self.last_edits = PageRevision.objects.raw(
             """
-            select wp.* FROM
+            SELECT wp.* FROM
                 wagtailcore_pagerevision wp JOIN (
-                    SELECT max(created_at) as max_created_at, page_id FROM wagtailcore_pagerevision where user_id = %s group by page_id
-                ) as max_rev on max_rev.max_created_at = wp.created_at order by wp.created_at desc
+                    SELECT max(created_at) AS max_created_at, page_id FROM wagtailcore_pagerevision WHERE user_id = %s GROUP BY page_id
+                ) AS max_rev ON max_rev.max_created_at = wp.created_at ORDER BY wp.created_at DESC
             """, [request.user.id])[:5]
 
     def render(self):

--- a/wagtail/wagtailadmin/views/home.py
+++ b/wagtail/wagtailadmin/views/home.py
@@ -49,10 +49,13 @@ class RecentEditsPanel(object):
     def __init__(self, request):
         self.request = request
         # Last n edited pages
-        self.last_edits = PageRevision.objects.filter(
-            user=self.request.user,
-            created_at=F('page__latest_revision_created_at')
-        ).order_by('-created_at')[:5]
+        self.last_edits = PageRevision.objects.raw(
+        """
+        select wp.* FROM
+            wagtailcore_pagerevision wp JOIN (
+                SELECT max(created_at) as max_created_at, page_id FROM wagtailcore_pagerevision where user_id = %s group by page_id
+            ) as max_rev on max_rev.max_created_at = wp.created_at order by wp.created_at desc
+        """, [request.user.id])[:5]
 
     def render(self):
         return render_to_string('wagtailadmin/home/recent_edits.html', {

--- a/wagtail/wagtailadmin/views/home.py
+++ b/wagtail/wagtailadmin/views/home.py
@@ -50,12 +50,12 @@ class RecentEditsPanel(object):
         self.request = request
         # Last n edited pages
         self.last_edits = PageRevision.objects.raw(
-        """
-        select wp.* FROM
-            wagtailcore_pagerevision wp JOIN (
-                SELECT max(created_at) as max_created_at, page_id FROM wagtailcore_pagerevision where user_id = %s group by page_id
-            ) as max_rev on max_rev.max_created_at = wp.created_at order by wp.created_at desc
-        """, [request.user.id])[:5]
+            """
+            select wp.* FROM
+                wagtailcore_pagerevision wp JOIN (
+                    SELECT max(created_at) as max_created_at, page_id FROM wagtailcore_pagerevision where user_id = %s group by page_id
+                ) as max_rev on max_rev.max_created_at = wp.created_at order by wp.created_at desc
+            """, [request.user.id])[:5]
 
     def render(self):
         return render_to_string('wagtailadmin/home/recent_edits.html', {

--- a/wagtail/wagtailcore/migrations/0029_auto_20160515_2027.py
+++ b/wagtail/wagtailcore/migrations/0029_auto_20160515_2027.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0028_merge'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='pagerevision',
+            name='created_at',
+            field=models.DateTimeField(db_index=True, verbose_name='created at'),
+        ),
+    ]

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1388,7 +1388,7 @@ class PageRevision(models.Model):
         default=False,
         db_index=True
     )
-    created_at = models.DateTimeField(verbose_name=_('created at'))
+    created_at = models.DateTimeField(db_index=True, verbose_name=_('created at'))
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL, verbose_name=_('user'), null=True, blank=True,
         on_delete=models.SET_NULL


### PR DESCRIPTION
I've made two changes for this. I've made some comparisions for both changes between three versions of the query. My base have 50k pages and 100k revisions. I'm using PostgreSQL.

First I moved the LIMIT to the inner query, reducing the number of rows for some operations like the hash join.

|    Query    | Time  |   Cost   |
|-------------|-------|----------|
| Current     | 112ms | 12183.33 |
| PR 1911     | 203ms | 36004.76 |
| Inner LIMIT | 123ms | 19235.77 |

I also created an index on the `created_at` column.

|    Query    | Time  |   Cost   |
|-------------|-------|----------|
| Current     | 91ms  | 12183.23 |
| PR 1911     | 123ms | 13438.32 |
| Inner LIMIT | 81ms  | 10425.82 |
