### PR TITLE
Track parent page for editing internal links in rich text

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
@@ -45,14 +45,13 @@
 
                     if (enclosingLink) {
                         href = enclosingLink.getAttribute('href');
-                        pageId = enclosingLink.getAttribute('data-id');
+                        parentPageId = enclosingLink.getAttribute('data-parent-id');
                         linkType = enclosingLink.getAttribute('data-linktype');
 
                         urlParams['link_text'] = enclosingLink.innerText;
 
-                        if (linkType == 'page' && pageId) {
-                            // TODO: Actually show the parent not the page itself.
-                            url = window.chooserUrls.pageChooser + pageId.toString() + '/';
+                        if (linkType == 'page' && parentPageId) {
+                            url = window.chooserUrls.pageChooser + parentPageId.toString() + '/';
                         } else if (href.startsWith('mailto:')) {
                             url = window.chooserUrls.emailLinkChooser;
                             href = href.replace('mailto:', '');
@@ -77,6 +76,7 @@
                                 a.setAttribute('href', pageData.url);
                                 if (pageData.id) {
                                     a.setAttribute('data-id', pageData.id);
+                                    a.setAttribute('data-parent-id', pageData.parentId);
                                     a.setAttribute('data-linktype', 'page');
                                 }
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_choose.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_choose.html
@@ -6,7 +6,7 @@ Expects a variable 'page', the page instance.
 
 <h2>
     {% if page.can_choose %}
-        <a class="choose-page" href="#{{ page.id }}" data-id="{{ page.id }}" data-title="{{ page.title }}" data-url="{{ page.url }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ page.title }}</a>
+        <a class="choose-page" href="#{{ page.id }}" data-id="{{ page.id }}" data-title="{{ page.title }}" data-url="{{ page.url }}" data-parent-id="{{ page.get_parent.id }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ page.title }}</a>
     {% else %}
         {{ page.title }}
     {% endif %}

--- a/wagtail/wagtailcore/rich_text.py
+++ b/wagtail/wagtailcore/rich_text.py
@@ -41,6 +41,9 @@ class PageLinkHandler(object):
 
             if for_editor:
                 editor_attrs = 'data-linktype="page" data-id="%d" ' % page.id
+                parent_page = page.get_parent()
+                if parent_page:
+                    editor_attrs += 'data-parent-id="%d" ' % parent_page.id
             else:
                 editor_attrs = ''
 

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -193,7 +193,7 @@ class TestRichTextBlock(TestCase):
         self.assertIn(
             (
                 '&lt;p&gt;Merry &lt;a data-linktype=&quot;page&quot; data-id=&quot;4&quot;'
-                ' href=&quot;/events/christmas/&quot;&gt;Christmas&lt;/a&gt;!&lt;/p&gt;'
+                ' data-parent-id=&quot;3&quot; href=&quot;/events/christmas/&quot;&gt;Christmas&lt;/a&gt;!&lt;/p&gt;'
             ),
             result
         )

--- a/wagtail/wagtailcore/tests/test_rich_text.py
+++ b/wagtail/wagtailcore/tests/test_rich_text.py
@@ -4,6 +4,7 @@ from bs4 import BeautifulSoup
 from django.test import TestCase
 from mock import patch
 
+from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.rich_text import (
     DbWhitelister, PageLinkHandler, RichText, expand_db_html, extract_attrs)
 
@@ -30,8 +31,20 @@ class TestPageLinkHandler(TestCase):
             {'id': 1},
             True
         )
-        self.assertEqual(result,
-                         '<a data-linktype="page" data-id="1" href="None">')
+        self.assertEqual(
+            result,
+            '<a data-linktype="page" data-id="1" href="None">'
+        )
+
+        events_page_id = Page.objects.get(url_path='/home/events/').pk
+        result = PageLinkHandler.expand_db_attributes(
+            {'id': events_page_id},
+            True
+        )
+        self.assertEqual(
+            result,
+            '<a data-linktype="page" data-id="%d" data-parent-id="2" href="/events/">' % events_page_id
+        )
 
     def test_expand_db_attributes_not_for_editor(self):
         result = PageLinkHandler.expand_db_attributes(


### PR DESCRIPTION
Fixes #2639 - changes the behaviour of editing existing internal links so that the page chooser opens up at the link's parent page, rather than at the page itself.

Various moving parts to this fix, which are probably worth explaining here:

* In `rich_text.py`, the link handler for `linktype="page"` links has been updated to add a `data-parent-id` attribute when it expands links in editor mode. (This attribute is ignored when going the other way, so the database representation is unchanged.)
* `hallo-wagtaillink.js` now picks up that attribute instead of `data-id` when opening the popup to edit an exiting page link.
* `_page_title_choose.html` now adds a `data-parent-id` attribute to the page links inside the chooser, which causes this to be included as `parentId` in the dictionary of page info returned from the chooser.
* `hallo-wagtaillink.js` also writes this back to the generated link in the rich text field, so that editing a just-inserted link works consistently with ones that have come from the database.