### PR TITLE
Provide fallback implementation of unittest.assertLogs for Python <3.4

### DIFF
--- a/wagtail/tests/assert_logs.py
+++ b/wagtail/tests/assert_logs.py
@@ -1,0 +1,84 @@
+import logging
+import sys
+from collections import namedtuple
+
+
+# Implementation of TestCase.assertLogs for pre-3.4 Python versions.
+# Borrowed from https://github.com/django/django/pull/3467/commits/1b4f10963628bb68246c193f1124a1f7b6e4c696
+
+class _BaseTestCaseContext(object):
+    def __init__(self, test_case):
+        self.test_case = test_case
+
+    def _raiseFailure(self, standardMsg):
+        msg = self.test_case._formatMessage(self.msg, standardMsg)
+        raise self.test_case.failureException(msg)
+
+
+_LoggingWatcher = namedtuple("_LoggingWatcher", ["records", "output"])
+
+
+class _CapturingHandler(logging.Handler):
+    """
+    A logging handler capturing all (raw and formatted) logging output.
+    """
+
+    def __init__(self):
+        logging.Handler.__init__(self)
+        self.watcher = _LoggingWatcher([], [])
+
+    def flush(self):
+        pass
+
+    def emit(self, record):
+        self.watcher.records.append(record)
+        msg = self.format(record)
+        self.watcher.output.append(msg)
+
+
+class _AssertLogsContext(_BaseTestCaseContext):
+    """A context manager used to implement TestCase.assertLogs()."""
+
+    # original format is "%(levelname)s:%(name)s:%(message)s"
+    LOGGING_FORMAT = "%(message)s"
+
+    def __init__(self, test_case, logger_name, level):
+        _BaseTestCaseContext.__init__(self, test_case)
+        self.logger_name = logger_name
+        if level:
+            if sys.version_info[0] == 2:
+                self.level = logging._levelNames.get(level, level)
+            else:
+                self.level = logging._nameToLevel.get(level, level)
+        else:
+            self.level = logging.INFO
+        self.msg = None
+
+    def __enter__(self):
+        if isinstance(self.logger_name, logging.Logger):
+            logger = self.logger = self.logger_name
+        else:
+            logger = self.logger = logging.getLogger(self.logger_name)
+        formatter = logging.Formatter(self.LOGGING_FORMAT)
+        handler = _CapturingHandler()
+        handler.setFormatter(formatter)
+        self.watcher = handler.watcher
+        self.old_handlers = logger.handlers[:]
+        self.old_level = logger.level
+        self.old_propagate = logger.propagate
+        logger.handlers = [handler]
+        logger.setLevel(self.level)
+        logger.propagate = False
+        return handler.watcher
+
+    def __exit__(self, exc_type, exc_value, tb):
+        self.logger.handlers = self.old_handlers
+        self.logger.propagate = self.old_propagate
+        self.logger.setLevel(self.old_level)
+        if exc_type is not None:
+            # let unexpected exceptions pass through
+            return False
+        if len(self.watcher.records) == 0:
+            self._raiseFailure(
+                "no logs of level {} or higher triggered on {}"
+                .format(logging.getLevelName(self.level), self.logger.name))

--- a/wagtail/tests/assert_logs.py
+++ b/wagtail/tests/assert_logs.py
@@ -48,10 +48,10 @@ class _AssertLogsContext(_BaseTestCaseContext):
         _BaseTestCaseContext.__init__(self, test_case)
         self.logger_name = logger_name
         if level:
-            if sys.version_info[0] == 2:
-                self.level = logging._levelNames.get(level, level)
-            else:
+            if getattr(logging, '_nameToLevel', False):
                 self.level = logging._nameToLevel.get(level, level)
+            else:
+                self.level = logging._levelNames.get(level, level)
         else:
             self.level = logging.INFO
         self.msg = None

--- a/wagtail/tests/assert_logs.py
+++ b/wagtail/tests/assert_logs.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import logging
-import sys
 from collections import namedtuple
 
 

--- a/wagtail/tests/assert_logs.py
+++ b/wagtail/tests/assert_logs.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import logging
 import sys
 from collections import namedtuple

--- a/wagtail/tests/utils.py
+++ b/wagtail/tests/utils.py
@@ -11,6 +11,8 @@ from django.test import TestCase
 from django.utils import six
 from django.utils.text import slugify
 
