### PR TITLE
Tweaks to the output of the update_index command

### DIFF
--- a/wagtail/wagtailsearch/management/commands/update_index.py
+++ b/wagtail/wagtailsearch/management/commands/update_index.py
@@ -80,19 +80,19 @@ class Command(BaseCommand):
             object_count = 0
             if not schema_only:
                 for model in models:
+                    self.stdout.write('{}: {}.{} '.format(backend_name, model._meta.app_label, model.__name__).ljust(35), ending='')
+
                     # Add items (1000 at a time)
                     for chunk in self.print_iter_progress(self.queryset_chunks(model.get_indexed_objects())):
                         index.add_items(model, chunk)
                         object_count += len(chunk)
 
-            self.print_newline()
+                    self.print_newline()
 
             # Finish rebuild
             rebuilder.finish()
 
-            self.print_newline()
-            self.stdout.write(backend_name + ": (indexed %d objects)" % object_count)
-            self.print_newline()
+            self.stdout.write(backend_name + ": indexed %d objects" % object_count)
             self.print_newline()
 
     def add_arguments(self, parser):
@@ -136,8 +136,9 @@ class Command(BaseCommand):
         for i, value in enumerate(iterable, start=1):
             yield value
             self.stdout.write('.', ending='')
-            if i % 50 == 0:
+            if i % 40 == 0:
                 self.print_newline()
+                self.stdout.write(' ' * 35, ending='')
 
             elif i % 10 == 0:
                 self.stdout.write(' ', ending='')


### PR DESCRIPTION
Since https://github.com/torchbox/wagtail/commit/23ee8c923b60126953eb67b6060e4cd51fec5445 the output of ``update_index`` changed to show the dots for all models in an index on the same line:
```
Updating backend: default
default: Rebuilding index wagtail
...........

default: (indexed 36 objects)
```

This is confusing because there are 11 dots, each representing a bulk index request containing up to 1000 objects and the message at the bottom says there are only 36 objects. It is unclear what data is being indexed.

This PR makes this clearer this by showing each model on a single line again:
```
Updating backend: default
default: Rebuilding index wagtail
default: wagtailcore.Page          .
default: wagtaildocs.Document      
default: wagtailimages.Image       .
default: demo.HomePage             .
default: demo.StandardIndexPage    .
default: demo.StandardPage         .
default: demo.BlogIndexPage        .
default: demo.BlogPage             .
default: demo.PersonPage           .
default: demo.ContactPage          .
default: demo.EventIndexPage       .
default: demo.EventPage            .
default: demo.FormPage             
default: indexed 36 objects
```

Here's how it looks when there are over 40k objects being indexed for a single model:

```
Updating backend: default
default: Rebuilding index wagtail
default: wagtailcore.Page          .
default: wagtaildocs.Document      
default: wagtailimages.Image       .......... .......... .......... ..........
                                   .......... .......... .......... ..........
                                   .......... .......... .......... ..........
default: demo.HomePage             .
default: demo.StandardIndexPage    .
default: demo.StandardPage         .
default: demo.BlogIndexPage        .
default: demo.BlogPage             .
default: demo.PersonPage           .
default: demo.ContactPage          .
default: demo.EventIndexPage       .
default: demo.EventPage            .
default: demo.FormPage             
default: indexed 120024 objects
```

And here's how it looks for Elasticsearch 2, which splits models up into separate indices:

```
Updating backend: default
default: Rebuilding index wagtail__wagtailcore_page
default: wagtailcore.Page          .
default: demo.HomePage             .
default: demo.StandardIndexPage    .
default: demo.StandardPage         .
default: demo.BlogIndexPage        .
default: demo.BlogPage             .
default: demo.PersonPage           .
default: demo.ContactPage          .
default: demo.EventIndexPage       .
default: demo.EventPage            .
default: demo.FormPage             
default: indexed 24 objects

default: Rebuilding index wagtail__wagtaildocs_document
default: wagtaildocs.Document      
default: indexed 0 objects

default: Rebuilding index wagtail__wagtailimages_image
default: wagtailimages.Image       .
default: indexed 12 objects
```