### PR TITLE
Add some missing class="button" styles

### DIFF
--- a/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/includes/searchpromotion_form.html
+++ b/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/includes/searchpromotion_form.html
@@ -1,9 +1,9 @@
 {% load i18n %}
 <li id="inline_child_{{ form.prefix }}"{% if form.DELETE.value %} style="display: none;"{% endif %}>
     <ul class="controls">
-        <li><button class="icon text-replace icon-order-up inline-child-move-up" id="{{ form.prefix }}-move-up">{% trans "Move up" %}</button></li>
-        <li><button class="icon text-replace icon-order-down inline-child-move-down" id="{{ form.prefix }}-move-down">{% trans "Move down" %}</button></li>
-        <li><button class="icon text-replace icon-bin" id="{{ form.DELETE.id_for_label }}-button">{% trans "Delete" %}</button></li>
+        <li><button type="button" class="button icon text-replace icon-order-up inline-child-move-up" id="{{ form.prefix }}-move-up">{% trans "Move up" %}</button></li>
+        <li><button type="button" class="button icon text-replace icon-order-down inline-child-move-down" id="{{ form.prefix }}-move-down">{% trans "Move down" %}</button></li>
+        <li><button type="button" class="button icon text-replace icon-bin" id="{{ form.DELETE.id_for_label }}-button">{% trans "Delete" %}</button></li>
     </ul>
 
     <fieldset>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/_lock_switch.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/_lock_switch.html
@@ -12,7 +12,7 @@
             <form action="{% url 'wagtailadmin_pages:unlock' page.id %}" method="POST" class="status-tag primary">
                 {% csrf_token %}
                 <input type="hidden" name="next" value="{% url 'wagtailadmin_pages:edit' page.id %}">
-                <input type="submit" class="unbutton" value="{% trans "Locked" %}">
+                <input type="submit" class="button unbutton" value="{% trans "Locked" %}">
             </form>
         {% else %}
             <span class="status-tag primary">Locked</span>


### PR DESCRIPTION
I'm pretty sure this catches all the remaining instances from #2524 now - I've grepped the codebase for `type="submit"` (and all variant quotes), `dropdown` and `<button`, and verified that they all have `class="button"` where appropriate.

Along the way I spotted a more serious issue with the up/down/delete controls in wagtailsearchpromotions - they were missing `type="button"`, which resulted in them submitting the form when you tried to use them. Will make a separate PR to backport this fix to 1.4.x.