### PR TITLE
Run isort as part of 'make lint'

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ pipeline:
     image: python:3.5
     commands:
       - XDG_CACHE_HOME=/drone/pip-cache pip install wheel
-      - XDG_CACHE_HOME=/drone/pip-cache pip install isort -e .[testing,docs]
+      - XDG_CACHE_HOME=/drone/pip-cache pip install -e .[testing,docs]
       - isort --check-only --diff --recursive wagtail
   js:
     image: node:4.2.4

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ develop: clean-pyc
 
 lint:
 	flake8 wagtail
+	isort --check-only --diff --recursive wagtail
 
 test:
 	python runtests.py

--- a/docs/contributing/python_guidelines.rst
+++ b/docs/contributing/python_guidelines.rst
@@ -4,7 +4,7 @@ Python coding guidelines
 PEP8
 ~~~~
 
-We ask that all Python contributions adhere to the `PEP8 <http://www.python.org/dev/peps/pep-0008/>`_ style guide, apart from the restriction on line length (E501). The `pep8 tool <http://pep8.readthedocs.org/en/latest/>`_ makes it easy to check your code, e.g. ``pep8 --ignore=E501 your_file.py``.
+We ask that all Python contributions adhere to the `PEP8 <http://www.python.org/dev/peps/pep-0008/>`_ style guide, apart from the restriction on line length (E501). In addition, import lines should be sorted according to `isort <http://timothycrosley.github.io/isort/>`_ rules. If you have installed Wagtail's testing dependencies (``pip install -e .[testing]``), you can check your code by running ``make lint``.
 
 
 Python 2 and 3 compatibility

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,11 @@
 [bdist_wheel]
 universal = 1
 
+[flake8]
+ignore = E501,E303
+exclude = wagtail/project_template/*
+max-line-length = 120
+
 [isort]
 line_length=100
 multi_line_output=4

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ testing_extras = [
     # For coverage and PEP8 linting
     'coverage>=3.7.0',
     'flake8>=2.2.0',
+    'isort>=4.2.0',
 ]
 
 # Documentation dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,6 @@ envlist = py{27,33,34,35}-dj{18,19}-{sqlite,postgres,mysql}-{elasticsearch,noela
           py{27,34,35}-dj110-{sqlite,postgres,mysql}-{elasticsearch,noelasticsearch},
           flake8
 
-[flake8]
-ignore = E501,E303
-exclude = wagtail/project_template/*
-max-line-length = 120
-
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
 commands =


### PR DESCRIPTION
...because I'm tired of having to look up the command line incantation in .drone.yml (or worse, forgetting to run it entirely). :-)

Also added documentation about isort and `make lint` to the Python coding guidelines.