### PR TITLE
Inherit relevant border-radius from the parent

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -309,6 +309,8 @@ input[type=checkbox]:checked:before {
             text-align: center;
             background-color: rgba(0, 0, 0, 0.2);
             display: block;
+            border-top-left-radius: inherit;
+            border-bottom-left-radius: inherit;
         }
     }
 


### PR DESCRIPTION
Fixes #2818 

Turns the `:before` did not inherit its parent border-radius. So the small grey is actually the square / rectangle element with its alpha channel on `0.2`. I've made it inherit its parent radius, because it can also be the case that the parent doesn't have a border-radius.

Normally `overflow: hidden` would fix this for children, but it doesn't seem to make a difference.