### PR TITLE
Fix URL under package version badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 .. image:: https://img.shields.io/pypi/l/wagtail.svg
     :target: https://pypi.python.org/pypi/wagtail/
 .. image:: https://img.shields.io/pypi/v/wagtail.svg
-    :target: https://crate.io/packages/wagtail/
+    :target: https://pypi.python.org/pypi/wagtail/
 .. image:: https://coveralls.io/repos/torchbox/wagtail/badge.svg?branch=master
     :target: https://coveralls.io/r/torchbox/wagtail?branch=master
 


### PR DESCRIPTION
Originally reported in #774, not too sure why this was closed right away.

crate.io has been shut down and the domain repurposed/sold. Backstory on https://www.reddit.com/r/Python/comments/1wcp93/what_happened_to_crateio/ (and/or https://github.com/crateio/crate.io/issues/18).

