### PR TITLE
Fixes for a few typos and formatting issues in the Explorer's table headers.

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_table_headers_explore.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_table_headers_explore.html
@@ -20,16 +20,16 @@ ordering: the current sort parameter
         <th class="ord">
             {% if orderable %}
                 {% if ordering == "ord" %}
-                    <a href="{% url 'wagtailadmin_explore' parent_page.id %}" class="icon icon-order text-replace" title="{% trans 'Disable ordering of child pages' %}">{% trans 'Order' %}</a></th>
+                    <a href="{% url 'wagtailadmin_explore' parent_page.id %}" class="icon icon-order text-replace" title="{% trans 'Disable ordering of child pages' %}">{% trans 'Order' %}</a>
                 {% else %}
-                    <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering=ord" class="icon icon-order text-replace" title="{% trans 'Enable ordering of child pages' %}">{% trans 'Order' %}</a></th>
+                    <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering=ord" class="icon icon-order text-replace" title="{% trans 'Enable ordering of child pages' %}">{% trans 'Order' %}</a>
                 {% endif %}
             {% endif %}
         </th>
     {% endif %}
     <th class="title">
         {% if sortable %}
-            <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == "title" %}-{% endif %}title" class="icon icon-arrow-{% if ordering == "title" %}down-after{% elif ordering == "-title" %}up-after{% else %}down-after{% endif %} {% if ordering == "title" or ordering == "-title" %}teal{% endif %}">
+            <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == 'title' %}-{% endif %}title" class="icon icon-arrow-{% if ordering == 'title' %}down-after{% elif ordering == '-title' %}up-after{% else %}down-after{% endif %} {% if ordering == 'title' or ordering == '-title' %}teal{% endif %}">
                 {% trans 'Title' %}
             </a>
         {% else %}
@@ -41,25 +41,25 @@ ordering: the current sort parameter
     {% endif %}
      <th class="updated">
         {% if sortable %}
-            <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == "latest_revision_created_at" %}-{% endif %}latest_revision_created_at" class="icon icon-arrow-{% if ordering == "-latest_revision_created_at" %}up-after{% else %}down-after{% endif %} {% if ordering == "latest_revision_created_at" or ordering == "-latest_revision_created_at" %}teal {% endif %}">
+            <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == 'latest_revision_created_at' %}-{% endif %}latest_revision_created_at" class="icon icon-arrow-{% if ordering == '-latest_revision_created_at' %}up-after{% else %}down-after{% endif %} {% if ordering == 'latest_revision_created_at' or ordering == '-latest_revision_created_at' %}teal {% endif %}">
                 {% trans 'Updated' %}
             </a>
         {% else %}
             {% trans 'Updated' %}
-        {% endif %}                   
+        {% endif %}
     </th>
     <th class="type">
         {% if sortable %}
-            <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == "content_type" %}-{% endif %}content_type" class="icon icon-arrow-{% if ordering == "-content_type" %}up-after{% else %}down-after{% endif %} {% if ordering == "content_type" or ordering == "-content_type" %}teal {% endif %}">
+            <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == 'content_type' %}-{% endif %}content_type" class="icon icon-arrow-{% if ordering == '-content_type' %}up-after{% else %}down-after{% endif %} {% if ordering == 'content_type' or ordering == '-content_type' %}teal {% endif %}">
                 {% trans 'Type' %}
             </a>
         {% else %}
             {% trans 'Type' %}
-        {% endif %}                   
+        {% endif %}
     </th>
     <th class="status">
         {% if sortable %}
-            <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == "live" %}-{% endif %}live" class="icon icon-arrow-{% if ordering == "-live" %}up-after{% else %}down-after{% endif %} {% if ordering == "live" or ordering == "-live" %}teal {% endif %}">
+            <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == 'live' %}-{% endif %}live" class="icon icon-arrow-{% if ordering == '-live' %}up-after{% else %}down-after{% endif %} {% if ordering == 'live' or ordering == '-live' %}teal {% endif %}">
                 {% trans 'Status' %}
             </a>
         {% else %}


### PR DESCRIPTION
The bugfix here is the removal of the redundant </th> tags at the top. I noticed these while writing the Page explorability PR, #2463.

The formatting issue was the use of double quotes for python string comparisons. That messed up the template syntax highlighting, since double quotes were already being used around the HTML attribute values.