### PR TITLE
include_block template tag for improved StreamField template inclusion

### DIFF
--- a/docs/releases/1.6.rst
+++ b/docs/releases/1.6.rst
@@ -89,3 +89,30 @@ should be updated to:
 .. code-block:: python
 
     bases=(models.Model, wagtail.wagtailsearch.index.Indexed),
+
+``render`` and ``render_basic`` methods on StreamField blocks now accept a ``context`` keyword argument
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``render`` and ``render_basic`` methods on ``wagtail.wagtailcore.blocks.Block`` have been updated to accept an optional ``context`` keyword argument, a template context to use when rendering the block. If you have defined any custom StreamField blocks that override either of these methods, the method signature now needs to be updated to include this keyword argument:
+
+.. code-block:: python
+
+    class MyBlock(Block):
+
+        def render(self, value):
+            ...
+
+        def render_basic(self, value):
+            ...
+
+should now become:
+
+.. code-block:: python
+
+    class MyBlock(Block):
+
+        def render(self, value, context=None):
+            ...
+
+        def render_basic(self, value, context=None):
+            ...

--- a/wagtail/contrib/table_block/blocks.py
+++ b/wagtail/contrib/table_block/blocks.py
@@ -74,22 +74,28 @@ class TableBlock(FieldBlock):
     def is_html_renderer(self):
         return self.table_options['renderer'] == 'html'
 
-    def render(self, value):
+    def render(self, value, context=None):
         template = getattr(self.meta, 'template', None)
         if template and value:
             table_header = value['data'][0] if value.get('data', None) and len(value['data']) > 0 and value.get('first_row_is_table_header', False) else None
             first_col_is_header = value.get('first_col_is_header', False)
-            context = {
+
+            if context is None:
+                new_context = {}
+            else:
+                new_context = dict(context)
+
+            new_context.update({
                 'self': value,
                 self.TEMPLATE_VAR: value,
                 'table_header': table_header,
                 'first_col_is_header': first_col_is_header,
                 'html_renderer': self.is_html_renderer(),
                 'data': value['data'][1:] if table_header else value.get('data', [])
-            }
-            return render_to_string(template, context)
+            })
+            return render_to_string(template, new_context)
         else:
-            return self.render_basic(value)
+            return self.render_basic(value, context=context)
 
     @property
     def media(self):

--- a/wagtail/contrib/table_block/tests.py
+++ b/wagtail/contrib/table_block/tests.py
@@ -84,7 +84,6 @@ class TestTableBlock(TestTableBlockRenderingBase):
         self.assertHTMLEqual(result, expected)
         self.assertIn('Test 2', result)
 
-
     def test_render_empty_table(self):
         """
         An empty table should render okay.
@@ -92,7 +91,6 @@ class TestTableBlock(TestTableBlockRenderingBase):
         block = TableBlock()
         result = block.render(self.default_value)
         self.assertHTMLEqual(result, self.default_expected)
-
 
     def test_do_not_render_html(self):
         """
@@ -108,7 +106,6 @@ class TestTableBlock(TestTableBlockRenderingBase):
         block = TableBlock()
         result = block.render(value)
         self.assertHTMLEqual(result, expected)
-
 
     def test_row_headers(self):
         """
@@ -134,7 +131,6 @@ class TestTableBlock(TestTableBlockRenderingBase):
         result = block.render(value)
         self.assertHTMLEqual(result, expected)
 
-
     def test_row_and_column_headers(self):
         """
         Test row and column headers at the same time.
@@ -146,7 +142,6 @@ class TestTableBlock(TestTableBlockRenderingBase):
         block = TableBlock()
         result = block.render(value)
         self.assertHTMLEqual(result, expected)
-
 
     def test_value_for_and_from_form(self):
         """
@@ -162,7 +157,6 @@ class TestTableBlock(TestTableBlockRenderingBase):
         self.assertJSONEqual(expected_json, returned_json)
         self.assertEqual(block.value_from_form(returned_json), value)
 
-
     def test_is_html_renderer(self):
         """
         Test that settings flow through correctly to
@@ -177,3 +171,19 @@ class TestTableBlock(TestTableBlockRenderingBase):
         new_options['renderer'] = 'html'
         block2 = TableBlock(table_options=new_options)
         self.assertEqual(block2.is_html_renderer(), True)
