### PR TITLE
Unable to use TransactionTestCase without wagtailsearchpromotions app on PostgreSQL

### DIFF
--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -9,7 +9,7 @@ MEDIA_URL = '/media/'
 
 DATABASES = {
     'default': {
-        'ENGINE': os.environ.get('DATABASE_ENGINE', 'django.db.backends.sqlite3'),
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': os.environ.get('DATABASE_NAME', 'wagtail'),
         'USER': os.environ.get('DATABASE_USER', None),
         'PASSWORD': os.environ.get('DATABASE_PASS', None),
@@ -98,7 +98,7 @@ INSTALLED_APPS = (
     'wagtail.contrib.wagtailroutablepage',
     'wagtail.contrib.wagtailfrontendcache',
     'wagtail.contrib.wagtailapi',
-    'wagtail.contrib.wagtailsearchpromotions',
+    # 'wagtail.contrib.wagtailsearchpromotions',
     'wagtail.contrib.settings',
     'wagtail.contrib.modeladmin',
     'wagtail.contrib.table_block',

--- a/wagtail/wagtailsearch/tests/test_migrations.py
+++ b/wagtail/wagtailsearch/tests/test_migrations.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import, unicode_literals
+
+import unittest
+
+from django.db import connection
+from django.test import TestCase, TransactionTestCase
+
+
+@unittest.skipIf(connection.vendor != 'postgresql', 'This testcase needs PostgreSQL.')
+class MigrationTransactionTestCase(TransactionTestCase):
+
+    def test_migration_remove_editor(self):
+        pass
+
+
+class MigrationTestCase(TestCase):
+
+    def test_migration_remove_editor(self):
+        pass


### PR DESCRIPTION
Hi,

I made a PR just to easily let's you reproduce the bug because I cannot fix it yet. In that way, you just have to execute the test (don't forgot to have a postgreSQL database test ready, I temporary force the test settings to use it instead of using environment variables). Then with : 
````
./runtests.py wagtail.wagtailsearch.tests.test_migrations
````
PostgreSQL should throw the following exception for the transaction test case : 

> psycopg2.NotSupportedError: cannot truncate a table referenced in a foreign key constraint

To summarize, if we use postgreSQL, don't have wagtailsearchpromotions app enabled and want to do some TransactionTestCase in our project, we can't.

Obviously, the migration 0003 remove the EditorsPick's table model which is still use by wagtailsearchpromotions ?

I can't still figure out why TestCase works fine and TransactionTestCase don't...?

Thanks

