### PR TITLE
Django 1.11: Added ALLOWED_HOSTS to a few tests

### DIFF
--- a/wagtail/contrib/settings/tests/test_admin.py
+++ b/wagtail/contrib/settings/tests/test_admin.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.core.urlresolvers import reverse
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils.text import capfirst
 
 from wagtail.contrib.settings.registry import SettingMenuItem
@@ -127,6 +127,7 @@ class TestSettingEditView(BaseTestSettingView):
         self.assertEqual(setting.email, 'test@example.com')
 
 
+@override_settings(ALLOWED_HOSTS=['testserver', 'example.com', 'noneoftheabove.example.com'])
 class TestMultiSite(BaseTestSettingView):
     def setUp(self):
         self.default_site = Site.objects.get(is_default_site=True)

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -84,6 +84,7 @@ class TestValidation(TestCase):
         self.assertTrue(Page.objects.filter(id=christmas_page.id).exists())
 
 
+@override_settings(ALLOWED_HOSTS=['localhost', 'events.example.com', 'about.example.com', 'unknown.site.com'])
 class TestSiteRouting(TestCase):
     fixtures = ['test.json']
 
@@ -377,6 +378,7 @@ class TestServeView(TestCase):
         response = self.client.get('/events/tentative-unpublished-event/')
         self.assertEqual(response.status_code, 404)
 
+    @override_settings(ALLOWED_HOSTS=['localhost', 'events.example.com'])
     def test_serve_with_multiple_sites(self):
         events_page = Page.objects.get(url_path='/home/events/')
         Site.objects.create(hostname='events.example.com', root_page=events_page)
@@ -1146,6 +1148,7 @@ class TestIssue2024(TestCase):
         self.assertEqual(event_index.content_type, ContentType.objects.get_for_model(Page))
 
 
+@override_settings(ALLOWED_HOSTS=['localhost'])
 class TestDummyRequest(TestCase):
     fixtures = ['test.json']
 

--- a/wagtail/wagtailcore/tests/test_sites.py
+++ b/wagtail/wagtailcore/tests/test_sites.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.core.exceptions import ValidationError
 from django.http.request import HttpRequest
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from wagtail.wagtailcore.models import Page, Site
 
@@ -58,6 +58,7 @@ class TestSiteNameDisplay(TestCase):
         self.assertEqual(site.__str__(), 'example.com:8080 [default]')
 
 
+@override_settings(ALLOWED_HOSTS=['example.com', 'unknown.com'])
 class TestFindSiteForRequest(TestCase):
     def setUp(self):
         self.default_site = Site.objects.get()

--- a/wagtail/wagtailredirects/tests.py
+++ b/wagtail/wagtailredirects/tests.py
@@ -1,13 +1,14 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.core.urlresolvers import reverse
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailcore.models import Page, Site
 from wagtail.wagtailredirects import models
 
 
+@override_settings(ALLOWED_HOSTS=['testserver', 'localhost', 'test.example.com', 'other.example.com'])
 class TestRedirects(TestCase):
     fixtures = ['test.json']
 


### PR DESCRIPTION
ALLOWED_HOSTS is now required in tests. See: https://github.com/django/django/commit/17e661641ddaf8266e7430d83cfb2039abc55df7