### PR TITLE
StructBlock - get_prep_value to return OrderedDict

### DIFF
--- a/wagtail/wagtailcore/blocks/struct_block.py
+++ b/wagtail/wagtailcore/blocks/struct_block.py
@@ -120,7 +120,7 @@ class BaseStructBlock(Block):
 
     def get_prep_value(self, value):
         # recursively call get_prep_value on children and return as a plain dict
-        return dict([
+        return collections.OrderedDict([
             (name, self.child_blocks[name].get_prep_value(val))
             for name, val in value.items()
         ])


### PR DESCRIPTION
`get_prep_value` should return an OrderedDict so we keep the order for the fields inside the StructBlock.

This is needed for the rewriting of Streamfield in React. 