### PR TITLE
Fix for wagtail-userbar on touch devices

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/userbar.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/userbar.js
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', function userBar(e) {
         // in accordance with: https://hacks.mozilla.org/2013/04/detecting-touch-its-the-why-not-the-how/
         trigger.addEventListener('touchend', function preventSimulatedClick(e) {
             e.preventDefault();
-            toggleUserbar();
+            toggleUserbar(e);
         });
 
     } else {


### PR DESCRIPTION
This patch fixes the javascript error that was breaking the userbar (the little bird circle on editable pages) on all touch devices. Tapping the userbar icon will now properly toggle the menu, instead of doing nothing.