### PR TITLE
Makes notes for wagtail.contrib.settings more visible

### DIFF
--- a/docs/reference/contrib/settings.rst
+++ b/docs/reference/contrib/settings.rst
@@ -118,7 +118,7 @@ Then access the settings through ``{{ settings }}``:
 
     {{ settings.app_label.SocialMediaSettings.instagram }}
 
-(Replace ``app_label`` with the label of the app containing your settings model.)
+.. note:: Replace ``app_label`` with the label of the app containing your settings model.
 
 If you are not in a ``RequestContext``, then context processors will not have run, and the ``settings`` variable will not be availble. To get the ``settings``, use the provided ``{% get_settings %}`` template tag. If a ``request`` is in the template context, but for some reason it is not a ``RequestContext``, just use ``{% get_settings %}``:
 
@@ -168,7 +168,7 @@ Then access the settings through the ``settings()`` template function:
 
     {{ settings("app_label.SocialMediaSettings").twitter }}
 
-(Replace ``app_label`` with the label of the app containing your settings model.)
+.. note:: Replace ``app_label`` with the label of the app containing your settings model.
 
 This will look for a ``request`` variable in the template context, and find the correct site to use from that. If for some reason you do not have a ``request`` available, you can instead use the settings defined for the default site:
 


### PR DESCRIPTION
I've seen a lot of questions related to this documentation section. I hope this PR will help focus attention.

Before:
<img width="717" alt="screen shot 2016-07-06 at 18 50 07" src="https://cloud.githubusercontent.com/assets/509198/16624998/8ae69b8a-43ab-11e6-8cc1-2708e410b1ec.png">

After:
<img width="712" alt="screen shot 2016-07-06 at 18 57 38" src="https://cloud.githubusercontent.com/assets/509198/16624999/8f209c8c-43ab-11e6-9625-7b2316a6fa07.png">
