### PR TITLE
Allow editing of images and embeds by passing params in querystring

### DIFF
--- a/wagtail/wagtailembeds/views/chooser.py
+++ b/wagtail/wagtailembeds/views/chooser.py
@@ -11,7 +11,8 @@ from wagtail.wagtailembeds.forms import EmbedForm
 
 
 def chooser(request):
-    form = EmbedForm()
+    initial = request.GET if request.GET.get('edit') else {}
+    form = EmbedForm(initial=initial)
 
     return render_modal_workflow(request, 'wagtailembeds/chooser/chooser.html', 'wagtailembeds/chooser/chooser.js', {
         'form': form,

--- a/wagtail/wagtailembeds/views/chooser.py
+++ b/wagtail/wagtailembeds/views/chooser.py
@@ -11,8 +11,7 @@ from wagtail.wagtailembeds.forms import EmbedForm
 
 
 def chooser(request):
-    initial = request.GET if request.GET.get('edit') else {}
-    form = EmbedForm(initial=initial)
+    form = EmbedForm(initial=request.GET.dict())
 
     return render_modal_workflow(request, 'wagtailembeds/chooser/chooser.html', 'wagtailembeds/chooser/chooser.js', {
         'form': form,

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -182,7 +182,8 @@ def chooser_select_format(request, image_id):
                 {'image_json': image_json}
             )
     else:
-        form = ImageInsertionForm(initial={'alt_text': image.default_alt_text})
+        initial = request.GET if request.GET.get('edit') else {'alt_text': image.default_alt_text}
+        form = ImageInsertionForm(initial=initial)
 
     return render_modal_workflow(
         request, 'wagtailimages/chooser/select_format.html', 'wagtailimages/chooser/select_format.js',

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -182,7 +182,8 @@ def chooser_select_format(request, image_id):
                 {'image_json': image_json}
             )
     else:
-        initial = request.GET if request.GET.get('edit') else {'alt_text': image.default_alt_text}
+        initial = {'alt_text': image.default_alt_text}
+        initial.update(request.GET.dict())
         form = ImageInsertionForm(initial=initial)
 
     return render_modal_workflow(


### PR DESCRIPTION
Allows Wagtail TinyMCE editor to edit existing images and embeds by passing current values in querystring.
Hallo editor requires development to take advantage of this capability.