### PR TITLE
Fixing webpack config for production mode.

### DIFF
--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -51,7 +51,6 @@ module.exports = function exports() {
       }),
       new webpack.optimize.CommonsChunkPlugin('common', COMMON_PATH, Infinity)
     ],
-    devtool: '#inline-source-map',
     module: {
       loaders: [
         {

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -4,5 +4,6 @@ var config = base('development');
 
 // development overrides go here
 config.watch = true;
+config.devtool = 'cheap-module-eval-source-map';
 
 module.exports = config;


### PR DESCRIPTION
We don't want inline source in prod. Optimising final bundle size a lot.
For dev mode, cheap-module-eval is faster than inline-source.