### PR TITLE
Eliminate Django 2.0 deprecation warnings for on_delete, is_anonymous, is_authenticated

### DIFF
--- a/wagtail/tests/demosite/models.py
+++ b/wagtail/tests/demosite/models.py
@@ -26,13 +26,15 @@ class AbstractLinkFields(models.Model):
         'wagtailcore.Page',
         null=True,
         blank=True,
-        related_name='+'
+        related_name='+',
+        on_delete=models.CASCADE
     )
     link_document = models.ForeignKey(
         'wagtaildocs.Document',
         null=True,
         blank=True,
-        related_name='+'
+        related_name='+',
+        on_delete=models.CASCADE
     )
 
     @property
@@ -137,7 +139,7 @@ class ContactFieldsMixin(models.Model):
 # Home page
 
 class HomePage(Page):
-    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+')
+    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+', on_delete=models.CASCADE)
     body = RichTextField(blank=True)
 
     api_fields = (
@@ -155,11 +157,11 @@ class HomePage(Page):
 
 
 class HomePageCarouselItem(Orderable, AbstractCarouselItem):
-    page = ParentalKey('HomePage', related_name='carousel_items')
+    page = ParentalKey('HomePage', related_name='carousel_items', on_delete=models.CASCADE)
 
 
 class HomePageRelatedLink(Orderable, AbstractRelatedLink):
-    page = ParentalKey('HomePage', related_name='related_links')
+    page = ParentalKey('HomePage', related_name='related_links', on_delete=models.CASCADE)
 
 
 HomePage.content_panels = Page.content_panels + [
@@ -173,7 +175,7 @@ HomePage.content_panels = Page.content_panels + [
 # Standard pages
 
 class StandardPage(Page):
-    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+')
+    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+', on_delete=models.CASCADE)
     intro = RichTextField(blank=True)
     body = RichTextField(blank=True)
     feed_image = models.ForeignKey(
@@ -199,11 +201,11 @@ class StandardPage(Page):
 
 
 class StandardPageCarouselItem(Orderable, AbstractCarouselItem):
-    page = ParentalKey('StandardPage', related_name='carousel_items')
+    page = ParentalKey('StandardPage', related_name='carousel_items', on_delete=models.CASCADE)
 
 
 class StandardPageRelatedLink(Orderable, AbstractRelatedLink):
-    page = ParentalKey('StandardPage', related_name='related_links')
+    page = ParentalKey('StandardPage', related_name='related_links', on_delete=models.CASCADE)
 
 
 StandardPage.content_panels = Page.content_panels + [
@@ -221,7 +223,7 @@ StandardPage.promote_panels = [
 
 
 class StandardIndexPage(Page):
-    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+')
+    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+', on_delete=models.CASCADE)
     intro = RichTextField(blank=True)
     feed_image = models.ForeignKey(
         'wagtailimages.Image',
@@ -243,7 +245,7 @@ class StandardIndexPage(Page):
 
 
 class StandardIndexPageRelatedLink(Orderable, AbstractRelatedLink):
-    page = ParentalKey('StandardIndexPage', related_name='related_links')
+    page = ParentalKey('StandardIndexPage', related_name='related_links', on_delete=models.CASCADE)
 
 
 StandardIndexPage.content_panels = Page.content_panels + [
@@ -261,7 +263,7 @@ StandardIndexPage.promote_panels = [
 # Blog pages
 
 class BlogEntryPage(Page):
-    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+')
+    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+', on_delete=models.CASCADE)
     body = RichTextField()
     tags = ClusterTaggableManager(through='BlogEntryPageTag', blank=True)
     date = models.DateField("Post date")
@@ -292,15 +294,15 @@ class BlogEntryPage(Page):
 
 
 class BlogEntryPageCarouselItem(Orderable, AbstractCarouselItem):
-    page = ParentalKey('BlogEntryPage', related_name='carousel_items')
+    page = ParentalKey('BlogEntryPage', related_name='carousel_items', on_delete=models.CASCADE)
 
 
 class BlogEntryPageRelatedLink(Orderable, AbstractRelatedLink):
-    page = ParentalKey('BlogEntryPage', related_name='related_links')
+    page = ParentalKey('BlogEntryPage', related_name='related_links', on_delete=models.CASCADE)
 
 
 class BlogEntryPageTag(TaggedItemBase):
-    content_object = ParentalKey('BlogEntryPage', related_name='tagged_items')
+    content_object = ParentalKey('BlogEntryPage', related_name='tagged_items', on_delete=models.CASCADE)
 
 
 BlogEntryPage.content_panels = Page.content_panels + [
@@ -319,7 +321,7 @@ BlogEntryPage.promote_panels = [
 
 
 class BlogIndexPage(Page):
-    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+')
+    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+', on_delete=models.CASCADE)
     intro = RichTextField(blank=True)
 
     api_fields = (
@@ -358,7 +360,7 @@ class BlogIndexPage(Page):
 
 
 class BlogIndexPageRelatedLink(Orderable, AbstractRelatedLink):
-    page = ParentalKey('BlogIndexPage', related_name='related_links')
+    page = ParentalKey('BlogIndexPage', related_name='related_links', on_delete=models.CASCADE)
 
 
 BlogIndexPage.content_panels = Page.content_panels + [
@@ -370,7 +372,7 @@ BlogIndexPage.content_panels = Page.content_panels + [
 # Events pages
 
 class EventPage(Page):
-    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+')
+    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+', on_delete=models.CASCADE)
     AUDIENCE_CHOICES = (
         ('public', "Public"),
         ('private', "Private"),
@@ -426,15 +428,15 @@ class EventPage(Page):
 
 
 class EventPageCarouselItem(Orderable, AbstractCarouselItem):
-    page = ParentalKey('EventPage', related_name='carousel_items')
+    page = ParentalKey('EventPage', related_name='carousel_items', on_delete=models.CASCADE)
 
 
 class EventPageRelatedLink(Orderable, AbstractRelatedLink):
-    page = ParentalKey('EventPage', related_name='related_links')
+    page = ParentalKey('EventPage', related_name='related_links', on_delete=models.CASCADE)
 
 
 class EventPageSpeaker(Orderable, AbstractLinkFields):
-    page = ParentalKey('EventPage', related_name='speakers')
+    page = ParentalKey('EventPage', related_name='speakers', on_delete=models.CASCADE)
     first_name = models.CharField("Name", max_length=255, blank=True)
     last_name = models.CharField("Surname", max_length=255, blank=True)
     image = models.ForeignKey(
@@ -481,7 +483,7 @@ EventPage.promote_panels = [
 
 
 class EventIndexPage(Page):
-    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+')
+    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+', on_delete=models.CASCADE)
     intro = RichTextField(blank=True)
 
     api_fields = (
@@ -508,7 +510,7 @@ class EventIndexPage(Page):
 
 
 class EventIndexPageRelatedLink(Orderable, AbstractRelatedLink):
-    page = ParentalKey('EventIndexPage', related_name='related_links')
+    page = ParentalKey('EventIndexPage', related_name='related_links', on_delete=models.CASCADE)
 
 
 EventIndexPage.content_panels = Page.content_panels + [
@@ -520,7 +522,7 @@ EventIndexPage.content_panels = Page.content_panels + [
 # Person page
 
 class PersonPage(Page, ContactFieldsMixin):
-    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+')
+    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+', on_delete=models.CASCADE)
     first_name = models.CharField(max_length=255)
     last_name = models.CharField(max_length=255)
     intro = RichTextField(blank=True)
@@ -559,7 +561,7 @@ class PersonPage(Page, ContactFieldsMixin):
 
 
 class PersonPageRelatedLink(Orderable, AbstractRelatedLink):
-    page = ParentalKey('PersonPage', related_name='related_links')
+    page = ParentalKey('PersonPage', related_name='related_links', on_delete=models.CASCADE)
 
 
 PersonPage.content_panels = Page.content_panels + [
@@ -582,7 +584,7 @@ PersonPage.promote_panels = [
 # Contact page
 
 class ContactPage(Page, ContactFieldsMixin):
-    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+')
+    page_ptr = models.OneToOneField(Page, parent_link=True, related_name='+', on_delete=models.CASCADE)
     body = RichTextField(blank=True)
     feed_image = models.ForeignKey(
         'wagtailimages.Image',

--- a/wagtail/tests/search/migrations/0001_initial.py
+++ b/wagtail/tests/search/migrations/0001_initial.py
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
                 ('searchtest_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='searchtests.SearchTest')),
                 ('subtitle', models.CharField(blank=True, max_length=255, null=True)),
                 ('extra_content', models.TextField()),
-                ('page', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='wagtailcore.Page')),
+                ('page', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='wagtailcore.Page')),
             ],
             bases=('searchtests.searchtest',),
         ),

--- a/wagtail/tests/search/models.py
+++ b/wagtail/tests/search/models.py
@@ -58,7 +58,7 @@ class SearchTest(index.Indexed, models.Model):
 class SearchTestChild(SearchTest):
     subtitle = models.CharField(max_length=255, null=True, blank=True)
     extra_content = models.TextField()
-    page = models.ForeignKey('wagtailcore.Page', null=True, blank=True)
+    page = models.ForeignKey('wagtailcore.Page', null=True, blank=True, on_delete=models.SET_NULL)
 
     search_fields = SearchTest.search_fields + [
         index.SearchField('subtitle', partial_match=True),

--- a/wagtail/tests/snippets/migrations/0005_multisectionrichtextsnippet_richtextsection.py
+++ b/wagtail/tests/snippets/migrations/0005_multisectionrichtextsnippet_richtextsection.py
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, serialize=False, verbose_name='ID', auto_created=True)),
                 ('body', wagtail.wagtailcore.fields.RichTextField()),
-                ('snippet', modelcluster.fields.ParentalKey(to='snippetstests.MultiSectionRichTextSnippet', related_name='sections')),
+                ('snippet', modelcluster.fields.ParentalKey(to='snippetstests.MultiSectionRichTextSnippet', related_name='sections', on_delete=models.CASCADE)),
             ],
         ),
     ]

--- a/wagtail/tests/snippets/models.py
+++ b/wagtail/tests/snippets/models.py
@@ -78,7 +78,7 @@ class FileUploadSnippet(models.Model):
 
 
 class RichTextSection(models.Model):
-    snippet = ParentalKey('MultiSectionRichTextSnippet', related_name='sections')
+    snippet = ParentalKey('MultiSectionRichTextSnippet', related_name='sections', on_delete=models.CASCADE)
     body = RichTextField()
 
     panels = [

--- a/wagtail/tests/testapp/migrations/0006_sectionedrichtextpage_sectionedrichtextpagesection.py
+++ b/wagtail/tests/testapp/migrations/0006_sectionedrichtextpage_sectionedrichtextpagesection.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='SectionedRichTextPage',
             fields=[
-                ('page_ptr', models.OneToOneField(parent_link=True, to='wagtailcore.Page', serialize=False, auto_created=True, primary_key=True)),
+                ('page_ptr', models.OneToOneField(parent_link=True, to='wagtailcore.Page', serialize=False, auto_created=True, primary_key=True, on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', primary_key=True, serialize=False, auto_created=True)),
                 ('sort_order', models.IntegerField(editable=False, null=True, blank=True)),
                 ('body', wagtail.wagtailcore.fields.RichTextField()),
-                ('page', modelcluster.fields.ParentalKey(related_name='sections', to='tests.SectionedRichTextPage')),
+                ('page', modelcluster.fields.ParentalKey(related_name='sections', to='tests.SectionedRichTextPage', on_delete=models.CASCADE)),
             ],
             options={
                 'ordering': ['sort_order'],

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -55,13 +55,15 @@ class LinkFields(models.Model):
         'wagtailcore.Page',
         null=True,
         blank=True,
-        related_name='+'
+        related_name='+',
+        on_delete=models.CASCADE
     )
     link_document = models.ForeignKey(
         'wagtaildocs.Document',
         null=True,
         blank=True,
-        related_name='+'
+        related_name='+',
+        on_delete=models.CASCADE
     )
 
     @property
@@ -158,15 +160,15 @@ FilePage.content_panels = [
 # Event page
 
 class EventPageCarouselItem(Orderable, CarouselItem):
-    page = ParentalKey('tests.EventPage', related_name='carousel_items')
+    page = ParentalKey('tests.EventPage', related_name='carousel_items', on_delete=models.CASCADE)
 
 
 class EventPageRelatedLink(Orderable, RelatedLink):
-    page = ParentalKey('tests.EventPage', related_name='related_links')
+    page = ParentalKey('tests.EventPage', related_name='related_links', on_delete=models.CASCADE)
 
 
 class EventPageSpeaker(Orderable, LinkFields):
-    page = ParentalKey('tests.EventPage', related_name='speakers')
+    page = ParentalKey('tests.EventPage', related_name='speakers', on_delete=models.CASCADE)
     first_name = models.CharField("Name", max_length=255, blank=True)
     last_name = models.CharField("Surname", max_length=255, blank=True)
     image = models.ForeignKey(
@@ -334,7 +336,7 @@ EventIndex.content_panels = [
 
 
 class FormField(AbstractFormField):
-    page = ParentalKey('FormPage', related_name='form_fields')
+    page = ParentalKey('FormPage', related_name='form_fields', on_delete=models.CASCADE)
 
 
 class FormPage(AbstractEmailForm):
@@ -357,7 +359,7 @@ FormPage.content_panels = [
 # FormPage with a non-HTML extension
 
 class JadeFormField(AbstractFormField):
-    page = ParentalKey('JadeFormPage', related_name='form_fields')
+    page = ParentalKey('JadeFormPage', related_name='form_fields', on_delete=models.CASCADE)
 
 
 class JadeFormPage(AbstractEmailForm):
@@ -376,13 +378,13 @@ JadeFormPage.content_panels = [
 
 # Snippets
 class AdvertPlacement(models.Model):
-    page = ParentalKey('wagtailcore.Page', related_name='advert_placements')
-    advert = models.ForeignKey('tests.Advert', related_name='+')
+    page = ParentalKey('wagtailcore.Page', related_name='advert_placements', on_delete=models.CASCADE)
+    advert = models.ForeignKey('tests.Advert', related_name='+', on_delete=models.CASCADE)
     colour = models.CharField(max_length=255)
 
 
 class AdvertTag(TaggedItemBase):
-    content_object = ParentalKey('Advert', related_name='tagged_items')
+    content_object = ParentalKey('Advert', related_name='tagged_items', on_delete=models.CASCADE)
 
 
 @python_2_unicode_compatible
@@ -486,7 +488,7 @@ class BusinessNowherePage(Page):
 
 
 class TaggedPageTag(TaggedItemBase):
-    content_object = ParentalKey('tests.TaggedPage', related_name='tagged_items')
+    content_object = ParentalKey('tests.TaggedPage', related_name='tagged_items', on_delete=models.CASCADE)
 
 
 class TaggedPage(Page):
@@ -507,15 +509,15 @@ class SingletonPage(Page):
 
 
 class PageChooserModel(models.Model):
-    page = models.ForeignKey('wagtailcore.Page', help_text='help text')
+    page = models.ForeignKey('wagtailcore.Page', help_text='help text', on_delete=models.CASCADE)
 
 
 class EventPageChooserModel(models.Model):
-    page = models.ForeignKey('tests.EventPage', help_text='more help text')
+    page = models.ForeignKey('tests.EventPage', help_text='more help text', on_delete=models.CASCADE)
 
 
 class SnippetChooserModel(models.Model):
-    advert = models.ForeignKey(Advert, help_text='help text')
+    advert = models.ForeignKey(Advert, help_text='help text', on_delete=models.CASCADE)
 
     panels = [
         SnippetChooserPanel('advert'),
@@ -596,8 +598,8 @@ class BlogCategory(models.Model):
 
 
 class BlogCategoryBlogPage(models.Model):
-    category = models.ForeignKey(BlogCategory, related_name="+")
-    page = ParentalKey('ManyToManyBlogPage', related_name='categories')
+    category = models.ForeignKey(BlogCategory, related_name="+", on_delete=models.CASCADE)
+    page = ParentalKey('ManyToManyBlogPage', related_name='categories', on_delete=models.CASCADE)
     panels = [
         FieldPanel('category'),
     ]
@@ -621,7 +623,7 @@ class OneToOnePage(Page):
     """
     body = RichTextBlock(blank=True)
     page_ptr = models.OneToOneField(Page, parent_link=True,
-                                    related_name='+')
+                                    related_name='+', on_delete=models.CASCADE)
 
 
 class GenericSnippetPage(Page):
@@ -738,7 +740,7 @@ class CustomRichBlockFieldPage(Page):
 # a page that only contains RichTextField within an InlinePanel,
 # to test that the inline child's form media gets pulled through
 class SectionedRichTextPageSection(Orderable):
-    page = ParentalKey('tests.SectionedRichTextPage', related_name='sections')
+    page = ParentalKey('tests.SectionedRichTextPage', related_name='sections', on_delete=models.CASCADE)
     body = RichTextField()
 
     panels = [

--- a/wagtail/utils/compat.py
+++ b/wagtail/utils/compat.py
@@ -1,1 +1,17 @@
 from __future__ import absolute_import, unicode_literals
+
+import django
+
+
+def user_is_authenticated(user):
+    if django.VERSION >= (1, 10):
+        return user.is_authenticated
+    else:
+        return user.is_authenticated()
+
+
+def user_is_anonymous(user):
+    if django.VERSION >= (1, 10):
+        return user.is_anonymous
+    else:
+        return user.is_anonymous()

--- a/wagtail/wagtailadmin/decorators.py
+++ b/wagtail/wagtailadmin/decorators.py
@@ -4,6 +4,7 @@ from django.contrib.auth.views import redirect_to_login as auth_redirect_to_logi
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
+from wagtail.utils.compat import user_is_anonymous
 from wagtail.wagtailadmin import messages
 
 
@@ -16,7 +17,7 @@ def require_admin_access(view_func):
     def decorated_view(request, *args, **kwargs):
         user = request.user
 
-        if user.is_anonymous():
+        if user_is_anonymous(user):
             return redirect_to_login(request)
 
         if user.has_perms(['wagtailadmin.access_admin']):

--- a/wagtail/wagtailadmin/views/account.py
+++ b/wagtail/wagtailadmin/views/account.py
@@ -13,6 +13,7 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.cache import never_cache
 from django.views.decorators.debug import sensitive_post_parameters
 
+from wagtail.utils.compat import user_is_authenticated
 from wagtail.wagtailadmin import forms
 from wagtail.wagtailcore.models import UserPagePermissionsProxy
 from wagtail.wagtailusers.forms import NotificationPreferencesForm
@@ -108,7 +109,7 @@ def notification_preferences(request):
 @sensitive_post_parameters()
 @never_cache
 def login(request):
-    if request.user.is_authenticated() and request.user.has_perm('wagtailadmin.access_admin'):
+    if user_is_authenticated(request.user) and request.user.has_perm('wagtailadmin.access_admin'):
         return redirect('wagtailadmin_home')
     else:
         from django.contrib.auth import get_user_model

--- a/wagtail/wagtailcore/permission_policies/base.py
+++ b/wagtail/wagtailcore/permission_policies/base.py
@@ -7,6 +7,8 @@ from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.db.models import Q
 from django.utils.functional import cached_property
 
+from wagtail.utils.compat import user_is_authenticated
+
 
 class BasePermissionPolicy(object):
     """
@@ -149,10 +151,10 @@ class AuthenticationOnlyPermissionPolicy(BasePermissionPolicy):
     full permission over the given model
     """
     def user_has_permission(self, user, action):
-        return user.is_authenticated() and user.is_active
+        return user_is_authenticated(user) and user.is_active
 
     def user_has_any_permission(self, user, actions):
-        return user.is_authenticated() and user.is_active
+        return user_is_authenticated(user) and user.is_active
 
     def users_with_any_permission(self, actions):
         return get_user_model().objects.filter(is_active=True)

--- a/wagtail/wagtailcore/permission_policies/collections.py
+++ b/wagtail/wagtailcore/permission_policies/collections.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import Group, Permission
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.db.models import Q
 
+from wagtail.utils.compat import user_is_authenticated
 from wagtail.wagtailcore.models import Collection, GroupCollectionPermission
 
 from .base import BaseDjangoAuthPermissionPolicy
@@ -28,7 +29,7 @@ class CollectionPermissionLookupMixin(object):
         If collection is specified, only consider GroupCollectionPermission records
         that apply to that collection.
         """
-        if not (user.is_active and user.is_authenticated()):
+        if not (user.is_active and user_is_authenticated(user)):
             return False
 
         if user.is_superuser:
@@ -164,7 +165,7 @@ class CollectionPermissionPolicy(CollectionPermissionLookupMixin, BaseDjangoAuth
         Return a queryset of all instances of this model for which the given user has
         permission to perform any of the given actions
         """
-        if not (user.is_active and user.is_authenticated()):
+        if not (user.is_active and user_is_authenticated(user)):
             return self.model.objects.none()
         elif user.is_superuser:
             return self.model.objects.all()
@@ -191,7 +192,7 @@ class CollectionPermissionPolicy(CollectionPermissionLookupMixin, BaseDjangoAuth
             # in any collection
             return Collection.objects.all()
 
-        elif not user.is_authenticated():
+        elif not user_is_authenticated(user):
             return Collection.objects.none()
 
         else:
@@ -274,7 +275,7 @@ class CollectionOwnershipPermissionPolicy(
             # active superusers can perform any action (including unrecognised ones)
             # on any instance
             return self.model.objects.all()
-        elif not user.is_authenticated():
+        elif not user_is_authenticated(user):
             return self.model.objects.none()
         elif 'change' in actions or 'delete' in actions:
             # return instances which are:
@@ -332,7 +333,7 @@ class CollectionOwnershipPermissionPolicy(
             # in any collection
             return Collection.objects.all()
 
-        elif not user.is_authenticated():
+        elif not user_is_authenticated(user):
             return Collection.objects.none()
 
         elif 'change' in actions or 'delete' in actions:

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -512,7 +512,7 @@ class AbstractRendition(models.Model):
 
 
 class Rendition(AbstractRendition):
-    image = models.ForeignKey(Image, related_name='renditions')
+    image = models.ForeignKey(Image, related_name='renditions', on_delete=models.CASCADE)
 
     class Meta:
         unique_together = (


### PR DESCRIPTION
Because test runs are currently quite noisy, and there's no harm in getting this in early...

Added `on_delete` to model fields that are currently missing, and added compatibility shims for `user.is_anonymous` and `user.is_authenticated` (which should now be accessed as attributes rather than methods).