### PR TITLE
#1446 add pagination to wagtailadmin.views.pages.move_choose_destination

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/move_choose_destination.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/move_choose_destination.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 {% block titletag %}{% blocktrans with title=page_to_move.title %}Select a new parent page for {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     <header class="nice-padding">
@@ -8,5 +8,7 @@
 
     <div class="nice-padding">
         {% include "wagtailadmin/pages/listing/_list_move.html" with pages=child_pages parent_page=viewed_page %}
+        {% url 'wagtailadmin_pages:move_choose_destination' page_to_move.id viewed_page.id as pagination_base_url %}
+        {% paginate child_pages base_url=pagination_base_url %}
     </div>
 {% endblock %}

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -677,6 +677,9 @@ def move_choose_destination(request, page_to_move_id, viewed_page_id=None):
 
         child_pages.append(target)
 
+    # Pagination
+    paginator, child_pages = paginate(request, child_pages, per_page=50)
+
     return render(request, 'wagtailadmin/pages/move_choose_destination.html', {
         'page_to_move': page_to_move,
         'viewed_page': viewed_page,


### PR DESCRIPTION
Pagination in the `move_choose_destination` function, to fix #1446.

No unit tests added because we couldn't see anywhere that pagination was currently being tested in wagtailadmin.tests.test_page_views.

Note that when this view is loaded with the named URL `move` then pagination links will redirect to the two-positional-arg version, as the pagination link in the template always supplies the `viewed_page_id` argument.

Credit due also to Žan Anderle, @zanderle