+
+    def test_render_with_extra_context(self):
+        """
+        Test that extra context variables passed in block.render are passed through
+        to the template.
+        """
+        block = TableBlock(template="tests/blocks/table_block_with_caption.html")
+
+        value = {'first_row_is_table_header': False, 'first_col_is_header': False,
+                 'data': [['Test 1', 'Test 2', 'Test 3'], [None, None, None],
+                          [None, None, None]]}
+        result = block.render(value, context={
+            'caption': "A fascinating table."
+        })
+        self.assertIn("Test 1", result)
+        self.assertIn("<div>A fascinating table.</div>", result)

--- a/wagtail/tests/testapp/templates/tests/blocks/heading_block.html
+++ b/wagtail/tests/testapp/templates/tests/blocks/heading_block.html
@@ -1,0 +1,1 @@
+<h1{% if language %} lang="{{ language }}"{% endif %}>{{ value }}</h1>

--- a/wagtail/tests/testapp/templates/tests/blocks/heading_block.html
+++ b/wagtail/tests/testapp/templates/tests/blocks/heading_block.html
@@ -1,1 +1,1 @@
-<h1{% if language %} lang="{{ language }}"{% endif %}>{{ value }}</h1>
+<h1{% if language %} lang="{{ language }}"{% endif %}{% if classname %} class="{{ classname }}"{% endif %}>{{ value }}</h1>

--- a/wagtail/tests/testapp/templates/tests/blocks/include_block_only_test.html
+++ b/wagtail/tests/testapp/templates/tests/blocks/include_block_only_test.html
@@ -1,0 +1,3 @@
+{% load wagtailcore_tags %}
+
+<body>{% include_block test_block with classname="IMPORTANT"|lower only %}</body>

--- a/wagtail/tests/testapp/templates/tests/blocks/include_block_test.html
+++ b/wagtail/tests/testapp/templates/tests/blocks/include_block_test.html
@@ -1,0 +1,3 @@
+{% load wagtailcore_tags %}
+
+<body>{% include_block test_block %}</body>

--- a/wagtail/tests/testapp/templates/tests/blocks/include_block_test_with_filter.html
+++ b/wagtail/tests/testapp/templates/tests/blocks/include_block_test_with_filter.html
@@ -1,0 +1,3 @@
+{% load wagtailcore_tags %}
+
+<body>{% include_block test_block|default:999 %}</body>

--- a/wagtail/tests/testapp/templates/tests/blocks/include_block_with_test.html
+++ b/wagtail/tests/testapp/templates/tests/blocks/include_block_with_test.html
@@ -1,0 +1,3 @@
+{% load wagtailcore_tags %}
+
+<body>{% include_block test_block with classname="IMPORTANT"|lower %}</body>

--- a/wagtail/tests/testapp/templates/tests/blocks/section_block.html
+++ b/wagtail/tests/testapp/templates/tests/blocks/section_block.html
@@ -1,1 +1,1 @@
-<h1>{{ value.title }}</h1>{{ value.bound_blocks.body.render }}
+<h1{% if language %} lang="{{ language }}"{% endif %}>{{ value.title }}</h1>{{ value.bound_blocks.body.render }}

--- a/wagtail/tests/testapp/templates/tests/blocks/stream_with_language.html
+++ b/wagtail/tests/testapp/templates/tests/blocks/stream_with_language.html
@@ -1,0 +1,5 @@
+{% load wagtailcore_tags %}
+
+{% for block in value %}
+    <div class="{{ block.block_type }}"{% if language %} lang="{{ language }}"{% endif %}>{% include_block block %}</div>
+{% endfor %}

--- a/wagtail/tests/testapp/templates/tests/blocks/table_block_with_caption.html
+++ b/wagtail/tests/testapp/templates/tests/blocks/table_block_with_caption.html
@@ -1,0 +1,2 @@
+{% include "table_block/blocks/table.html" %}
+<div>{{ caption }}</div>

--- a/wagtail/wagtailcore/blocks/base.py
+++ b/wagtail/wagtailcore/blocks/base.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import collections
 import inspect
