### PR TITLE
Implemented annotate_score on SearchResults

### DIFF
--- a/docs/topics/search/searching.rst
+++ b/docs/topics/search/searching.rst
@@ -166,8 +166,36 @@ For example:
     [<EventPage: Easter>, <EventPage: Halloween>, <EventPage: Christmas>]
 
 
-.. _wagtailsearch_frontend_views:
+Annotating results with score
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. versionadded:: 1.7
+
+For each matched result, Elasticsearch calculates a "score", which is a number
+that represents how relevant the result is based on the user's query. The
+results are usually ordered based on the score.
+
+There are some cases where having access to the score is useful (such as
+programmatically combining two queries for different models). You can add the
+score to each result by calling the ``.annotate_score(field)`` method on the
+``SearchQuerySet``.
+
+For example:
+
+.. code-block:: python
+
+    >>> events = EventPage.objects.search("Event").annotate_score("_score")
+    >>> for event in events:
+    ...    print(event.title, event._score)
+    ...
+    ("Easter", 2.5),
+    ("Haloween", 1.7),
+    ("Christmas", 1.5),
+
+Note that the score itself is arbitrary and it is only useful for comparison
+of results for the same query.
+
+.. _wagtailsearch_frontend_views:
 
 An example page search view
 ===========================

--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -104,6 +104,7 @@ class BaseSearchResults(object):
         self.stop = None
         self._results_cache = None
         self._count_cache = None
+        self._score_field = None
 
     def _set_limits(self, start=None, stop=None):
         if stop is not None:
@@ -177,6 +178,11 @@ class BaseSearchResults(object):
         if len(data) > 20:
             data[-1] = "...(remaining elements truncated)..."
         return '<SearchResults %r>' % data
+
+    def annotate_score(self, field_name):
+        clone = self._clone()
+        clone._score_field = field_name
+        return clone
 
 
 class BaseSearchBackend(object):

--- a/wagtail/wagtailsearch/backends/db.py
+++ b/wagtail/wagtailsearch/backends/db.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import warnings
 
 from django.db import models
+from django.db.models.expressions import Value
 
 from wagtail.utils.deprecation import RemovedInWagtail18Warning
 from wagtail.wagtailsearch.backends.base import (
@@ -76,7 +77,12 @@ class DatabaseSearchResults(BaseSearchResults):
         return queryset.filter(q).distinct()[self.start:self.stop]
 
     def _do_search(self):
-        return self.get_queryset()
+        queryset = self.get_queryset()
+
+        if self._score_field:
+            queryset = queryset.annotate(**{self._score_field: Value(None, output_field=models.FloatField())})
+
+        return queryset
 
     def _do_count(self):
         return self.get_queryset().count()

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -430,6 +430,7 @@ class ElasticsearchSearchResults(BaseSearchResults):
 
         # Get pks from results
         pks = [hit['fields']['pk'][0] for hit in hits['hits']['hits']]
+        scores = {str(hit['fields']['pk'][0]): hit['_score'] for hit in hits['hits']['hits']}
 
         # Initialise results dictionary
         results = dict((str(pk), None) for pk in pks)
@@ -438,6 +439,9 @@ class ElasticsearchSearchResults(BaseSearchResults):
         queryset = self.query.queryset.filter(pk__in=pks)
         for obj in queryset:
             results[str(obj.pk)] = obj
+
+            if self._score_field:
+                setattr(obj, self._score_field, scores.get(str(obj.pk)))
 
         # Return results in order given by Elasticsearch
         return [results[str(pk)] for pk in pks if results[str(pk)]]

--- a/wagtail/wagtailsearch/tests/test_db_backend.py
+++ b/wagtail/wagtailsearch/tests/test_db_backend.py
@@ -5,6 +5,7 @@ import warnings
 
 from django.test import TestCase
 
+from wagtail.tests.search import models
 from wagtail.utils.deprecation import RemovedInWagtail18Warning
 
 from .test_backends import BackendTests
@@ -20,6 +21,13 @@ class TestDBBackend(BackendTests, TestCase):
     @unittest.expectedFailure
     def test_update_index_command(self):
         super(TestDBBackend, self).test_update_index_command()
+
+    def test_annotate_score(self):
+        results = self.backend.search("Hello", models.SearchTest).annotate_score('_score')
+
+        for result in results:
+            # DB backend doesn't do scoring, so annotate_score should just add None
+            self.assertIsNone(result._score)
 
 
 class TestOldNameDeprecationWarning(TestCase):

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -250,6 +250,12 @@ class TestElasticsearchSearchBackend(BackendTests, TestCase):
         results = self.backend.search(None, models.SearchTest)
         self.assertEqual(set(results), set())
 
+    def test_annotate_score(self):
+        results = self.backend.search("Hello", models.SearchTest).annotate_score('_score')
+
+        for result in results:
+            self.assertIsInstance(result._score, float)
+
 
 class TestElasticsearchSearchQuery(TestCase):
     def assertDictEqual(self, a, b):


### PR DESCRIPTION
This allows the user to retrieve the scores for each search result:

```python
for page in Page.objects.search("Hello").annotate_score('_score'):
    print(page.title, page._score)
```

TODO:
 - [x] Docs