### PR TITLE
Disable cls._deferred check for >=Django 1.10

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -257,7 +257,7 @@ class PageBase(models.base.ModelBase):
     def __init__(cls, name, bases, dct):
         super(PageBase, cls).__init__(name, bases, dct)
 
-        if cls._deferred:
+        if DJANGO_VERSION < (1, 10) and getattr(cls, '_deferred', False):
             # this is an internal class built for Django's deferred-attribute mechanism;
             # don't proceed with all this page type registration stuff
             return

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -1081,6 +1081,18 @@ class TestIsCreatable(TestCase):
         self.assertNotIn(AbstractPage, get_page_models())
 
 
+class TestDeferredPageClasses(TestCase):
+    def test_deferred_page_classes_are_not_registered(self):
+        """
+        In Django <1.10, a call to `defer` such as `SimplePage.objects.defer('content')`
+        will dynamically create a subclass of SimplePage. Ensure that these subclasses
+        are not registered in the get_page_models() list
+        """
+        list(SimplePage.objects.defer('content'))
+        simplepage_subclasses = [cls for cls in get_page_models() if issubclass(cls, SimplePage)]
+        self.assertEqual(simplepage_subclasses, [SimplePage])
+
+
 class TestPageManager(TestCase):
     def test_page_manager(self):
         """


### PR DESCRIPTION
See #2723. ~~Incorporates #2724~~

Looks like we don't need to check `cls._deferred` anymore (after Django 1.10). More details [here](https://code.djangoproject.com/ticket/26207) and in related PR.