+import sys
 import warnings
 from importlib import import_module
 
@@ -29,20 +30,17 @@ def accepts_context(func):
     Helper function used by _render_with_context and _render_basic_with_context. Return true
     if the callable 'func' accepts a 'context' keyword argument
     """
-    try:
-        # Python >= 3.3
+    if sys.version_info >= (3, 3):
         signature = inspect.signature(func)
-    except AttributeError:
+        try:
+            signature.bind_partial(context=None)
+            return True
+        except TypeError:
+            return False
+    else:
         # Fall back on inspect.getargspec, available on Python 2.7 but deprecated since 3.5
         argspec = inspect.getargspec(func)
         return ('context' in argspec.args) or (argspec.keywords is not None)
-
-    # inspect.signature(func) succeeded - proceed to test for a 'context' kwarg
-    try:
-        signature.bind_partial(context=None)
-        return True
-    except TypeError:
-        return False
 
 
 # =========================================

--- a/wagtail/wagtailcore/blocks/base.py
+++ b/wagtail/wagtailcore/blocks/base.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import collections
+import inspect
 import warnings
 from importlib import import_module
 
@@ -226,13 +227,13 @@ class Block(six.with_metaclass(BaseBlock, object)):
         In Wagtail 1.8, when support for context-less `render` methods is dropped,
         this method will be deleted (and calls to it replaced with a direct call to `render`).
         """
-        try:
-            return self.render(value, context=context)
-        except TypeError:
-            # retry without the 'context' kwarg
-            result = self.render(value)
+        argspec = inspect.getargspec(self.render)
 
-            # if this is successful, the block needs updating for Wagtail >=1.6 -
+        if ('context' in argspec.args) or argspec.keywords is not None:
+            # this render method can receive a 'context' kwarg, so we're good
+            return self.render(value, context=context)
+        else:
+            # this render method needs updating for Wagtail >=1.6 -
             # output a deprecation warning
 
             # find the specific parent class that defines `render` by stepping through the MRO,
@@ -247,7 +248,9 @@ class Block(six.with_metaclass(BaseBlock, object)):
                 "keyword argument" % class_with_render_method,
                 category=RemovedInWagtail18Warning
             )
-            return result
+
+            # fall back on a call to 'render' without the context kwarg
+            return self.render(value)
 
     def render(self, value, context=None):
         """
@@ -277,13 +280,13 @@ class Block(six.with_metaclass(BaseBlock, object)):
         In Wagtail 1.8, when support for context-less `render_basic` methods is dropped,
         this method will be deleted (and calls to it replaced with a direct call to `render_basic`).
         """
-        try:
-            return self.render_basic(value, context=context)
-        except TypeError:
-            # retry without the 'context' kwarg
-            result = self.render_basic(value)
+        argspec = inspect.getargspec(self.render_basic)
 
-            # if this is successful, the block needs updating for Wagtail >=1.6 -
+        if ('context' in argspec.args) or argspec.keywords is not None:
+            # this render_basic method can receive a 'context' kwarg, so we're good
+            return self.render_basic(value, context=context)
+        else:
+            # this render_basic method needs updating for Wagtail >=1.6 -
             # output a deprecation warning
 
             # find the specific parent class that defines `render_basic` by stepping through the MRO,
@@ -298,7 +301,9 @@ class Block(six.with_metaclass(BaseBlock, object)):
                 "keyword argument" % class_with_render_basic_method,
                 category=RemovedInWagtail18Warning
             )