+from wagtail.tests.assert_logs import _AssertLogsContext
+
 
 class WagtailTestUtils(object):
 
@@ -76,6 +78,30 @@ class WagtailTestUtils(object):
         for mod in list(sys.modules.values()):
             if hasattr(mod, key):
                 getattr(mod, key).clear()
+
+    # Configuring LOGGING_FORMAT is not possible without subclassing
+    # unittest.TestCase, so use this implementation even on Python 3.4
+    def assertLogs(self, logger=None, level=None):
+        """Fail unless a log message of level *level* or higher is emitted
+        on *logger_name* or its children.  If omitted, *level* defaults to
+        INFO and *logger* defaults to the root logger.
+
+        This method must be used as a context manager, and will yield
+        a recording object with two attributes: `output` and `records`.
+        At the end of the context manager, the `output` attribute will
+        be a list of the matching formatted log messages and the
+        `records` attribute will be a list of the corresponding LogRecord
+        objects.
+
+        Example::
+
+            with self.assertLogs('foo', level='INFO') as cm:
+                logging.getLogger('foo').info('first message')
+                logging.getLogger('foo.bar').error('second message')
+            self.assertEqual(cm.output, ['INFO:foo:first message',
+                                         'ERROR:foo.bar:second message'])
+        """
+        return _AssertLogsContext(self, logger, level)
 
 
 class WagtailPageTests(WagtailTestUtils, TestCase):

--- a/wagtail/wagtailsearch/tests/test_index_functions.py
+++ b/wagtail/wagtailsearch/tests/test_index_functions.py
@@ -6,6 +6,7 @@ from django.test import TestCase, override_settings
 
 from wagtail.tests.search import models
 from wagtail.tests.testapp.models import SimplePage
+from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailsearch import index
 
@@ -52,7 +53,7 @@ class TestGetIndexedInstance(TestCase):
         'BACKEND': 'wagtail.wagtailsearch.tests.DummySearchBackend'
     }
 })
-class TestInsertOrUpdateObject(TestCase):
+class TestInsertOrUpdateObject(TestCase, WagtailTestUtils):
     def test_inserts_object(self, backend):
         obj = models.SearchTest.objects.create(title="Test")
         index.insert_or_update_object(obj)
@@ -85,7 +86,7 @@ class TestInsertOrUpdateObject(TestCase):
             index.insert_or_update_object(obj)
 
         self.assertEqual(len(cm.output), 1)
-        self.assertIn("ERROR:wagtail.search.index:Exception raised while adding <SearchTest: Test> into the 'default' search backend", cm.output[0])
+        self.assertIn("Exception raised while adding <SearchTest: Test> into the 'default' search backend", cm.output[0])
         self.assertIn("Traceback (most recent call last):", cm.output[0])
         self.assertIn("ValueError: Test", cm.output[0])
 
@@ -96,7 +97,7 @@ class TestInsertOrUpdateObject(TestCase):
         'BACKEND': 'wagtail.wagtailsearch.tests.DummySearchBackend'
     }
 })
-class TestRemoveObject(TestCase):
+class TestRemoveObject(TestCase, WagtailTestUtils):
     def test_removes_object(self, backend):
         obj = models.SearchTest.objects.create(title="Test")
         index.remove_object(obj)
@@ -118,6 +119,6 @@ class TestRemoveObject(TestCase):
             index.remove_object(obj)
 
         self.assertEqual(len(cm.output), 1)
-        self.assertIn("ERROR:wagtail.search.index:Exception raised while deleting <SearchTest: Test> from the 'default' search backend", cm.output[0])
+        self.assertIn("Exception raised while deleting <SearchTest: Test> from the 'default' search backend", cm.output[0])
         self.assertIn("Traceback (most recent call last):", cm.output[0])
         self.assertIn("ValueError: Test", cm.output[0])


### PR DESCRIPTION
Tests from #2407 are failing on Python <3.4 because unittest.assertLogs was only added in 3.4. This PR provides a fallback implementation, 'borrowed' from a (non-merged) Django pull request: https://github.com/django/django/pull/3467/commits/1b4f10963628bb68246c193f1124a1f7b6e4c696