### PR TITLE
Disable browser validation for images and docs

### DIFF
--- a/wagtail/wagtaildocs/forms.py
+++ b/wagtail/wagtaildocs/forms.py
@@ -13,6 +13,7 @@ from wagtail.wagtaildocs.permissions import permission_policy as documents_permi
 
 class BaseDocumentForm(BaseCollectionMemberForm):
     permission_policy = documents_permission_policy
+    use_required_attribute = False
 
 
 def get_document_form(model):

--- a/wagtail/wagtailimages/forms.py
+++ b/wagtail/wagtailimages/forms.py
@@ -25,6 +25,7 @@ def formfield_for_dbfield(db_field, **kwargs):
 
 class BaseImageForm(BaseCollectionMemberForm):
     permission_policy = images_permission_policy
+    use_required_attribute = False
 
 
 def get_image_form(model):


### PR DESCRIPTION
Django 1.10 adds browser validation to all required fields by default. We don't need this behaviour for images and docs.

Note: there are other possible solutions. We can add a new form for an edit view that will define file field as not required.

Fixes #2897