### PR TITLE
Remove TagSearchable class

### DIFF
--- a/docs/releases/1.6.rst
+++ b/docs/releases/1.6.rst
@@ -30,3 +30,29 @@ Bug fixes
 Upgrade considerations
 ======================
 
+``TagSearchable`` needs removing from custom image / document model migrations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The mixin class ``wagtail.wagtailadmin.taggable.TagSearchable``, used internally by image and document models, has been deprecated. If you are using custom image or document models in your project, the migration(s) which created them will contain frozen references to ``wagtail.wagtailadmin.taggable.TagSearchable``, which must now be removed. The line:
+
+.. code-block:: python
+
+    import wagtail.wagtailadmin.taggable
+
+should be replaced by:
+
+.. code-block:: python
+
+    import wagtail.wagtailsearch.index
+
+and the line:
+
+.. code-block:: python
+
+    bases=(models.Model, wagtail.wagtailadmin.taggable.TagSearchable),
+
+should be updated to:
+
+.. code-block:: python
+
+    bases=(models.Model, wagtail.wagtailsearch.index.Indexed),

--- a/wagtail/tests/testapp/migrations/0001_initial.py
+++ b/wagtail/tests/testapp/migrations/0001_initial.py
@@ -9,11 +9,11 @@ import taggit.managers
 from django.conf import settings
 from django.db import migrations, models
 
-import wagtail.wagtailadmin.taggable
 import wagtail.wagtailcore.blocks
 import wagtail.wagtailcore.fields
 import wagtail.wagtailimages.blocks
 import wagtail.wagtailimages.models
+import wagtail.wagtailsearch.index
 
 
 class Migration(migrations.Migration):
@@ -145,7 +145,7 @@ class Migration(migrations.Migration):
             options={
                 'abstract': False,
             },
-            bases=(models.Model, wagtail.wagtailadmin.taggable.TagSearchable),
+            bases=(models.Model, wagtail.wagtailsearch.index.Indexed),
         ),
         migrations.CreateModel(
             name='CustomImageFilePath',
@@ -167,7 +167,7 @@ class Migration(migrations.Migration):
             options={
                 'abstract': False,
             },
-            bases=(models.Model, wagtail.wagtailadmin.taggable.TagSearchable),
+            bases=(models.Model, wagtail.wagtailsearch.index.Indexed),
         ),
         migrations.CreateModel(
             name='CustomManagerPage',

--- a/wagtail/wagtailadmin/taggable.py
+++ b/wagtail/wagtailadmin/taggable.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
+import warnings
+
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count
 from taggit.models import Tag
 
-from wagtail.utils.deprecation import SearchFieldsShouldBeAList
+from wagtail.utils.deprecation import RemovedInWagtail18Warning, SearchFieldsShouldBeAList
 from wagtail.wagtailsearch import index
 
 
@@ -29,3 +31,9 @@ class TagSearchable(index.Indexed):
         ).annotate(
             item_count=Count('taggit_taggeditem_items')
         ).order_by('-item_count')[:10]
+
+
+warnings.warn(
+    "The wagtail.wagtailadmin.taggable module is deprecated.",
+    category=RemovedInWagtail18Warning, stacklevel=2
+)

--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -5,12 +5,14 @@ from functools import wraps
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.core.mail import send_mail as django_send_mail
-from django.db.models import Q
+from django.db.models import Count, Q
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
 from modelcluster.fields import ParentalKey
+from taggit.models import Tag
 
 from wagtail.wagtailcore.models import GroupPagePermission, Page, PageRevision
 from wagtail.wagtailusers.models import UserProfile
@@ -49,6 +51,16 @@ def get_object_usage(obj):
                     )
 
     return pages
+
+
+def popular_tags_for_model(model, count=10):
+    "Return a queryset of the most frequently used tags used on this model class"
+    content_type = ContentType.objects.get_for_model(model)
+    return Tag.objects.filter(
+        taggit_taggeditem_items__content_type=content_type
+        ).annotate(
+            item_count=Count('taggit_taggeditem_items')
+        ).order_by('-item_count')[:count]
 
 
 def users_with_page_permission(page, permission_type, include_superusers=True):

--- a/wagtail/wagtaildocs/migrations/0001_initial.py
+++ b/wagtail/wagtaildocs/migrations/0001_initial.py
@@ -5,7 +5,7 @@ import taggit.managers
 from django.conf import settings
 from django.db import migrations, models
 
