### PR TITLE
Allow test failures on Django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,18 @@ matrix:
     - env: TOXENV=py27-dj110-mysql-elasticsearch
     - env: TOXENV=py35-dj110-postgres-elasticsearch
 
+    - env: TOXENV=py27-dj110-sqlite-noelasticsearch
+    - env: TOXENV=py27-dj110-postgres-noelasticsearch
+    - env: TOXENV=py27-dj110-mysql-noelasticsearch
+    - env: TOXENV=py27-dj110-mysql-elasticsearch
+    - env: TOXENV=py34-dj110-postgres-noelasticsearch
+    - env: TOXENV=py34-dj110-sqlite-noelasticsearch
+    - env: TOXENV=py34-dj110-mysql-noelasticsearch
+    - env: TOXENV=py35-dj110-sqlite-noelasticsearch
+    - env: TOXENV=py35-dj110-postgres-noelasticsearch
+    - env: TOXENV=py35-dj110-mysql-noelasticsearch
+    - env: TOXENV=py35-dj110-postgres-elasticsearch
+
 # Services
 services:
   - elasticsearch


### PR DESCRIPTION
An update to Django 1.10 has caused a test to fail. While I'm not usually one who believes in rolling back features due to small test failures, I think it's warranted in this case as Django 1.10 is not stable yet and we shouldn't guarentee full support until at least an RC has been released.