### PR TITLE
Make 'permanent' / 'temporary' label on redirects translatable, instead of classname

### DIFF
--- a/wagtail/wagtailredirects/models.py
+++ b/wagtail/wagtailredirects/models.py
@@ -40,9 +40,9 @@ class Redirect(models.Model):
 
     def get_is_permanent_display(self):
         if self.is_permanent:
-            return "permanent"
+            return _("permanent")
         else:
-            return "temporary"
+            return _("temporary")
 
     @classmethod
     def get_for_site(cls, site=None):

--- a/wagtail/wagtailredirects/templates/wagtailredirects/list.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/list.html
@@ -36,7 +36,7 @@
                         {{ redirect.link }}
                     {% endif %}
                 </td>
-                <td class="type"><div class="status-tag {% if redirect.get_is_permanent_display == "permanent" %}{% trans "primary" %}{% endif %}">{{ redirect.get_is_permanent_display }}</div></td>
+                <td class="type"><div class="status-tag {% if redirect.is_permanent %}primary{% endif %}">{{ redirect.get_is_permanent_display }}</div></td>
             </tr>
         {% endfor %}
     </tbody>


### PR DESCRIPTION
Reported by @leo-naeka on Transifex. The 'primary' classname on the 'permanent' / 'temporary' label in redirect listings was wrongly being translated (meaning that the style was not applied in non-English localisations); conversely, the label itself wasn't being translated...