### PR TITLE
Remove duplicate output of form media in settings

### DIFF
--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -43,11 +43,9 @@
 
 {% block extra_css %}
     {% include "wagtailadmin/pages/_editor_css.html" %}
-    {{ form.media.css }}
     {{ site_switcher.media.css }}
 {% endblock %}
 {% block extra_js %}
     {% include "wagtailadmin/pages/_editor_js.html" %}
-    {{ form.media.js }}
     {{ site_switcher.media.js }}
 {% endblock %}


### PR DESCRIPTION
Fixes #2664.

Form media declarations are output in edit.html, but this is redundant as they're already output in _editor_css.html / _editor_js.html, and the duplicate definitions cause the rich text editor to fail to activate for some reason.