### PR TITLE
Implement support for ordering and searching at the same time over the API

### DIFF
--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -49,10 +49,6 @@ class OrderingFilter(BaseFilterBackend):
         Eg: ?order=random
         """
         if 'order' in request.GET:
-            # Prevent ordering while searching
-            if 'search' in request.GET:
-                raise BadRequestError("ordering with a search query is not supported")
-
             order_by = request.GET['order']
 
             # Random ordering
@@ -102,9 +98,10 @@ class SearchFilter(BaseFilterBackend):
 
             search_query = request.GET['search']
             search_operator = request.GET.get('search_operator', None)
+            order_by_relevance = 'order' not in request.GET
 
             sb = get_search_backend()
-            queryset = sb.search(search_query, queryset, operator=search_operator)
+            queryset = sb.search(search_query, queryset, operator=search_operator, order_by_relevance=order_by_relevance)
 
         return queryset
 

--- a/wagtail/api/v2/tests/test_documents.py
+++ b/wagtail/api/v2/tests/test_documents.py
@@ -269,12 +269,13 @@ class TestDocumentListing(TestCase):
 
         self.assertEqual(set(document_id_list), set([2]))
 
-    def test_search_when_ordering_gives_error(self):
+    def test_search_with_order(self):
         response = self.get_response(search='james', order='title')
         content = json.loads(response.content.decode('UTF-8'))
 
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "ordering with a search query is not supported"})
+        document_id_list = self.get_document_id_list(content)
+
+        self.assertEqual(document_id_list, [2])
 
     @override_settings(WAGTAILAPI_SEARCH_ENABLED=False)
     def test_search_when_disabled_gives_error(self):

--- a/wagtail/api/v2/tests/test_images.py
+++ b/wagtail/api/v2/tests/test_images.py
@@ -268,12 +268,13 @@ class TestImageListing(TestCase):
 
         self.assertEqual(set(image_id_list), set([5]))
 
-    def test_search_when_ordering_gives_error(self):
+    def test_search_with_order(self):
         response = self.get_response(search='james', order='title')
         content = json.loads(response.content.decode('UTF-8'))
 
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "ordering with a search query is not supported"})
+        image_id_list = self.get_image_id_list(content)
+
+        self.assertEqual(image_id_list, [5])
 
     @override_settings(WAGTAILAPI_SEARCH_ENABLED=False)
     def test_search_when_disabled_gives_error(self):

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -552,12 +552,13 @@ class TestPageListing(TestCase):
 
         self.assertEqual(set(page_id_list), set([16, 18, 19]))
 
-    def test_search_when_ordering_gives_error(self):
+    def test_search_with_order(self):
         response = self.get_response(search='blog', order='title')
         content = json.loads(response.content.decode('UTF-8'))
 
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {'message': "ordering with a search query is not supported"})
+        page_id_list = self.get_page_id_list(content)
+
+        self.assertEqual(page_id_list, [19, 5, 16, 18])
 
     @override_settings(WAGTAILAPI_SEARCH_ENABLED=False)
     def test_search_when_disabled_gives_error(self):


### PR DESCRIPTION
When the API was originally created, this was not possible to do with Wagtail search. So I added a check to prevent people from doing it.

Custom ordering was implemented in Wagtailsearch in #1815 so this can now be switched on.