### PR TITLE
Str funcs for group perms

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1516,6 +1516,7 @@ PAGE_PERMISSION_TYPE_CHOICES = [
 ]
 
 
+@python_2_unicode_compatible
 class GroupPagePermission(models.Model):
     group = models.ForeignKey(Group, verbose_name=_('group'), related_name='page_permissions', on_delete=models.CASCADE)
     page = models.ForeignKey('Page', verbose_name=_('page'), related_name='group_permissions', on_delete=models.CASCADE)
@@ -1529,6 +1530,13 @@ class GroupPagePermission(models.Model):
         unique_together = ('group', 'page', 'permission_type')
         verbose_name = _('group page permission')
         verbose_name_plural = _('group page permissions')
+
+    def __str__(self):
+        return "Group %d ('%s') has permission '%s' on page %d ('%s')" % (
+            self.group.id, self.group,
+            self.permission_type,
+            self.page.id, self.page
+        )
 
 
 class UserPagePermissionsProxy(object):


### PR DESCRIPTION
`GroupCollectionPermission` had a `__str__()` function, but `GroupPagePermission` didn't. So I added one.

Personally, I'd prefer that both classes used a string format more like django's `Permission` model:
```
    def __str__(self):
        return "%s | %s | %s" % (
            six.text_type(self.content_type.app_label),
            six.text_type(self.content_type),
            six.text_type(self.name))
```

But I didn't want to change `GroupCollectionPermission`'s existing implementation.