### PR TITLE
Allow configuration or override of QueryDailyHits garbage collection

### DIFF
--- a/wagtail/wagtailsearch/models.py
+++ b/wagtail/wagtailsearch/models.py
@@ -67,7 +67,7 @@ class QueryDailyHits(models.Model):
         """
         days = getattr(settings, 'WAGTAIL_SEARCH_HITS_TTL', 7) if days is None else days
         min_date = timezone.now().date() - datetime.timedelta(days)
-        
+
         cls.objects.filter(date__lt=min_date).delete()
 
     class Meta:

--- a/wagtail/wagtailsearch/models.py
+++ b/wagtail/wagtailsearch/models.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import datetime
 
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
@@ -60,12 +61,13 @@ class QueryDailyHits(models.Model):
     hits = models.IntegerField(default=0)
 
     @classmethod
-    def garbage_collect(cls):
+    def garbage_collect(cls, days=None):
         """
-        Deletes all QueryDailyHits records that are older than 7 days
+        Deletes all QueryDailyHits records that are older than a set number of days
         """
-        min_date = timezone.now().date() - datetime.timedelta(days=7)
-
+        days = getattr(settings, 'WAGTAIL_SEARCH_HITS_TTL', 7) if days is None else days
+        min_date = timezone.now().date() - datetime.timedelta(days)
+        
         cls.objects.filter(date__lt=min_date).delete()
 
     class Meta:


### PR DESCRIPTION
The existing default of 7 days can be changed either by setting `WAGTAIL_SEARCH_HITS_TTL` or passing a `days` parameter to `QueryDailyHits.garbage_collect` e.g. from a custom management command.