### PR TITLE
Simplify and fix dirty forms behaviour

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -152,6 +152,7 @@ Contributors
 * Raphael Stolt
 * Tim Graham
 * Thibaud Colas
+* Sean Muck
 
 Translators
 ===========

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -63,6 +63,11 @@ function enableDirtyFormCheck(formSelector, options) {
     var confirmationMessage = options.confirmationMessage || ' ';
     var alwaysDirty = options.alwaysDirty || false;
     var initialData = $form.serialize();
+    var formSubmitted = false;
+
+    $($form).submit(function() {
+        formSubmitted = true;
+    });
 
     window.addEventListener('beforeunload', function(event) {
         // Ignore if the user clicked on an ignored element
@@ -75,7 +80,10 @@ function enableDirtyFormCheck(formSelector, options) {
             }
         });
 
-        if (dirtyFormCheckIsActive && !triggeredByIgnoredButton && (alwaysDirty || $form.serialize() != initialData)) {
+        var displayConfirmation = dirtyFormCheckIsActive && !formSubmitted && !triggeredByIgnoredButton
+            && (alwaysDirty || $form.serialize() != initialData);
+
+        if (displayConfirmation) {
             event.returnValue = confirmationMessage;
             return confirmationMessage;
         }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -45,9 +45,6 @@ function initTagField(id, autocompleteUrl) {
  *  - formSelector - A CSS selector to select the form to apply this check to.
  *
  *  - options - An object for passing in options. Possible options are:
- *    - ignoredButtonsSelector - A CSS selector to find buttons to ignore within
- *      the form. If the navigation was triggered by one of these buttons, The
- *      check will be ignored. defaults to: input[type="submit"].
  *    - confirmationMessage - The message to display in the prompt.
  *    - alwaysDirty - When set to true the form will always be considered dirty,
  *      prompting the user even when nothing has been changed.
@@ -57,9 +54,6 @@ var dirtyFormCheckIsActive = true;
 
 function enableDirtyFormCheck(formSelector, options) {
     var $form = $(formSelector);
-    var $ignoredButtons = $form.find(
-        options.ignoredButtonsSelector || 'input[type="submit"],button[type="submit"]'
-    );
     var confirmationMessage = options.confirmationMessage || ' ';
     var alwaysDirty = options.alwaysDirty || false;
     var initialData = $form.serialize();
@@ -70,18 +64,9 @@ function enableDirtyFormCheck(formSelector, options) {
     });
 
     window.addEventListener('beforeunload', function(event) {
-        // Ignore if the user clicked on an ignored element
-        var triggeredByIgnoredButton = false;
-        var $trigger = $(event.explicitOriginalTarget || document.activeElement);
-
-        $ignoredButtons.each(function() {
-            if ($(this).is($trigger)) {
-                triggeredByIgnoredButton = true;
-            }
-        });
-
-        var displayConfirmation = dirtyFormCheckIsActive && !formSubmitted && !triggeredByIgnoredButton
-            && (alwaysDirty || $form.serialize() != initialData);
+        var displayConfirmation = (
+            dirtyFormCheckIsActive && !formSubmitted && (alwaysDirty || $form.serialize() != initialData)
+        );
 
         if (displayConfirmation) {
             event.returnValue = confirmationMessage;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -333,13 +333,11 @@ function initCollapsibleBlocks() {
 
 function initKeyboardShortcuts() {
     Mousetrap.bind(['mod+p'], function(e) {
-        disableDirtyFormCheck();
         $('.action-preview').trigger('click');
         return false;
     });
 
     Mousetrap.bind(['mod+s'], function(e) {
-        disableDirtyFormCheck();
         $('.action-save').trigger('click');
         return false;
     });

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
@@ -83,7 +83,7 @@
                 {
                     confirmationMessage: '{{ confirmation_message|escapejs }}',
 
-                    {% if form.errors %}
+                    {% if has_unsaved_changes %}
                         alwaysDirty: true,
                     {% endif %}
                 }

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -117,7 +117,7 @@
                 {
                     confirmationMessage: '{{ confirmation_message|escapejs }}',
 
-                    {% if form.errors %}
+                    {% if has_unsaved_changes %}
                         alwaysDirty: true,
                     {% endif %}
                 }

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -554,6 +554,9 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         self.assertFormError(response, 'form', 'go_live_at', "Go live date/time must be before expiry date/time")
         self.assertFormError(response, 'form', 'expire_at', "Go live date/time must be before expiry date/time")
 
+        # form should be marked as having unsaved changes for the purposes of the dirty-forms warning
+        self.assertContains(response, "alwaysDirty: true")
+
     def test_create_simplepage_scheduled_expire_in_the_past(self):
         post_data = {
             'title': "New page!",
@@ -569,6 +572,9 @@ class TestPageCreation(TestCase, WagtailTestUtils):
 
         # Check that a form error was raised
         self.assertFormError(response, 'form', 'expire_at', "Expiry date/time must be in the future")
+
+        # form should be marked as having unsaved changes for the purposes of the dirty-forms warning
+        self.assertContains(response, "alwaysDirty: true")
 
     def test_create_simplepage_post_publish(self):
         # Connect a mock signal handler to page_published signal
@@ -696,6 +702,9 @@ class TestPageCreation(TestCase, WagtailTestUtils):
 
         # Check that a form error was raised
         self.assertFormError(response, 'form', 'slug', "This slug is already in use")
+
+        # form should be marked as having unsaved changes for the purposes of the dirty-forms warning
+        self.assertContains(response, "alwaysDirty: true")
 
     def test_create_nonexistantparent(self):
         response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', 100000)))
@@ -1042,6 +1051,9 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         self.assertFormError(response, 'form', 'go_live_at', "Go live date/time must be before expiry date/time")
         self.assertFormError(response, 'form', 'expire_at', "Go live date/time must be before expiry date/time")
 
+        # form should be marked as having unsaved changes for the purposes of the dirty-forms warning
+        self.assertContains(response, "alwaysDirty: true")
+
     def test_edit_scheduled_expire_in_the_past(self):
         post_data = {
             'title': "I've been edited!",
@@ -1055,6 +1067,9 @@ class TestPageEdit(TestCase, WagtailTestUtils):
 
         # Check that a form error was raised
         self.assertFormError(response, 'form', 'expire_at', "Expiry date/time must be in the future")
+
+        # form should be marked as having unsaved changes for the purposes of the dirty-forms warning
+        self.assertContains(response, "alwaysDirty: true")
 
     def test_page_edit_post_publish(self):
         # Connect a mock signal handler to page_published signal
@@ -2847,6 +2862,27 @@ class TestChildRelationsOnSuperclass(TestCase, WagtailTestUtils):
         self.assertEqual(page.advert_placements.count(), 1)
         self.assertEqual(page.advert_placements.first().advert.text, 'test_advert')
 
+    def test_post_create_form_with_validation_error_in_formset(self):
+        post_data = {
+            'title': "New index!",
+            'slug': 'new-index',
+            'advert_placements-TOTAL_FORMS': '1',
+            'advert_placements-INITIAL_FORMS': '0',
+            'advert_placements-MAX_NUM_FORMS': '1000',
+            'advert_placements-0-advert': '1',
+            'advert_placements-0-colour': '',  # should fail as colour is a required field
+            'advert_placements-0-id': '',
+        }
+        response = self.client.post(
+            reverse('wagtailadmin_pages:add', args=('tests', 'standardindex', self.root_page.id)), post_data
+        )
+
+        # Should remain on the edit page with a validation error
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "This field is required.")
+        # form should be marked as having unsaved changes
+        self.assertContains(response, "alwaysDirty: true")
+
     def test_get_edit_form(self):
         response = self.client.get(reverse('wagtailadmin_pages:edit', args=(self.index_page.id, )))
         self.assertEqual(response.status_code, 200)
@@ -2883,6 +2919,26 @@ class TestChildRelationsOnSuperclass(TestCase, WagtailTestUtils):
         self.assertEqual(page.advert_placements.count(), 2)
         self.assertEqual(page.advert_placements.all()[0].advert.text, 'test_advert')
         self.assertEqual(page.advert_placements.all()[1].advert.text, 'test_advert')
+
+    def test_post_edit_form_with_validation_error_in_formset(self):
+        post_data = {
+            'title': "My lovely index",
+            'slug': 'my-lovely-index',
+            'advert_placements-TOTAL_FORMS': '1',
+            'advert_placements-INITIAL_FORMS': '1',
+            'advert_placements-MAX_NUM_FORMS': '1000',
+            'advert_placements-0-advert': '1',
+            'advert_placements-0-colour': '',
+            'advert_placements-0-id': self.index_page.advert_placements.first().id,
+            'action-publish': "Publish",
+        }
+        response = self.client.post(reverse('wagtailadmin_pages:edit', args=(self.index_page.id, )), post_data)
+
+        # Should remain on the edit page with a validation error
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "This field is required.")
+        # form should be marked as having unsaved changes
+        self.assertContains(response, "alwaysDirty: true")
 
 
 class TestRevisions(TestCase, WagtailTestUtils):

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -254,10 +254,12 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
         else:
             messages.error(request, _("The page could not be created due to validation errors"))
             edit_handler = edit_handler_class(instance=page, form=form)
+            has_unsaved_changes = True
     else:
         signals.init_new_page.send(sender=create, page=page, parent=parent_page)
         form = form_class(instance=page)
         edit_handler = edit_handler_class(instance=page, form=form)
+        has_unsaved_changes = False
 
     return render(request, 'wagtailadmin/pages/create.html', {
         'content_type': content_type,
@@ -267,6 +269,7 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
         'preview_modes': page.preview_modes,
         'form': form,
         'next': next_url,
+        'has_unsaved_changes': has_unsaved_changes,
     })
 
 
@@ -446,9 +449,11 @@ def edit(request, page_id):
                     if formset.errors
                 ])
             )
+            has_unsaved_changes = True
     else:
         form = form_class(instance=page)
         edit_handler = edit_handler_class(instance=page, form=form)
+        has_unsaved_changes = False
 
     # Check for revisions still undergoing moderation and warn
     if latest_revision and latest_revision.submitted_for_moderation:
@@ -462,6 +467,7 @@ def edit(request, page_id):
         'preview_modes': page.preview_modes,
         'form': form,
         'next': next_url,
+        'has_unsaved_changes': has_unsaved_changes,
     })
 
 
@@ -528,6 +534,7 @@ def preview_on_edit(request, page_id):
             'edit_handler': edit_handler,
             'preview_modes': page.preview_modes,
             'form': form,
+            'has_unsaved_changes': True,
         })
         response['X-Wagtail-Preview'] = 'error'
         return response
@@ -590,6 +597,7 @@ def preview_on_create(request, content_type_app_name, content_type_model_name, p
             'edit_handler': edit_handler,
             'preview_modes': page.preview_modes,
             'form': form,
+            'has_unsaved_changes': True,
         })
         response['X-Wagtail-Preview'] = 'error'
         return response

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/list.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/list.html
@@ -36,7 +36,7 @@
                         <h2><a href="{% url 'wagtaildocs:edit' doc.id %}">{{ doc.title }}</a></h2>
                     {% endif %}
                 </td>
