### PR TITLE
Update IntegerBlock docs to show correct kwargs

### DIFF
--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -103,7 +103,7 @@ IntegerBlock
 
 ``wagtail.wagtailcore.blocks.IntegerBlock``
 
-A single-line integer input that validates that the integer is a valid whole number. The keyword arguments ``required``, ``max_length``, ``min_length`` and ``help_text`` are accepted.
+A single-line integer input that validates that the integer is a valid whole number. The keyword arguments ``required``, ``max_value``, ``min_value`` and ``help_text`` are accepted.
 
 For an example of ``IntegerBlock`` in use, see :ref:`streamfield_personblock_example`
 


### PR DESCRIPTION
It should be max and min value - not length. See [here](https://github.com/torchbox/wagtail/blob/07c3ba84fbfcb1f5bf305e47bc6c8f9dbbbe291e/wagtail/wagtailcore/blocks/field_block.py#L306).

So this would work 

`blocks.IntegerBlock(max_value=10, min_value=0)`

but this wouldn't do anything

`blocks.IntegerBlock(max_length=10, min_length=0)`