### PR TITLE
Fix tests that are checking issue #613

### DIFF
--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -921,6 +921,7 @@ class TestGetUsage(TestCase, WagtailTestUtils):
         self.assertRegex(response.content, b'<tbody>(\s|\n)*</tbody>')
 
 
+@override_settings(_WAGTAILSEARCH_FORCE_AUTO_UPDATE=['elasticsearch'])
 class TestIssue613(TestCase, WagtailTestUtils):
     def get_elasticsearch_backend(self):
         from django.conf import settings

--- a/wagtail/wagtailimages/tests/test_models.py
+++ b/wagtail/wagtailimages/tests/test_models.py
@@ -366,6 +366,7 @@ class TestIssue573(TestCase):
         image.get_rendition('fill-800x600')
 
 
+@override_settings(_WAGTAILSEARCH_FORCE_AUTO_UPDATE=['elasticsearch'])
 class TestIssue613(TestCase, WagtailTestUtils):
     def get_elasticsearch_backend(self):
         from django.conf import settings

--- a/wagtail/wagtailsearch/backends/__init__.py
+++ b/wagtail/wagtailsearch/backends/__init__.py
@@ -77,10 +77,24 @@ def get_search_backend(backend='default', **kwargs):
     return backend_cls(params)
 
 
+def _backend_requires_auto_update(backend_name, params):
+    if params.get('AUTO_UPDATE', True):
+        return True
+
+    # _WAGTAILSEARCH_FORCE_AUTO_UPDATE is only used by Wagtail tests. It allows
+    # us to test AUTO_UPDATE behaviour against Elasticsearch without having to
+    # have AUTO_UPDATE enabed for every test.
+    force_auto_update = getattr(settings, '_WAGTAILSEARCH_FORCE_AUTO_UPDATE', [])
+    if backend_name in force_auto_update:
+        return True
+
+    return False
+
+
 def get_search_backends_with_name(with_auto_update=False):
     if hasattr(settings, 'WAGTAILSEARCH_BACKENDS'):
         for backend, params in settings.WAGTAILSEARCH_BACKENDS.items():
-            if with_auto_update and params.get('AUTO_UPDATE', True) is False:
+            if with_auto_update and _backend_requires_auto_update(backend, params) is False:
                 continue
 
             yield backend, get_search_backend(backend)


### PR DESCRIPTION
These tests haven't been run for a while due to a mistake in ``tox.ini``. They are currently broken on master.

They broke because they require ``AUTO_UPDATE`` to be ``True`` for the Elasticsearch backend, but we recently disabled that to improve speed and reliability of the entire test suite. This commit adds a way for the tests that need ``AUTO_UPDATE`` to force it to be enabled on specific backends