-                <td><a href="{{ doc.url }}" class="nolink">{{ doc.filename }}</a></td>
+                <td><a href="{{ doc.url }}" class="nolink" download>{{ doc.filename }}</a></td>
                 <td><div class="human-readable-date" title="{{ doc.created_at|date:"d M Y H:i" }}">{{ doc.created_at|timesince }} ago</div></td>
             </tr>
         {% endfor %}


### PR DESCRIPTION
Incorporates #2801 (fixes #2798), #2807 and #2808 (partially fixes #2513).

I noticed that @spmuck's approach in #2801 (listening to form submission actions rather than click events) allowed us to eliminate much of the old code, such as `ignoredButtonsSelector`. This also means that we're no longer relying on "which button/link triggered this event?" logic, which seems to be poorly standardised across browsers.

I had to make sure that I wasn't introducing any regressions by removing this code, so it made sense to fix (almost) all of the outstanding dirty forms issues, and put together the following checklist covering the expected behaviour and all past and current failing edge cases:

* Browsing away (e.g. clicking 'Images') without making any changes SHOULD NOT trigger the message
* Making a change then browsing away SHOULD trigger the message
* Making a change then clicking 'Save' SHOULD NOT trigger the message
* Making a change then pressing Cmd+S (with no input field focused) SHOULD NOT trigger the message
* Making a change then pressing enter SHOULD NOT trigger the message
* Making a change then clicking 'Preview' SHOULD NOT trigger the message; subsequently browsing away SHOULD trigger the message
* Making a change then pressing Cmd+P (with no input field focused) SHOULD NOT trigger the message
	(NB: may require allowing popups)
