### PR TITLE
Prevent alert after pressing enter while saving page. 

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -63,6 +63,11 @@ function enableDirtyFormCheck(formSelector, options) {
     var confirmationMessage = options.confirmationMessage || ' ';
     var alwaysDirty = options.alwaysDirty || false;
     var initialData = $form.serialize();
+    var formSubmitted = false;
+
+    $($form).submit(function() {
+        formSubmitted = true;
+    });
 
     window.addEventListener('beforeunload', function(event) {
         // Ignore if the user clicked on an ignored element
@@ -75,7 +80,10 @@ function enableDirtyFormCheck(formSelector, options) {
             }
         });
 
-        if (dirtyFormCheckIsActive && !triggeredByIgnoredButton && (alwaysDirty || $form.serialize() != initialData)) {
+        var displayConfirmation = dirtyFormCheckIsActive && !formSubmitted && !triggeredByIgnoredButton
+            && (alwaysDirty || $form.serialize() != initialData);
+
+        if (displayConfirmation) {
             event.returnValue = confirmationMessage;
             return confirmationMessage;
         }


### PR DESCRIPTION
Fixes #2798

## Solution

Check if form has been submitted before showing navigation alert. This will prevent the alert from showing when pressing enter in an input box.