### PR TITLE
Fixed search tests

### DIFF
--- a/wagtail/wagtailsearch/tests/test_indexed_class.py
+++ b/wagtail/wagtailsearch/tests/test_indexed_class.py
@@ -1,10 +1,24 @@
 from __future__ import absolute_import, unicode_literals
 
+from contextlib import contextmanager
+
 from django.core import checks
 from django.test import TestCase
 
 from wagtail.tests.search import models
 from wagtail.wagtailsearch import index
+
+
+@contextmanager
+def patch_search_fields(model, new_search_fields):
+    """
+    A context manager to allow testing of different search_fields configurations
+    without permanently changing the models' search_fields.
+    """
+    old_search_fields = model.search_fields
+    model.search_fields = new_search_fields
+    yield
+    model.search_fields = old_search_fields
 
 
 class TestContentTypeNames(TestCase):
@@ -71,12 +85,12 @@ class TestSearchFields(TestCase):
         self.assertEqual(len(cls.get_filterable_search_fields()), 1)
 
     def test_checking_search_fields(self):
-        models.SearchTest.search_fields += [index.SearchField('foo')]
-        expected_errors = [
-            checks.Warning(
-                "SearchTest.search_fields contains field 'foo' but it doesn't exist",
-                obj=models.SearchTest
-            )
-        ]
-        errors = models.SearchTest.check()
-        self.assertEqual(errors, expected_errors)
+        with patch_search_fields(models.SearchTest, models.SearchTest.search_fields + [index.SearchField('foo')]):
+            expected_errors = [
+                checks.Warning(
+                    "SearchTest.search_fields contains field 'foo' but it doesn't exist",
+                    obj=models.SearchTest
+                )
+            ]
+            errors = models.SearchTest.check()
+            self.assertEqual(errors, expected_errors)


### PR DESCRIPTION
A test was mutating the search_fields attribute of the SearchTest model causing subsequent tests that depended on the previous value to fail.