### PR TITLE
Fix version number regression

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -364,6 +364,10 @@ body.explorer-open {
             }
         }
 
+        .footer {
+            position: absolute;
+        }
+
     }
 
     li.submenu-active {


### PR DESCRIPTION
As described in issue #2802, the version number made the account / logout items unclickable.
Turns out the wagtail-version was inheriting styles from that component, but position fixed is conflicting with the submenu due to css transform in combination with z-index of the menu (500) vs menu footer (2).
Targeting the submenu's footer and setting it to absolute positioning fixes this.

Re-tested in: IE9, IE10, IE11, Edge, Chrome (latest), Firefox ESR (v45), iOS9, Safari 9.1.1.