### PR TITLE
Implement support for using pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import, unicode_literals
+
+import os
+import shutil
+import warnings
+
+import django
+
+
+def pytest_addoption(parser):
+    parser.addoption('--deprecation', choices=['all', 'pending', 'imminent', 'none'], default='pending')
+    parser.addoption('--postgres', action='store_true')
+    parser.addoption('--elasticsearch', action='store_true')
+
+
+def pytest_configure(config):
+    deprecation = config.getoption('deprecation')
+
+    only_wagtail = r'^wagtail(\.|$)'
+    if deprecation == 'all':
+        # Show all deprecation warnings from all packages
+        warnings.simplefilter('default', DeprecationWarning)
+        warnings.simplefilter('default', PendingDeprecationWarning)
+    elif deprecation == 'pending':
+        # Show all deprecation warnings from wagtail
+        warnings.filterwarnings('default', category=DeprecationWarning, module=only_wagtail)
+        warnings.filterwarnings('default', category=PendingDeprecationWarning, module=only_wagtail)
+    elif deprecation == 'imminent':
+        # Show only imminent deprecation warnings from wagtail
+        warnings.filterwarnings('default', category=DeprecationWarning, module=only_wagtail)
+    elif deprecation == 'none':
+        # Deprecation warnings are ignored by default
+        pass
+
+    if config.getoption('postgres'):
+        os.environ['DATABASE_ENGINE'] = 'django.db.backends.postgresql_psycopg2'
+
+    # Setup django after processing the pytest arguments so that the env
+    # variables are available in the settings
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wagtail.tests.settings')
+    django.setup()
+
+    from wagtail.tests.settings import MEDIA_ROOT, STATIC_ROOT
+    shutil.rmtree(STATIC_ROOT, ignore_errors=True)
+    shutil.rmtree(MEDIA_ROOT, ignore_errors=True)
+
+
+def pytest_unconfigure(config):
+    from wagtail.tests.settings import MEDIA_ROOT, STATIC_ROOT
+    shutil.rmtree(STATIC_ROOT, ignore_errors=True)
+    shutil.rmtree(MEDIA_ROOT, ignore_errors=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,9 @@ line_length=100
 multi_line_output=4
 skip=migrations
 add_imports=from __future__ import absolute_import,from __future__ import unicode_literals
+
+
+[pytest]
+django_find_project = false
+python_files=test_*.py 
+testpaths=wagtail

--- a/wagtail/wagtailcore/tests/test_migrations.py
+++ b/wagtail/wagtailcore/tests/test_migrations.py
@@ -10,11 +10,11 @@ from django.db.migrations.autodetector import MigrationAutodetector
 from django.db.migrations.loader import MigrationLoader
 from django.db.migrations.questioner import MigrationQuestioner
 from django.db.migrations.state import ProjectState
-from django.test import TransactionTestCase
+from django.test import TestCase
 from django.utils.six import iteritems
 
 
-class TestForMigrations(TransactionTestCase):
+class TestForMigrations(TestCase):
     def test__migrations(self):
         app_labels = set(app.label for app in apps.get_app_configs()
                          if app.name.startswith('wagtail.'))


### PR DESCRIPTION
This adds a conftest.py module to setup the test infrastructure
correctly. It doesn't yet add pytest and pytest-django to the testing
requirements so for now it is completly optional.

This change also updates the test_migrations testcase to use a regular
TestCase baseclass instead of the TransactionTestCase. Otherwise the
following tests fail with db errors.