### PR TITLE
Add 'download' attribute to document download links

### DIFF
--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/list.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/list.html
@@ -36,7 +36,7 @@
                         <h2><a href="{% url 'wagtaildocs:edit' doc.id %}">{{ doc.title }}</a></h2>
                     {% endif %}
                 </td>
-                <td><a href="{{ doc.url }}" class="nolink">{{ doc.filename }}</a></td>
+                <td><a href="{{ doc.url }}" class="nolink" download>{{ doc.filename }}</a></td>
                 <td><div class="human-readable-date" title="{{ doc.created_at|date:"d M Y H:i" }}">{{ doc.created_at|timesince }} ago</div></td>
             </tr>
         {% endfor %}


### PR DESCRIPTION
Partially fixes #2513 - Firefox and Chrome (and hopefully Edge >=13) do not trigger
onbeforeunload events when following these links. Safari and IE don't currently
support it, though.