-            return result
+
+            # fall back on a call to 'render_basic' without the context kwarg
+            return self.render_basic(value)
 
     def render_basic(self, value, context=None):
         """

--- a/wagtail/wagtailcore/blocks/base.py
+++ b/wagtail/wagtailcore/blocks/base.py
@@ -469,6 +469,16 @@ class BoundBlock(object):
     def render(self, context=None):
         return self.block._render_with_context(self.value, context=context)
 
+    def render_as_block(self, context=None):
+        """
+        Alias for render; the include_block tag will specifically check for the presence of a method
+        with this name. (This is because {% include_block %} is just as likely to be invoked on a bare
+        value as a BoundBlock. If we looked for a `render` method instead, we'd run the risk of finding
+        an unrelated method that just happened to have that name - for example, when called on a
+        PageChooserBlock it could end up calling page.render.
+        """
+        return self.block._render_with_context(self.value, context=context)
+
     def id_for_label(self):
         return self.block.id_for_label(self.prefix)
 

--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -536,7 +536,7 @@ class PageChooserBlock(ChooserBlock):
         from wagtail.wagtailadmin.widgets import AdminPageChooser
         return AdminPageChooser(can_choose_root=self.can_choose_root)
 
-    def render_basic(self, value):
+    def render_basic(self, value, context=None):
         if value:
             return format_html('<a href="{0}">{1}</a>', value.url, value.title)
         else:

--- a/wagtail/wagtailcore/blocks/list_block.py
+++ b/wagtail/wagtailcore/blocks/list_block.py
@@ -140,10 +140,13 @@ class ListBlock(Block):
             for item in value
         ]
 
-    def render_basic(self, value):
+    def render_basic(self, value, context=None):
         children = format_html_join(
             '\n', '<li>{0}</li>',
-            [(self.child_block.render(child_value),) for child_value in value]
+            [
+                (self.child_block._render_with_context(child_value, context=context),)
+                for child_value in value
+            ]
         )
         return format_html("<ul>{0}</ul>", children)
 

--- a/wagtail/wagtailcore/blocks/stream_block.py
+++ b/wagtail/wagtailcore/blocks/stream_block.py
@@ -345,6 +345,9 @@ class StreamValue(collections.Sequence):
     def __repr__(self):
         return repr(list(self))
 
+    def render_as_block(self, context=None):
+        return self.stream_block.render(self, context=context)
+
     def __html__(self):
         return self.stream_block.render(self)
 

--- a/wagtail/wagtailcore/blocks/stream_block.py
+++ b/wagtail/wagtailcore/blocks/stream_block.py
@@ -9,7 +9,7 @@ from django.forms.utils import ErrorList
 from django.template.loader import render_to_string
 # Must be imported from Django so we get the new implementation of with_metaclass
 from django.utils import six
-from django.utils.encoding import force_text, python_2_unicode_compatible
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.html import format_html_join
 from django.utils.safestring import mark_safe
 
@@ -205,10 +205,13 @@ class BaseStreamBlock(Block):
             for child in value  # child is a BoundBlock instance
         ]
 
-    def render_basic(self, value):
+    def render_basic(self, value, context=None):
         return format_html_join(
             '\n', '<div class="block-{1}">{0}</div>',
-            [(force_text(child), child.block_type) for child in value]
+            [
+                (child.render(context=context), child.block_type)
+                for child in value
+            ]
         )
 
     def get_searchable_content(self, value):

--- a/wagtail/wagtailcore/blocks/struct_block.py
+++ b/wagtail/wagtailcore/blocks/struct_block.py
@@ -186,6 +186,9 @@ class StructValue(collections.OrderedDict):
     def __str__(self):
         return self.block.render(self)
 
+    def render_as_block(self, context=None):
+        return self.block.render(self, context=context)
+
     @cached_property
     def bound_blocks(self):
         return collections.OrderedDict([

--- a/wagtail/wagtailcore/templatetags/wagtailcore_tags.py
+++ b/wagtail/wagtailcore/templatetags/wagtailcore_tags.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django import template
+from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 
 from wagtail.wagtailcore import __version__
@@ -46,3 +47,15 @@ def richtext(value):
         html = expand_db_html(value)
 
     return mark_safe('<div class="rich-text">' + html + '</div>')
+
+
+@register.simple_tag(takes_context=True)
+def include_block(context, value):
+    """
+    Render the passed item of StreamField content, passing the current template context
+    if there's an identifiable way of doing so (i.e. if it has a `render_as_block` method).
+    """
+    if hasattr(value, 'render_as_block'):
+        return value.render_as_block(context=context.flatten())
+    else:
+        return force_text(value)

--- a/wagtail/wagtailcore/templatetags/wagtailcore_tags.py
+++ b/wagtail/wagtailcore/templatetags/wagtailcore_tags.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django import template
+from django.template.defaulttags import token_kwargs
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 
@@ -49,13 +50,52 @@ def richtext(value):
     return mark_safe('<div class="rich-text">' + html + '</div>')
 
 
-@register.simple_tag(takes_context=True)
-def include_block(context, value):
+class IncludeBlockNode(template.Node):
+    def __init__(self, block_var, extra_context):
+        self.block_var = block_var
+        self.extra_context = extra_context
+
+    def render(self, context):
+        try:
+            value = self.block_var.resolve(context)
+        except template.VariableDoesNotExist:
+            return ''
+
+        if hasattr(value, 'render_as_block'):
+            new_context = context.flatten()
+
+            if self.extra_context:
+                for var_name, var_value in self.extra_context.items():
+                    new_context[var_name] = var_value.resolve(context)
+
+            return value.render_as_block(context=new_context)
+        else:
+            return force_text(value)
+
+
+@register.tag
+def include_block(parser, token):
     """
     Render the passed item of StreamField content, passing the current template context
     if there's an identifiable way of doing so (i.e. if it has a `render_as_block` method).
     """
-    if hasattr(value, 'render_as_block'):
-        return value.render_as_block(context=context.flatten())
+    tokens = token.split_contents()
+
+    try:
+        tag_name = tokens.pop(0)
+        block_var_token = tokens.pop(0)
+    except IndexError:
+        raise template.TemplateSyntaxError("%r tag requires at least one argument" % tag_name)
+
+    block_var = parser.compile_filter(block_var_token)
+
+    if tokens and tokens[0] == 'with':
+        tokens.pop(0)
+        extra_context = token_kwargs(tokens, parser)
     else:
-        return force_text(value)
+        extra_context = None
+
+    if tokens:
+        raise template.TemplateSyntaxError("Unexpected argument to %r tag: %r" % (tag_name, tokens[0]))
+
+    return IncludeBlockNode(block_var, extra_context)

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -2096,3 +2096,89 @@ class TestTemplateRendering(TestCase):
 
         self.assertIn('data-prefix="my-link-block"', result)
         self.assertIn('<p>Hello from get_form_context!</p>', result)
+
+
+class TestIncludeBlockTag(TestCase):
+    def test_include_block_tag_with_boundblock(self):
+        """
+        The include_block tag should be able to render a BoundBlock's template
+        while keeping the parent template's context
+        """
+        block = blocks.CharBlock(template='tests/blocks/heading_block.html')
+        bound_block = block.bind('bonjour')
+
+        result = render_to_string('tests/blocks/include_block_test.html', {
+            'test_block': bound_block,
+            'language': 'fr',
+        })
+        self.assertIn('<body><h1 lang="fr">bonjour</h1></body>', result)
+
+    def test_include_block_tag_with_structvalue(self):
+        """
+        The include_block tag should be able to render a StructValue's template
+        while keeping the parent template's context
+        """
+        block = SectionBlock()
+        struct_value = block.to_python({'title': 'Bonjour', 'body': 'monde <i>italique</i>'})
+
+        result = render_to_string('tests/blocks/include_block_test.html', {
+            'test_block': struct_value,
+            'language': 'fr',
+        })
+
+        self.assertIn(
+            """<body><h1 lang="fr">Bonjour</h1><div class="rich-text">monde <i>italique</i></div></body>""",
+            result
+        )
+
+    def test_include_block_tag_with_streamvalue(self):
+        """
+        The include_block tag should be able to render a StreamValue's template
+        while keeping the parent template's context
+        """
+        block = blocks.StreamBlock([
+            ('heading', blocks.CharBlock(template='tests/blocks/heading_block.html')),
+            ('paragraph', blocks.CharBlock()),
+        ], template='tests/blocks/stream_with_language.html')
+
+        stream_value = block.to_python([
+            {'type': 'heading', 'value': 'Bonjour'}
+        ])
+
+        result = render_to_string('tests/blocks/include_block_test.html', {
+            'test_block': stream_value,
+            'language': 'fr',
+        })
+
+        self.assertIn('<div class="heading" lang="fr"><h1 lang="fr">Bonjour</h1></div>', result)
+
+    def test_include_block_tag_with_plain_value(self):
+        """
+        The include_block tag should be able to render a value without a render_as_block method
+        by just rendering it as a string
+        """
+        result = render_to_string('tests/blocks/include_block_test.html', {
+            'test_block': 42,
+        })
+
+        self.assertIn('<body>42</body>', result)
+
+    def test_include_block_tag_with_filtered_value(self):
+        """
+        The block parameter on include_block tag should support complex values including filters,
+        e.g. {% include_block foo|default:123 %}
+        """
+        block = blocks.CharBlock(template='tests/blocks/heading_block.html')
+        bound_block = block.bind('bonjour')
+
+        result = render_to_string('tests/blocks/include_block_test_with_filter.html', {
+            'test_block': bound_block,
+            'language': 'fr',
+        })
+        self.assertIn('<body><h1 lang="fr">bonjour</h1></body>', result)
+
+        result = render_to_string('tests/blocks/include_block_test_with_filter.html', {
+            'test_block': None,
+            'language': 'fr',
+        })
+        self.assertIn('<body>999</body>', result)

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -2182,3 +2182,17 @@ class TestIncludeBlockTag(TestCase):
             'language': 'fr',
         })
         self.assertIn('<body>999</body>', result)
+
+    def test_include_block_tag_with_extra_context(self):
+        """
+        Test that it's possible to pass extra context on an include_block tag using
+        {% include_block foo with classname="bar" %}
+        """
+        block = blocks.CharBlock(template='tests/blocks/heading_block.html')
+        bound_block = block.bind('bonjour')
+
+        result = render_to_string('tests/blocks/include_block_with_test.html', {
+            'test_block': bound_block,
+            'language': 'fr',
+        })
+        self.assertIn('<body><h1 lang="fr" class="important">bonjour</h1></body>', result)

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -2196,3 +2196,17 @@ class TestIncludeBlockTag(TestCase):
             'language': 'fr',
         })
         self.assertIn('<body><h1 lang="fr" class="important">bonjour</h1></body>', result)
+
+    def test_include_block_tag_with_only_flag(self):
+        """
+        A tag such as {% include_block foo with classname="bar" only %}
+        should not inherit the parent context
+        """
+        block = blocks.CharBlock(template='tests/blocks/heading_block.html')
+        bound_block = block.bind('bonjour')
+
+        result = render_to_string('tests/blocks/include_block_only_test.html', {
+            'test_block': bound_block,
+            'language': 'fr',
+        })
+        self.assertIn('<body><h1 class="important">bonjour</h1></body>', result)

--- a/wagtail/wagtaildocs/blocks.py
+++ b/wagtail/wagtaildocs/blocks.py
@@ -17,7 +17,7 @@ class DocumentChooserBlock(ChooserBlock):
         from wagtail.wagtaildocs.widgets import AdminDocumentChooser
         return AdminDocumentChooser
 
-    def render_basic(self, value):
+    def render_basic(self, value, context=None):
         if value:
             return format_html('<a href="{0}">{1}</a>', value.url, value.title)
         else:

--- a/wagtail/wagtailimages/blocks.py
+++ b/wagtail/wagtailimages/blocks.py
@@ -18,7 +18,7 @@ class ImageChooserBlock(ChooserBlock):
         from wagtail.wagtailimages.widgets import AdminImageChooser
         return AdminImageChooser
 
-    def render_basic(self, value):
+    def render_basic(self, value, context=None):
         if value:
             return get_rendition_or_not_found(value, 'original').img_tag()
         else:


### PR DESCRIPTION
As proposed in https://github.com/torchbox/wagtail/issues/1743#issuecomment-224543332 - this PR implements an `{% include_block my_block %}` template tag, which works equivalently to Django's `{% include 'my_template.html' %}` tag (including constructs like `{% include_block my_block with classname='foo' only %}`).

This improves on the current convention of rendering StreamField blocks using variable tags e.g. `{{ my_block }}`, as it allows the child template to inherit the template context - this is necessary for the `{% pageurl %}` tag to work (and also provides access to the `page` variable, which is frequently requested - e.g. to allow building StreamField-based forms that post back to the current page).

As part of this change, the `render` and `render_basic` methods on `Block` now accept a `context` kwarg, which introduces a backwards incompatibility (since third-party libraries may have overridden these methods with the old method signature) - I've put compatibility shims in place to mitigate this.

Fixes #1743, #2469.