### PR TITLE
Allow multiple, comma seperated email addresses...

### DIFF
--- a/wagtail/tests/testapp/migrations/0001_initial.py
+++ b/wagtail/tests/testapp/migrations/0001_initial.py
@@ -9,7 +9,7 @@ import taggit.managers
 from django.conf import settings
 from django.db import migrations, models
 
-import wagtail.wagtailadmin.taggable
+import wagtail.wagtailadmin.taggablei
 import wagtail.wagtailcore.blocks
 import wagtail.wagtailcore.fields
 import wagtail.wagtailimages.blocks
@@ -293,7 +293,7 @@ class Migration(migrations.Migration):
             name='FormPage',
             fields=[
                 ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('to_address', models.CharField(blank=True, help_text='Optional - form submissions will be emailed to this address', max_length=255, verbose_name='to address')),
+                ('to_address', models.CharField(blank=True, help_text='Optional - form submissions will be emailed to these addresses. Seperate multiple addresses by comma.', max_length=255, verbose_name='to address')),
                 ('from_address', models.CharField(blank=True, max_length=255, verbose_name='from address')),
                 ('subject', models.CharField(blank=True, max_length=255, verbose_name='subject')),
             ],

--- a/wagtail/tests/testapp/migrations/0001_initial.py
+++ b/wagtail/tests/testapp/migrations/0001_initial.py
@@ -9,7 +9,7 @@ import taggit.managers
 from django.conf import settings
 from django.db import migrations, models
 
-import wagtail.wagtailadmin.taggablei
+import wagtail.wagtailadmin.taggable
 import wagtail.wagtailcore.blocks
 import wagtail.wagtailcore.fields
 import wagtail.wagtailimages.blocks

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -212,7 +212,7 @@ class AbstractEmailForm(AbstractForm):
 
     to_address = models.CharField(
         verbose_name=_('to address'), max_length=255, blank=True,
-        help_text=_("Optional - form submissions will be emailed to this address")
+        help_text=_("Optional - form submissions will be emailed to these addresses. Seperate multiple addresses by comma.")
     )
     from_address = models.CharField(verbose_name=_('from address'), max_length=255, blank=True)
     subject = models.CharField(verbose_name=_('subject'), max_length=255, blank=True)
@@ -221,8 +221,9 @@ class AbstractEmailForm(AbstractForm):
         super(AbstractEmailForm, self).process_form_submission(form)
 
         if self.to_address:
+            addresses = [x.strip() for x in self.to_address.split(',')]
             content = '\n'.join([x[1].label + ': ' + text_type(form.data.get(x[0])) for x in form.fields.items()])
-            send_mail(self.subject, content, [self.to_address], self.from_address,)
+            send_mail(self.subject, content, addresses, self.from_address,)
 
     class Meta:
         abstract = True


### PR DESCRIPTION
to be used in the `to_address field` in the `AbstractEmailForm`.