### PR TITLE
ChoiceBlock should accept "include_blank=False"

### DIFF
--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -206,6 +206,9 @@ A dropdown select box for choosing from a list of choices. The following keyword
 ``help_text``
   Help text to display alongside the field.
 
+``include_blank`` (default: True)
+  If false, the blank choice (``---------``) will not be rendered.
+
 ``ChoiceBlock`` can also be subclassed to produce a reusable block with the same list of choices everywhere it is used. For example, a block definition such as:
 
 .. code-block:: python

--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -316,7 +316,7 @@ class ChoiceBlock(FieldBlock):
 
     choices = ()
 
-    def __init__(self, choices=None, required=True, help_text=None, **kwargs):
+    def __init__(self, choices=None, required=True, help_text=None, include_blank=True, **kwargs):
         if choices is None:
             # no choices specified, so pick up the choice list defined at the class level
             choices = list(self.choices)
@@ -334,21 +334,22 @@ class ChoiceBlock(FieldBlock):
         # If choices does not already contain a blank option, insert one
         # (to match Django's own behaviour for modelfields:
         # https://github.com/django/django/blob/1.7.5/django/db/models/fields/__init__.py#L732-744)
-        has_blank_choice = False
-        for v1, v2 in choices:
-            if isinstance(v2, (list, tuple)):
-                # this is a named group, and v2 is the value list
-                has_blank_choice = any([value in ('', None) for value, label in v2])
-                if has_blank_choice:
-                    break
-            else:
-                # this is an individual choice; v1 is the value
-                if v1 in ('', None):
-                    has_blank_choice = True
-                    break
-
-        if not has_blank_choice:
-            choices = BLANK_CHOICE_DASH + choices
+        if include_blank:
+            has_blank_choice = False
+            for v1, v2 in choices:
+                if isinstance(v2, (list, tuple)):
+                    # this is a named group, and v2 is the value list
+                    has_blank_choice = any([value in ('', None) for value, label in v2])
+                    if has_blank_choice:
+                        break
+                else:
+                    # this is an individual choice; v1 is the value
+                    if v1 in ('', None):
+                        has_blank_choice = True
+                        break
+    
+            if not has_blank_choice:
+                choices = BLANK_CHOICE_DASH + choices
 
         self.field = forms.ChoiceField(choices=choices, required=required, help_text=help_text)
         super(ChoiceBlock, self).__init__(**kwargs)

--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -347,7 +347,7 @@ class ChoiceBlock(FieldBlock):
                     if v1 in ('', None):
                         has_blank_choice = True
                         break
-    
+
             if not has_blank_choice:
                 choices = BLANK_CHOICE_DASH + choices
 

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -607,7 +607,7 @@ class TestChoiceBlock(unittest.TestCase):
             ('two', 'Two'),
         ])
         self.assertEqual(block.get_searchable_content('three'), [])
-    
+
     def test_no_blank_choice(self):
         block = blocks.ChoiceBlock(choices=[('tea', 'Tea'), ('coffee', 'Coffee')], include_blank=False)
         html = block.render_form('coffee', prefix='beverage')

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -607,6 +607,14 @@ class TestChoiceBlock(unittest.TestCase):
             ('two', 'Two'),
         ])
         self.assertEqual(block.get_searchable_content('three'), [])
+    
+    def test_no_blank_choice(self):
+        block = blocks.ChoiceBlock(choices=[('tea', 'Tea'), ('coffee', 'Coffee')], include_blank=False)
+        html = block.render_form('coffee', prefix='beverage')
+        self.assertIn('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertNotIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
+        self.assertIn('<option value="tea">Tea</option>', html)
+        self.assertIn('<option value="coffee" selected="selected">Coffee</option>', html)
 
 
 class TestRawHTMLBlock(unittest.TestCase):


### PR DESCRIPTION
Just like the referenced `modelfield`, ChoiceBlock should be able to NOT inlude a blank option.
