### PR TITLE
Fix for incorrect tag variable name in modeladmin

### DIFF
--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_row_value.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_row_value.html
@@ -7,5 +7,5 @@
         {% endfor %}
     </ul>
     {% endif %}
-    {{ item_closing_tag }}
+    {{ closing_tag }}
 {% endif %}


### PR DESCRIPTION
modeladmin's result_row_value.html template refers to item_closing_tag, but that should be closing_tag. 