### PR TITLE
Ensure Search tab pagination is retained on invalid image upload

### DIFF
--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -144,7 +144,8 @@ def chooser_upload(request):
     else:
         form = ImageForm(user=request.user)
 
-    images = Image.objects.order_by('title')
+    images = Image.objects.order_by('-created_at')
+    paginator, images = paginate(request, images, per_page=12)
 
     return render_modal_workflow(
         request, 'wagtailimages/chooser/chooser.html', 'wagtailimages/chooser/chooser.js',


### PR DESCRIPTION
Otherwise hidden Search tab causes web browser to load _every_ image in the system.

To trigger this bug, go to insert an image in a rich text field, click Upload tab, enter a title and select a non-image file. Click Upload. Search tab (not visible) will change to be ordered by title with no pagination and your web browser will request a rendition of every image in the system. Which can cause your web browser to grind to a halt, as well as be a bit confusing when switching back to the Search tab. 