### PR TITLE
Allow referencing models by string representation in SnippetChooserBlock

### DIFF
--- a/wagtail/wagtailsnippets/blocks.py
+++ b/wagtail/wagtailsnippets/blocks.py
@@ -3,12 +3,17 @@ from __future__ import absolute_import, unicode_literals
 from django.utils.functional import cached_property
 
 from wagtail.wagtailcore.blocks import ChooserBlock
+from wagtail.wagtailcore.utils import resolve_model_string
 
 
 class SnippetChooserBlock(ChooserBlock):
     def __init__(self, target_model, **kwargs):
         super(SnippetChooserBlock, self).__init__(**kwargs)
-        self.target_model = target_model
+        self._target_model = target_model
+
+    @cached_property
+    def target_model(self):
+        return resolve_model_string(self._target_model)
 
     @cached_property
     def widget(self):


### PR DESCRIPTION
Consider the following… models.py:

```
from .blocks import FooBlock
…

@register_snippet
class FooSnippet(models.Model):
    text_field = models.CharField(max_length=30)


class StandardPage(Page):
    body = StreamField(FooBlock())
```

and blocks.py

```
class FooBlock(blocks.StreamBlock):
    rich_text = RichTextBlock()
    foo_snippet = SnippetChooserBlock(FooSnippet)
```

This would result in circular imports. This PR makes it possible to do `foo_snippet = SnippetChooserBlock('myapp.FooSnippet')` instead.

No test case, as I couldn't see anywhere else that SnippetChooserBlock was being tested.