* Making a change that fails server-side validation (e.g. blanking a required field in a formset, or entering an expiry date before the go-live date), clicking 'Save', then browsing away SHOULD trigger the message
* Making a change that fails server-side validation then clicking 'Preview' SHOULD NOT trigger the message; subsequently browsing away SHOULD trigger the message
* Making a change that fails client-side validation (e.g. entering an invalid email into an EmailField), clicking 'Save', then browsing away SHOULD trigger the message
* Making a change that fails client-side validation then clicking 'Preview' SHOULD NOT trigger the message; subsequently browsing away SHOULD trigger the message
* Making a change, then opening the document chooser popup and clicking a download link SHOULD NOT trigger the message

These now succeed on Chrome 51, Firefox 47, IE 11 and Safari 9.1 with the following exceptions:

* Safari's onbeforeunload support somewhat broken as per https://github.com/torchbox/wagtail/pull/2793#issuecomment-229948331, and had to be tested by manually adding a cache-busting URL parameter to the URL each time. On the plus side, this bug only causes false negatives (not showing the warning when it should be shown), which are not nearly as bad as false positives...
* Safari does not support client-side validation on input fields such as `<input type="email">`, so these are validated server-side (i.e. those tests just duplicate the two tests above, and still pass)
* IE and Safari fail on document download links (#2513), due to not supporting the `download` attribute.

Unfortunately, removing the `ignoredButtonsSelector` closes off one possible avenue of fixing #2513 on IE and Safari - see #2535. However, I believe this is a fairly obscure bug, affecting minority browsers (I believe Edge is unaffected, but can't currently test this), and I think that leaving these unfixed is a better alternative than relying on the inherently unreliable button-detection code.