### PR TITLE
Pin html5lib to 0.999999

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
     "djangorestframework>=3.1.3",
     "Pillow>=2.6.1",
     "beautifulsoup4>=4.3.2",
-    "html5lib>=0.999,<1",
+    "html5lib==0.999999",
     "Unidecode>=0.04.14",
     "Willow>=0.3b4,<0.4",
 ]


### PR DESCRIPTION
Temporary fix for issue in html5lib update causing beautifulsoup4 (bs4) to raise an error, meaning wagtail tests fail in master, 1.5.x and 1.4.x, haven't tested before that yet.

A new version of html5lib was released, 0.99999999, and this release seems to be causing an error. The error seems to be being raised within beautifulsoup4 (bs4). It seems a bug report or fix for it is yet to be logged/pushed for bs4.

```
  File "/vagrant/repos/wagtail/wagtail/tests/testapp/models.py", line 22, in <module>
    from wagtail.wagtailcore.blocks import CharBlock, RichTextBlock
  File "/vagrant/repos/wagtail/wagtail/wagtailcore/blocks/__init__.py", line 5, in <module>
    from .field_block import *  # NOQA
  File "/vagrant/repos/wagtail/wagtail/wagtailcore/blocks/field_block.py", line 15, in <module>
    from wagtail.wagtailcore.rich_text import RichText
  File "/vagrant/repos/wagtail/wagtail/wagtailcore/rich_text.py", line 11, in <module>
    from wagtail.wagtailcore.whitelist import Whitelister
  File "/vagrant/repos/wagtail/wagtail/wagtailcore/whitelist.py", line 9, in <module>
    from bs4 import BeautifulSoup, Comment, NavigableString, Tag
  File "/home/vagrant/venv/lib/python3.4/site-packages/bs4/__init__.py", line 30, in <module>
    from .builder import builder_registry, ParserRejectedMarkup
  File "/home/vagrant/venv/lib/python3.4/site-packages/bs4/builder/__init__.py", line 314, in <module>
    from . import _html5lib
  File "/home/vagrant/venv/lib/python3.4/site-packages/bs4/builder/_html5lib.py", line 70, in <module>
    class TreeBuilderForHtml5lib(html5lib.treebuilders._base.TreeBuilder):
AttributeError: 'module' object has no attribute '_base'
```