### PR TITLE
Ensure form submission listing is explicitly ordered by submit_time

### DIFF
--- a/wagtail/wagtailforms/tests/test_views.py
+++ b/wagtail/wagtailforms/tests/test_views.py
@@ -160,15 +160,9 @@ class TestFormsSubmissions(TestCase, WagtailTestUtils):
         self.form_page = make_form_page()
 
         # Add a couple of form submissions
-        old_form_submission = FormSubmission.objects.create(
-            page=self.form_page,
-            form_data=json.dumps({
-                'your-email': "old@example.com",
-                'your-message': "this is a really old message",
-            }),
-        )
-        old_form_submission.submit_time = '2013-01-01T12:00:00.000Z'
-        old_form_submission.save()
+        # (save new_form_submission first, so that we're more likely to reveal bugs where
+        # we're relying on the database's internal ordering instead of explicitly ordering
+        # by submit_time)
 
         new_form_submission = FormSubmission.objects.create(
             page=self.form_page,
@@ -179,6 +173,16 @@ class TestFormsSubmissions(TestCase, WagtailTestUtils):
         )
         new_form_submission.submit_time = '2014-01-01T12:00:00.000Z'
         new_form_submission.save()
+
+        old_form_submission = FormSubmission.objects.create(
+            page=self.form_page,
+            form_data=json.dumps({
+                'your-email': "old@example.com",
+                'your-message': "this is a really old message",
+            }),
+        )
+        old_form_submission.submit_time = '2013-01-01T12:00:00.000Z'
+        old_form_submission.save()
 
         # Login
         self.login()

--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -54,7 +54,7 @@ def list_submissions(request, page_id):
 
     data_fields = form_page.get_data_fields()
 
-    submissions = form_submission_class.objects.filter(page=form_page)
+    submissions = form_submission_class.objects.filter(page=form_page).order_by('submit_time')
     data_headings = [label for name, label in data_fields]
 
     select_date_form = SelectDateForm(request.GET)


### PR DESCRIPTION
The form submission listing/export view in wagtailforms was not explicitly ordered by submit_time - it relied on the database's internal ordering, resulting in occasional test failures, e.g. https://travis-ci.org/torchbox/wagtail/jobs/135920555