-import wagtail.wagtailadmin.taggable
+import wagtail.wagtailsearch.index
 
 
 class Migration(migrations.Migration):
@@ -46,6 +46,6 @@ class Migration(migrations.Migration):
             ],
             options={
             },
-            bases=(models.Model, wagtail.wagtailadmin.taggable.TagSearchable),
+            bases=(models.Model, wagtail.wagtailsearch.index.Indexed),
         ),
     ]

--- a/wagtail/wagtaildocs/views/documents.py
+++ b/wagtail/wagtaildocs/views/documents.py
@@ -8,7 +8,9 @@ from django.views.decorators.vary import vary_on_headers
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin import messages
 from wagtail.wagtailadmin.forms import SearchForm
-from wagtail.wagtailadmin.utils import PermissionPolicyChecker, permission_denied
+from wagtail.wagtailadmin.utils import (
+    PermissionPolicyChecker, permission_denied, popular_tags_for_model
+)
 from wagtail.wagtailcore.models import Collection
 from wagtail.wagtaildocs.forms import get_document_form
 from wagtail.wagtaildocs.models import get_document_model
@@ -80,7 +82,7 @@ def index(request):
             'is_searching': bool(query_string),
 
             'search_form': form,
-            'popular_tags': Document.popular_tags(),
+            'popular_tags': popular_tags_for_model(Document),
             'user_can_add': permission_policy.user_has_permission(request.user, 'add'),
             'collections': collections,
             'current_collection': current_collection,

--- a/wagtail/wagtailimages/migrations/0001_initial.py
+++ b/wagtail/wagtailimages/migrations/0001_initial.py
@@ -5,8 +5,8 @@ import taggit.managers
 from django.conf import settings
 from django.db import migrations, models
 
-import wagtail.wagtailadmin.taggable
 import wagtail.wagtailimages.models
+import wagtail.wagtailsearch.index
 
 
 class Migration(migrations.Migration):
@@ -54,7 +54,7 @@ class Migration(migrations.Migration):
             options={
                 'abstract': False,
             },
-            bases=(models.Model, wagtail.wagtailadmin.taggable.TagSearchable),
+            bases=(models.Model, wagtail.wagtailsearch.index.Indexed),
         ),
         migrations.CreateModel(
             name='Rendition',

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -8,7 +8,7 @@ from django.shortcuts import get_object_or_404, render
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
-from wagtail.wagtailadmin.utils import PermissionPolicyChecker
+from wagtail.wagtailadmin.utils import PermissionPolicyChecker, popular_tags_for_model
 from wagtail.wagtailcore.models import Collection
 from wagtail.wagtailimages.formats import get_image_format
 from wagtail.wagtailimages.forms import ImageInsertionForm, get_image_form
@@ -98,7 +98,7 @@ def chooser(request):
         'is_searching': False,
         'query_string': q,
         'will_select_format': request.GET.get('select_format'),
-        'popular_tags': Image.popular_tags(),
+        'popular_tags': popular_tags_for_model(Image),
         'collections': collections,
     })
 

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -11,7 +11,7 @@ from django.views.decorators.vary import vary_on_headers
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin import messages
 from wagtail.wagtailadmin.forms import SearchForm
-from wagtail.wagtailadmin.utils import PermissionPolicyChecker, permission_denied
+from wagtail.wagtailadmin.utils import PermissionPolicyChecker, permission_denied, popular_tags_for_model
 from wagtail.wagtailcore.models import Collection, Site
 from wagtail.wagtailimages.exceptions import InvalidFilterSpecError
 from wagtail.wagtailimages.forms import URLGeneratorForm, get_image_form
@@ -76,7 +76,7 @@ def index(request):
             'is_searching': bool(query_string),
 
             'search_form': form,
-            'popular_tags': Image.popular_tags(),
+            'popular_tags': popular_tags_for_model(Image),
             'collections': collections,
             'current_collection': current_collection,
             'user_can_add': permission_policy.user_has_permission(request.user, 'add'),


### PR DESCRIPTION
Supersedes #2436, with differences / additions as follows:

* `get_indexed_objects` was dropped in #2498 and no longer needs to be moved
* `popular_tags` is now the helper function `wagtail.wagtailadmin.utils.popular_tags_for_model` instead of a class method
* the deprecation warning now uses the correct `stacklevel` parameter to point back to the calling module
* references to `TagSearchable` in migrations have been removed (and a release note added telling users to do the same for custom image/document models)