### PR TITLE
Fix #2637: Mark the RichText field as modified after removing embedded

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-bootstrap.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-bootstrap.js
@@ -76,8 +76,12 @@ function insertRichTextDeleteControl(elem) {
     var a = $('<a class="icon icon-cross text-replace delete-control">Delete</a>');
     $(elem).addClass('rich-text-deletable').prepend(a);
     a.click(function() {
+        var widget = $(elem).parent('.richtext').data('IKS-hallo');
         $(elem).fadeOut(function() {
             $(elem).remove();
+            if (widget != undefined && widget.options.editable) {
+                widget.element.trigger('change');
+            }
         });
     });
 }


### PR DESCRIPTION
Fix #2637. Probably not the most elegant fix, but given the deprecation of hallo.js (see torchbox/wagtail#2409), I don't think this is worth putting much more effort into this.

The idea is that the parent `.richtext` has all widgets data accessible but instead of trying to match the widget that match the element being deleted, hook directly into the base hallo widget and flag the field as modified (it has to happen after removing the element though as it checks if it really is modified and fail otherwise).