### PR TITLE
Load staticfiles not static in document and email templates.

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/notifications/base.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/notifications/base.html
@@ -1,4 +1,4 @@
-{% load i18n static %}
+{% load i18n staticfiles %}
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/wagtail/wagtaildocs/templates/wagtaildocs/multiple/add.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/multiple/add.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n static %}
+{% load i18n staticfiles %}
 {% block titletag %}{% trans "Add multiple documents" %}{% endblock %}
 {% block extra_css %}
     {{ block.super }}


### PR DESCRIPTION
This broke the document uploader on S3 for us.