### PR TITLE
Add VERSION tuple to wagtail.wagtailcore

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -37,6 +37,6 @@ webpack
 
 ## How to release
 
-The front-end is bundled at the same time as the Wagtail project, via `setuptools`. You'll need to set the `__semver__` property to a npm-compliant version number in `wagtail.wagtailcore`.
+The front-end is bundled at the same time as the Wagtail project, via `setuptools`.
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,9 +29,6 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
 
-# Get Wagtail version
-from wagtail.wagtailcore import __version__
-
 # Autodoc may need to import some models modules which require django settings
 # be configured
 os.environ['DJANGO_SETTINGS_MODULE'] = 'wagtail.tests.settings'
@@ -76,9 +73,12 @@ copyright = u'2015, Torchbox'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-#
+
+# Get Wagtail version
+from wagtail.wagtailcore import __version__, VERSION
+
 # The short X.Y version.
-version = __version__
+version = '{}.{}'.format(VERSION[0], VERSION[1])
 # The full version, including alpha/beta/rc tags.
 release = __version__
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ copyright = u'2015, Torchbox'
 # built documents.
 
 # Get Wagtail version
-from wagtail.wagtailcore import __version__, VERSION
+from wagtail import __version__, VERSION
 
 # The short X.Y version.
 version = '{}.{}'.format(VERSION[0], VERSION[1])

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 import sys
 
-from wagtail.wagtailcore import __version__
+from wagtail import __version__
 from wagtail.utils.setup import assets, sdist, check_bdist_egg
 
 try:

--- a/wagtail/__init__.py
+++ b/wagtail/__init__.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import, unicode_literals
+
+from wagtail.utils.version import get_semver_version, get_version
+
+# major.minor.patch.release.number
+# release must be one of alpha, beta, rc, or final
+VERSION = (1, 7, 0, 'alpha', 0)
+
+__version__ = get_version(VERSION)
+
+# Required for npm package for frontend
+__semver__ = get_semver_version(VERSION)

--- a/wagtail/contrib/wagtailfrontendcache/backends.py
+++ b/wagtail/contrib/wagtailfrontendcache/backends.py
@@ -7,7 +7,7 @@ from django.utils.six.moves.urllib.error import HTTPError, URLError
 from django.utils.six.moves.urllib.parse import urlencode, urlparse, urlunparse
 from django.utils.six.moves.urllib.request import Request, urlopen
 
-from wagtail.wagtailcore import __version__
+from wagtail import __version__
 
 logger = logging.getLogger('wagtail.frontendcache')
 

--- a/wagtail/utils/setup.py
+++ b/wagtail/utils/setup.py
@@ -9,7 +9,7 @@ from setuptools import Command
 from setuptools.command.bdist_egg import bdist_egg
 from setuptools.command.sdist import sdist as base_sdist
 
-from wagtail.wagtailcore import __semver__
+from wagtail import __semver__
 
 
 class assets_mixin(object):

--- a/wagtail/utils/version.py
+++ b/wagtail/utils/version.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import, unicode_literals
+
+
+# This file is heavily inspired by django.utils.version
+
+
+def get_version(version):
+    "Returns a PEP 386-compliant version number from VERSION."
+    # Now build the two parts of the version number:
+    # main = X.Y[.Z]
+    # sub = .devN - for pre-alpha releases
+    #     | {a|b|c}N - for alpha, beta and rc releases
+
+    main = get_main_version(version)
+
+    sub = ''
+    if version[3] != 'final':
+        mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'c'}
+        sub = mapping[version[3]] + str(version[4])
+
+    return main + sub
+
+
+def get_main_version(version):
+    "Returns main version (X.Y[.Z]) from VERSION."
+    parts = 2 if version[2] == 0 else 3
+    return '.'.join(str(x) for x in version[:parts])
+
+
+def get_semver_version(version):
+    "Returns the semver version (X.Y.Z[-(alpha|beta)]) from VERSION"
+    main = '.'.join(str(x) for x in version[:3])
+
+    sub = ''
+    if version[3] != 'final':
+        sub = '-{}.{}'.format(*version[3:])
+    return main + sub

--- a/wagtail/wagtailcore/__init__.py
+++ b/wagtail/wagtailcore/__init__.py
@@ -1,15 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
-from wagtail.utils.version import get_semver_version, get_version
-
-# major.minor.patch.release.number
-# release must be one of alpha, beta, rc, or final
-VERSION = (1, 7, 0, 'alpha', 0)
-
-__version__ = get_version(VERSION)
-
-# Required for npm package for frontend
-__semver__ = get_semver_version(VERSION)
+# Imported for historical reasons
+from wagtail import __semver__, __version__  # noqa
 
 
 def setup():

--- a/wagtail/wagtailcore/__init__.py
+++ b/wagtail/wagtailcore/__init__.py
@@ -1,7 +1,15 @@
-__version__ = '1.7a0'
+from __future__ import absolute_import, unicode_literals
+
+from wagtail.utils.version import get_semver_version, get_version
+
+# major.minor.patch.release.number
+# release must be one of alpha, beta, rc, or final
+VERSION = (1, 7, 0, 'alpha', 0)
+
+__version__ = get_version(VERSION)
+
 # Required for npm package for frontend
-__semver__ = '1.7.0-alpha'
-default_app_config = 'wagtail.wagtailcore.apps.WagtailCoreAppConfig'
+__semver__ = get_semver_version(VERSION)
 
 
 def setup():

--- a/wagtail/wagtailcore/templatetags/wagtailcore_tags.py
+++ b/wagtail/wagtailcore/templatetags/wagtailcore_tags.py
@@ -5,7 +5,7 @@ from django.template.defaulttags import token_kwargs
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 
-from wagtail.wagtailcore import __version__
+from wagtail import __version__
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.rich_text import RichText, expand_db_html
 

--- a/wagtail/wagtailcore/tests/test_jinja2.py
+++ b/wagtail/wagtailcore/tests/test_jinja2.py
@@ -4,8 +4,9 @@ from django.template import engines
 from django.template.loader import render_to_string
 from django.test import TestCase
 
+from wagtail import __version__
 from wagtail.tests.testapp.blocks import SectionBlock
-from wagtail.wagtailcore import __version__, blocks
+from wagtail.wagtailcore import blocks
 from wagtail.wagtailcore.models import Page, Site
 
 


### PR DESCRIPTION
This allows people developing plugins for Wagtail to test the Wagtail version more easily, using code like:

```python
from wagtail.wagtailcore import VERSION
if VERSION >= (1, 5):
    # Do something
else:
    # Do the old thing
```

I also used the new version tuple in the docs to generate version numbers like `1.5` for all the `1.5.x` releases, which is how those version numbers are supposed to work. This means that `http://docs.wagtail.io/en/1.5/` will always point to the latest 1.5 release, regardless of the patch level of the `1.5` series. This will likely require some changes to the configuration on RTD though, so this change can come as a separate PR if you want to discuss it separately.