### PR TITLE
Disable client-side validation on all admin forms

### DIFF
--- a/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
@@ -25,7 +25,7 @@
         <h2>{% blocktrans %}Choose a parent page{% endblocktrans %}</h2>
         <p>{% blocktrans with view.verbose_name_plural|capfirst as plural %}{{ plural }} can be added to more than one place within your site. Which of the following would you like to be the parent of your new page?{% endblocktrans %}</p>
 
-        <form action="" method="post">
+        <form action="" method="post" novalidate>
             {% csrf_token %}
 
             <ul class="fields">

--- a/wagtail/contrib/modeladmin/templates/modeladmin/create.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/create.html
@@ -19,7 +19,7 @@
         {% include "wagtailadmin/shared/header.html" with title=view.get_page_title subtitle=view.get_page_subtitle icon=view.header_icon tabbed=1 merged=1 %}
     {% endblock %}
 
-    <form action="{% block form_action %}{{ view.create_url }}{% endblock %}"{% if is_multipart %} enctype="multipart/form-data"{% endif %} method="POST">
+    <form action="{% block form_action %}{{ view.create_url }}{% endblock %}"{% if is_multipart %} enctype="multipart/form-data"{% endif %} method="POST" novalidate>
         {% csrf_token %}
 
         {% block form %}{{ edit_handler.render_form_content }}{% endblock %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/create.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/create.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n wagtailadmin_tags %}
+{% load i18n %}
 
 {% block titletag %}{{ view.get_meta_title }}{% endblock %}
 
@@ -19,7 +19,7 @@
         {% include "wagtailadmin/shared/header.html" with title=view.get_page_title subtitle=view.get_page_subtitle icon=view.header_icon tabbed=1 merged=1 %}
     {% endblock %}
 
-    <form action="{% block form_action %}{{ view.create_url }}{% endblock %}"{% if is_multipart %} enctype="multipart/form-data" {% novalidate_on_django_1_10 %}{% endif %} method="POST">
+    <form action="{% block form_action %}{{ view.create_url }}{% endblock %}"{% if is_multipart %} enctype="multipart/form-data"{% endif %} method="POST">
         {% csrf_token %}
 
         {% block form %}{{ edit_handler.render_form_content }}{% endblock %}

--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -15,7 +15,7 @@
             </div>
             <div class="right">
                 {% if site_switcher %}
-                <form method="get" id="settings-site-switch">
+                <form method="get" id="settings-site-switch" novalidate>
                     <label for="{{ site_switcher.site.id_for_label }}">
                         Site:
                     </label>
@@ -26,7 +26,7 @@
         </div>
     </header>
 
-    <form action="{% url 'wagtailsettings:edit' opts.app_label opts.model_name site.pk %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+    <form action="{% url 'wagtailsettings:edit' opts.app_label opts.model_name site.pk %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
 

--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n wagtailadmin_tags %}
+{% load i18n %}
 {% block titletag %}{% blocktrans %}Editing {{ setting_type_name}} - {{ instance }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}menu-settings{% endblock %}
 {% block content %}
@@ -26,7 +26,7 @@
         </div>
     </header>
 
-    <form action="{% url 'wagtailsettings:edit' opts.app_label opts.model_name site.pk %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data" {% novalidate_on_django_1_10 %}{% endif %}>
+    <form action="{% url 'wagtailsettings:edit' opts.app_label opts.model_name site.pk %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
 

--- a/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/add.html
+++ b/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/add.html
@@ -15,7 +15,7 @@
                 <p>The "Search term(s)/phrase" field below must contain the full and exact search for which you wish to provide recommended results, <em>including</em> any misspellings/user error. To help, you can choose from search terms that have been popular with users of your site.</p>
             {% endblocktrans %}
         </div>
-        <form action="{% url 'wagtailsearchpromotions:add' %}" method="POST">
+        <form action="{% url 'wagtailsearchpromotions:add' %}" method="POST" novalidate>
             {% csrf_token %}
 
             <ul class="fields">

--- a/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/edit.html
+++ b/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/edit.html
@@ -5,7 +5,7 @@
     {% trans "Editing" as editing_str %}
     {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=query.query_string icon="pick"  %}
 
-    <form action="{% url 'wagtailsearchpromotions:edit' query.id %}" method="POST" class="nice-padding">
+    <form action="{% url 'wagtailsearchpromotions:edit' query.id %}" method="POST" class="nice-padding" novalidate>
         {% csrf_token %}
 
         <ul class="fields">

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -216,13 +216,6 @@ $(function() {
         var reEnableAfter = 30;
         var dataName = 'disabledtimeout';
 
-        // Perform client-side validation on the form this submit button belongs to (if any)
-        var form = $self.closest('form').get(0);
-        if (form && form.checkValidity && (!form.checkValidity())) {
-            // form exists, browser provides a checkValidity method and checkValidity returns false
-            return;
-        }
-
         window.cancelSpinner = function() {
             $self.prop('disabled', '').removeData(dataName).removeClass('button-longrunning-active');
 
@@ -230,6 +223,13 @@ $(function() {
                 $replacementElem.text($self.data('original-text'));
             }
         };
+
+        // If client-side validation is active on this form, and is going to block submission of the
+        // form, don't activate the spinner
+        var form = $self.closest('form').get(0);
+        if (form && form.checkValidity && !form.noValidate && (!form.checkValidity())) {
+            return;
+        }
 
         // Disabling a button prevents it submitting the form, so disabling
         // must occur on a brief timeout only after this function returns.

--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/change_password.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/change_password.html
@@ -8,7 +8,7 @@
 
     <div class="nice-padding">
         {% if can_change_password %}
-            <form action="{% url 'wagtailadmin_account_change_password' %}" method="POST">
+            <form action="{% url 'wagtailadmin_account_change_password' %}" method="POST" novalidate>
                 {% csrf_token %}
                 <ul class="fields">
                     {% for field in form %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/notification_preferences.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/notification_preferences.html
@@ -7,7 +7,7 @@
     {% include "wagtailadmin/shared/header.html" with title=prefs_str %}
 
     <div class="nice-padding">
-        <form action="{% url 'wagtailadmin_account_notification_preferences' %}" method="POST">
+        <form action="{% url 'wagtailadmin_account_notification_preferences' %}" method="POST" novalidate>
             {% csrf_token %}
             <ul class="fields">
                 {% for field in form %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/confirm.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/password_reset/confirm.html
@@ -20,7 +20,7 @@
             </div>
         {% endif %}
 
-        <form method="post">
+        <form method="post" novalidate>
             {% csrf_token %}
             <h1>{% trans "Set your new password" %}</h1>
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/email_link.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/email_link.html
@@ -5,7 +5,7 @@
 <div class="nice-padding">
     {% include 'wagtailadmin/chooser/_link_types.html' with current='email' %}
 
-    <form action="{% url 'wagtailadmin_choose_page_email_link' %}{% querystring %}" method="post">
+    <form action="{% url 'wagtailadmin_choose_page_email_link' %}{% querystring %}" method="post" novalidate>
         {% csrf_token %}
         <ul class="fields">
             {% for field in form %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link.html
@@ -5,7 +5,7 @@
 <div class="nice-padding">
     {% include 'wagtailadmin/chooser/_link_types.html' with current='external' %}
 
-    <form action="{% url 'wagtailadmin_choose_page_external_link' %}{% querystring %}" method="post">
+    <form action="{% url 'wagtailadmin_choose_page_external_link' %}{% querystring %}" method="post" novalidate>
         {% csrf_token %}
         <ul class="fields">
             {% for field in form %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/generic/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/generic/create.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n wagtailadmin_tags %}
+{% load i18n %}
 
 {% block titletag %}{{ view.page_title }}{% endblock %}
 
@@ -7,7 +7,7 @@
 
     {% include "wagtailadmin/shared/header.html" with title=view.page_title icon=view.header_icon %}
 
-    <form action="{{ view.get_add_url }}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data" {% novalidate_on_django_1_10 %}{% endif %}>
+    <form action="{{ view.get_add_url }}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
 
         {% block hidden_fields %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/generic/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/generic/create.html
@@ -7,7 +7,7 @@
 
     {% include "wagtailadmin/shared/header.html" with title=view.page_title icon=view.header_icon %}
 
-    <form action="{{ view.get_add_url }}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+    <form action="{{ view.get_add_url }}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
 
         {% block hidden_fields %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/generic/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/generic/edit.html
@@ -8,7 +8,7 @@
     {% include "wagtailadmin/shared/header.html" with title=view.page_title subtitle=view.get_page_subtitle icon=view.header_icon %}
 
     <div class="nice-padding">
-        <form action="{{ view.get_edit_url }}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+        <form action="{{ view.get_edit_url }}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
             {% csrf_token %}
 
             {% block hidden_fields %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/generic/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/generic/edit.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n wagtailadmin_tags %}
+{% load i18n %}
 
 {% block titletag %}{{ view.page_title }} {{ view.get_page_subtitle }}{% endblock %}
 
@@ -8,7 +8,7 @@
     {% include "wagtailadmin/shared/header.html" with title=view.page_title subtitle=view.get_page_subtitle icon=view.header_icon %}
 
     <div class="nice-padding">
-        <form action="{{ view.get_edit_url }}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data" {% novalidate_on_django_1_10 %}{% endif %}>
+        <form action="{{ view.get_edit_url }}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
             {% csrf_token %}
 
             {% block hidden_fields %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/login.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/login.html
@@ -24,7 +24,7 @@
             </div>
         {% endif %}
 
-        <form action="{% url 'wagtailadmin_login' %}" method="post" autocomplete="off">
+        <form action="{% url 'wagtailadmin_login' %}" method="post" autocomplete="off" novalidate>
             {% csrf_token %}
 
             {% url 'wagtailadmin_home' as home_url %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/page_privacy/set_privacy.html
@@ -4,7 +4,7 @@
 
 <div class="nice-padding">
     <p class="help-block help-warning">{% trans "Privacy changes apply to all children of this page too." %}</p>
-    <form action="{% url 'wagtailadmin_pages:set_privacy' page.id %}" method="POST">
+    <form action="{% url 'wagtailadmin_pages:set_privacy' page.id %}" method="POST" novalidate>
         {% csrf_token %}
         <ul class="fields">
             {% include "wagtailadmin/shared/field_as_li.html" with field=form.restriction_type %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/copy.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/copy.html
@@ -6,7 +6,7 @@
     {% include "wagtailadmin/shared/header.html" with title=copy_str subtitle=page.title icon="doc-empty-inverse" %}
 
     <div class="nice-padding">
-        <form action="{% url 'wagtailadmin_pages:copy' page.id %}" method="POST">
+        <form action="{% url 'wagtailadmin_pages:copy' page.id %}" method="POST" novalidate>
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ next }}" />
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
@@ -17,7 +17,7 @@
         </div>
     </header>
 
-    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:add' content_type.app_label content_type.model parent_page.id %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:add' content_type.app_label content_type.model parent_page.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
         <input type="hidden" name="next" value="{{ next }}">
         {{ edit_handler.render_form_content }}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
@@ -17,7 +17,7 @@
         </div>
     </header>
 
-    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:add' content_type.app_label content_type.model parent_page.id %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data" {% novalidate_on_django_1_10 %}{% endif %}>
+    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:add' content_type.app_label content_type.model parent_page.id %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
         <input type="hidden" name="next" value="{{ next }}">
         {{ edit_handler.render_form_content }}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -24,7 +24,7 @@
         </div>
     </header>
 
-    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:edit' page.id %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:edit' page.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
         <input type="hidden" name="next" value="{{ next }}">
         {{ edit_handler.render_form_content }}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -24,7 +24,7 @@
         </div>
     </header>
 
-    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:edit' page.id %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data" {% novalidate_on_django_1_10 %}{% endif %}>
+    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:edit' page.id %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
         <input type="hidden" name="next" value="{{ next }}">
         {{ edit_handler.render_form_content }}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/header.html
@@ -24,7 +24,7 @@
                 <h1 class="icon icon-{{ icon }}">{{ title }}{% if subtitle %} <span>{{ subtitle }}</span>{% endif %}</h1>
             </div>
             {% if search_url %}
-                <form class="col search-form" action="{% url search_url %}{% if query_parameters %}?{{ query_parameters }}{% endif %}" method="get">
+                <form class="col search-form" action="{% url search_url %}{% if query_parameters %}?{{ query_parameters }}{% endif %}" method="get" novalidate>
                     <ul class="fields">
                         {% for field in search_form %}
                             {% include "wagtailadmin/shared/field_as_li.html" with field=field field_classes="field-small iconfield" input_classes="icon-search" %}

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -312,17 +312,3 @@ def message_tags(message):
         return level_tag
     else:
         return ''
-
-
-@register.simple_tag
-def novalidate_on_django_1_10():
-    """
-    Django 1.10 has a bug that breaks client-side validation on forms that include
-    prefilled file upload fields. This is due to be fixed in Django 1.10.1; as a
-    workaround, we apply this tag to disable client-side validation (using the
-    'novalidate' attribute) on all forms with enctype="multipart/form-data".
-    """
-    if django.VERSION >= (1, 10, 0) and django.VERSION < (1, 10, 1):
-        return 'novalidate'
-    else:
-        return ''

--- a/wagtail/wagtaildocs/templates/wagtaildocs/chooser/chooser.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/chooser/chooser.html
@@ -1,4 +1,4 @@
-{% load i18n wagtailadmin_tags %}
+{% load i18n %}
 {% trans "Choose a document" as  choose_str %}
 {% include "wagtailadmin/shared/header.html" with title=choose_str tabbed=1 merged=1 icon="doc-full-inverse" %}
 
@@ -28,7 +28,7 @@
     </section>
     {% if uploadform %}
         <section id="upload" class="{% if uploadform.errors %}active {% endif %}nice-padding">
-            <form class="document-upload" action="{% url 'wagtaildocs:chooser_upload' %}" method="POST" enctype="multipart/form-data" {% novalidate_on_django_1_10 %}>
+            <form class="document-upload" action="{% url 'wagtaildocs:chooser_upload' %}" method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
                 <ul class="fields">
                     {% for field in uploadform %}

--- a/wagtail/wagtaildocs/templates/wagtaildocs/chooser/chooser.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/chooser/chooser.html
@@ -12,7 +12,7 @@
 
 <div class="tab-content">
     <section id="search" class="{% if not uploadform.errors %}active {% endif %}nice-padding">
-        <form class="document-search search-bar" action="{% url 'wagtaildocs:chooser' %}" method="GET">
+        <form class="document-search search-bar" action="{% url 'wagtaildocs:chooser' %}" method="GET" novalidate>
             <ul class="fields">
                 {% for field in searchform %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
@@ -28,7 +28,7 @@
     </section>
     {% if uploadform %}
         <section id="upload" class="{% if uploadform.errors %}active {% endif %}nice-padding">
-            <form class="document-upload" action="{% url 'wagtaildocs:chooser_upload' %}" method="POST" enctype="multipart/form-data">
+            <form class="document-upload" action="{% url 'wagtaildocs:chooser_upload' %}" method="POST" enctype="multipart/form-data" novalidate>
                 {% csrf_token %}
                 <ul class="fields">
                     {% for field in uploadform %}

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/add.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/add.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n wagtailadmin_tags %}
+{% load i18n %}
 {% load wagtailimages_tags %}
 {% block titletag %}{% trans "Add a document" %}{% endblock %}
 
@@ -21,7 +21,7 @@
     {% include "wagtailadmin/shared/header.html" with title=add_str icon="doc-full-inverse" %}
 
     <div class="nice-padding">
-        <form action="{% url 'wagtaildocs:add' %}" method="POST" enctype="multipart/form-data" {% novalidate_on_django_1_10 %}>
+        <form action="{% url 'wagtaildocs:add' %}" method="POST" enctype="multipart/form-data">
             {% csrf_token %}
             <ul class="fields">
                 {% for field in form %}

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/add.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/add.html
@@ -21,7 +21,7 @@
     {% include "wagtailadmin/shared/header.html" with title=add_str icon="doc-full-inverse" %}
 
     <div class="nice-padding">
-        <form action="{% url 'wagtaildocs:add' %}" method="POST" enctype="multipart/form-data">
+        <form action="{% url 'wagtaildocs:add' %}" method="POST" enctype="multipart/form-data" novalidate>
             {% csrf_token %}
             <ul class="fields">
                 {% for field in form %}

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
@@ -23,7 +23,7 @@
     <div class="row row-flush nice-padding">
 
         <div class="col10 divider-after">
-            <form action="{% url 'wagtaildocs:edit' document.id %}" method="POST" enctype="multipart/form-data">
+            <form action="{% url 'wagtaildocs:edit' document.id %}" method="POST" enctype="multipart/form-data" novalidate>
                 {% csrf_token %}
                 <ul class="fields">
                     {% for field in form %}

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n wagtailadmin_tags %}
+{% load i18n %}
 {% load wagtailimages_tags %}
 {% block titletag %}{% blocktrans with title=document.title %}Editing {{ title }}{% endblocktrans %}{% endblock %}
 
@@ -23,7 +23,7 @@
     <div class="row row-flush nice-padding">
 
         <div class="col10 divider-after">
-            <form action="{% url 'wagtaildocs:edit' document.id %}" method="POST" enctype="multipart/form-data" {% novalidate_on_django_1_10 %}>
+            <form action="{% url 'wagtaildocs:edit' document.id %}" method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
                 <ul class="fields">
                     {% for field in form %}

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/index.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/index.html
@@ -30,7 +30,7 @@
 
     <div class="nice-padding">
         {% if collections %}
-            <form class="image-search search-bar" action="{% url 'wagtaildocs:index' %}" method="GET">
+            <form class="image-search search-bar" action="{% url 'wagtaildocs:index' %}" method="GET" novalidate>
                 <ul class="fields">
                     {% include "wagtailadmin/shared/collection_chooser.html" %}
                 </ul>

--- a/wagtail/wagtaildocs/templates/wagtaildocs/multiple/add.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/multiple/add.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n staticfiles wagtailadmin_tags %}
+{% load i18n staticfiles %}
 {% block titletag %}{% trans "Add multiple documents" %}{% endblock %}
 {% block extra_css %}
     {{ block.super }}
@@ -16,7 +16,7 @@
             <p>{% trans "Drag and drop documents into this area to upload immediately." %}</p>
             <p>{{ help_text }}
 
-            <form action="{% url 'wagtaildocs:add_multiple' %}" method="POST" enctype="multipart/form-data" {% novalidate_on_django_1_10 %}>
+            <form action="{% url 'wagtaildocs:add_multiple' %}" method="POST" enctype="multipart/form-data">
                 <div class="replace-file-input">
                     <button class="button bicolor icon icon-plus">{% trans "Or choose from your computer" %}</button>
                     <input id="fileupload" type="file" name="files[]" data-url="{% url 'wagtaildocs:add_multiple' %}" multiple>

--- a/wagtail/wagtaildocs/templates/wagtaildocs/multiple/edit_form.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/multiple/edit_form.html
@@ -1,6 +1,6 @@
-{% load i18n wagtailadmin_tags %}
+{% load i18n %}
 
-<form action="{% url 'wagtaildocs:edit_multiple' doc.id %}" method="POST" enctype="multipart/form-data" {% novalidate_on_django_1_10 %}>
+<form action="{% url 'wagtaildocs:edit_multiple' doc.id %}" method="POST" enctype="multipart/form-data">
     <ul class="fields">
         {% csrf_token %}
         {% for field in form %}

--- a/wagtail/wagtaildocs/templates/wagtaildocs/multiple/edit_form.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/multiple/edit_form.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<form action="{% url 'wagtaildocs:edit_multiple' doc.id %}" method="POST" enctype="multipart/form-data">
+<form action="{% url 'wagtaildocs:edit_multiple' doc.id %}" method="POST" enctype="multipart/form-data" novalidate>
     <ul class="fields">
         {% csrf_token %}
         {% for field in form %}

--- a/wagtail/wagtailembeds/templates/wagtailembeds/chooser/chooser.html
+++ b/wagtail/wagtailembeds/templates/wagtailembeds/chooser/chooser.html
@@ -5,7 +5,7 @@
 
 <div class="tab-content">
     <section id="form" class="active nice-padding">
-        <form class="embed-form" action="{% url 'wagtailembeds:chooser_upload' %}" method="POST">
+        <form class="embed-form" action="{% url 'wagtailembeds:chooser_upload' %}" method="POST" novalidate>
             {% csrf_token %}
             <ul class="fields">
                 {% for field in form %}

--- a/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
@@ -28,7 +28,7 @@
 {% endblock %}
 {% block content %}
     <header class="nice-padding">
-        <form action="" method="get">
+        <form action="" method="get" novalidate>
             <div class="row">
                 <div class="left">
                     <div class="col">

--- a/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.html
@@ -12,7 +12,7 @@
 
 <div class="tab-content">
     <section id="search" class="{% if not uploadform.errors %}active{% endif %} nice-padding">
-        <form class="image-search search-bar" action="{% url 'wagtailimages:chooser' %}{% if will_select_format %}?select_format=true{% endif %}" method="GET" autocomplete="off">
+        <form class="image-search search-bar" action="{% url 'wagtailimages:chooser' %}{% if will_select_format %}?select_format=true{% endif %}" method="GET" autocomplete="off" novalidate>
             <ul class="fields">
                 {% for field in searchform %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
@@ -36,7 +36,7 @@
     </section>
     {% if uploadform %}
         <section id="upload" class="{% if uploadform.errors %}active{% endif %} nice-padding">
-            <form class="image-upload" action="{% url 'wagtailimages:chooser_upload' %}{% if will_select_format %}?select_format=true{% endif %}" method="POST" enctype="multipart/form-data">
+            <form class="image-upload" action="{% url 'wagtailimages:chooser_upload' %}{% if will_select_format %}?select_format=true{% endif %}" method="POST" enctype="multipart/form-data" novalidate>
                 {% csrf_token %}
                 <ul class="fields">
                     {% for field in uploadform %}

--- a/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.html
@@ -1,4 +1,4 @@
-{% load wagtailimages_tags wagtailadmin_tags %}
+{% load wagtailimages_tags %}
 {% load i18n %}
 {% trans "Choose an image" as choose_str %}
 {% include "wagtailadmin/shared/header.html" with title=choose_str merged=1 tabbed=1 icon="image" %}
@@ -36,7 +36,7 @@
     </section>
     {% if uploadform %}
         <section id="upload" class="{% if uploadform.errors %}active{% endif %} nice-padding">
-            <form class="image-upload" action="{% url 'wagtailimages:chooser_upload' %}{% if will_select_format %}?select_format=true{% endif %}" method="POST" enctype="multipart/form-data" {% novalidate_on_django_1_10 %}>
+            <form class="image-upload" action="{% url 'wagtailimages:chooser_upload' %}{% if will_select_format %}?select_format=true{% endif %}" method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
                 <ul class="fields">
                     {% for field in uploadform %}

--- a/wagtail/wagtailimages/templates/wagtailimages/chooser/select_format.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/chooser/select_format.html
@@ -8,7 +8,7 @@
         {% image image max-800x600 class="show-transparency" %}
     </div>
     <div class="col6">
-        <form action="{% url 'wagtailimages:chooser_select_format' image.id %}" method="POST">
+        <form action="{% url 'wagtailimages:chooser_select_format' image.id %}" method="POST" novalidate>
             {% csrf_token %}
             <ul class="fields">
                 {% for field in form %}

--- a/wagtail/wagtailimages/templates/wagtailimages/images/add.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/add.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailimages_tags wagtailadmin_tags %}
+{% load wagtailimages_tags %}
 {% load i18n %}
 {% block titletag %}{% trans "Add an image" %}{% endblock %}
 
@@ -21,7 +21,7 @@
     {% include "wagtailadmin/shared/header.html" with title=add_str icon="image" %}
 
     <div class="nice-padding">
-        <form action="{% url 'wagtailimages:add' %}" method="POST" enctype="multipart/form-data" {% novalidate_on_django_1_10 %}>
+        <form action="{% url 'wagtailimages:add' %}" method="POST" enctype="multipart/form-data">
             {% csrf_token %}
             <ul class="fields">
                 {% for field in form %}

--- a/wagtail/wagtailimages/templates/wagtailimages/images/add.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/add.html
@@ -21,7 +21,7 @@
     {% include "wagtailadmin/shared/header.html" with title=add_str icon="image" %}
 
     <div class="nice-padding">
-        <form action="{% url 'wagtailimages:add' %}" method="POST" enctype="multipart/form-data">
+        <form action="{% url 'wagtailimages:add' %}" method="POST" enctype="multipart/form-data" novalidate>
             {% csrf_token %}
             <ul class="fields">
                 {% for field in form %}

--- a/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailimages_tags wagtailadmin_tags staticfiles i18n %}
+{% load wagtailimages_tags staticfiles i18n %}
 {% block titletag %}{% blocktrans with title=image.title %}Editing image {{ title }}{% endblocktrans %}{% endblock %}
 {% block extra_css %}
     {{ block.super }}
@@ -34,7 +34,7 @@
     <div class="row row-flush nice-padding">
 
         <div class="col5">
-            <form action="{% url 'wagtailimages:edit' image.id %}" method="POST" enctype="multipart/form-data" {% novalidate_on_django_1_10 %}>
+            <form action="{% url 'wagtailimages:edit' image.id %}" method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
                 <ul class="fields">
                     {% for field in form %}

--- a/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
@@ -34,7 +34,7 @@
     <div class="row row-flush nice-padding">
 
         <div class="col5">
-            <form action="{% url 'wagtailimages:edit' image.id %}" method="POST" enctype="multipart/form-data">
+            <form action="{% url 'wagtailimages:edit' image.id %}" method="POST" enctype="multipart/form-data" novalidate>
                 {% csrf_token %}
                 <ul class="fields">
                     {% for field in form %}

--- a/wagtail/wagtailimages/templates/wagtailimages/images/index.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/index.html
@@ -32,7 +32,7 @@
 
     <div class="nice-padding">
         {% if collections %}
-            <form class="image-search search-bar" action="{% url 'wagtailimages:index' %}" method="GET">
+            <form class="image-search search-bar" action="{% url 'wagtailimages:index' %}" method="GET" novalidate>
                 <ul class="fields">
                     {% include "wagtailadmin/shared/collection_chooser.html" %}
                 </ul>

--- a/wagtail/wagtailimages/templates/wagtailimages/multiple/add.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/multiple/add.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailimages_tags wagtailadmin_tags i18n staticfiles %}
+{% load wagtailimages_tags i18n staticfiles %}
 {% block titletag %}{% trans "Add multiple images" %}{% endblock %}
 {% block extra_css %}
     {{ block.super }}
@@ -16,7 +16,7 @@
             <p>{% trans "Drag and drop images into this area to upload immediately." %}</p>
             <p>{{ help_text }}
 
-            <form action="{% url 'wagtailimages:add_multiple' %}" method="POST" enctype="multipart/form-data" {% novalidate_on_django_1_10 %}>
+            <form action="{% url 'wagtailimages:add_multiple' %}" method="POST" enctype="multipart/form-data">
                 <div class="replace-file-input">
                     <button class="button bicolor icon icon-plus">{% trans "Or choose from your computer" %}</button>
                     <input id="fileupload" type="file" name="files[]" data-url="{% url 'wagtailimages:add_multiple' %}" multiple>

--- a/wagtail/wagtailimages/templates/wagtailimages/multiple/edit_form.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/multiple/edit_form.html
@@ -1,6 +1,6 @@
-{% load i18n wagtailadmin_tags %}
+{% load i18n %}
 
-<form action="{% url 'wagtailimages:edit_multiple' image.id %}" method="POST" enctype="multipart/form-data" {% novalidate_on_django_1_10 %}>
+<form action="{% url 'wagtailimages:edit_multiple' image.id %}" method="POST" enctype="multipart/form-data">
     <ul class="fields">
         {% csrf_token %}
         {% for field in form %}

--- a/wagtail/wagtailimages/templates/wagtailimages/multiple/edit_form.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/multiple/edit_form.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<form action="{% url 'wagtailimages:edit_multiple' image.id %}" method="POST" enctype="multipart/form-data">
+<form action="{% url 'wagtailimages:edit_multiple' image.id %}" method="POST" enctype="multipart/form-data" novalidate>
     <ul class="fields">
         {% csrf_token %}
         {% for field in form %}

--- a/wagtail/wagtailredirects/templates/wagtailredirects/add.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/add.html
@@ -15,7 +15,7 @@
         </div>
     {% endif %}
 
-    <form action="{% url 'wagtailredirects:add' %}" method="POST" class="nice-padding">
+    <form action="{% url 'wagtailredirects:add' %}" method="POST" class="nice-padding" novalidate>
         {% csrf_token %}
 
         <ul class="fields">

--- a/wagtail/wagtailredirects/templates/wagtailredirects/edit.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/edit.html
@@ -15,7 +15,7 @@
         </div>
     {% endif %}
 
-    <form action="{% url 'wagtailredirects:edit' redirect.id %}" method="POST" class="nice-padding">
+    <form action="{% url 'wagtailredirects:edit' redirect.id %}" method="POST" class="nice-padding" novalidate>
         {% csrf_token %}
 
         <ul class="fields">

--- a/wagtail/wagtailsearch/templates/wagtailsearch/queries/chooser/chooser.html
+++ b/wagtail/wagtailsearch/templates/wagtailsearch/queries/chooser/chooser.html
@@ -3,7 +3,7 @@
 {% include "wagtailadmin/shared/header.html" with title=pop_str %}
 
 <div class="nice-padding">
-    <form class="query-search search-bar full-width" action="{% url 'wagtailsearch_admin:queries_chooserresults' %}" method="GET" autocomplete="off">
+    <form class="query-search search-bar full-width" action="{% url 'wagtailsearch_admin:queries_chooserresults' %}" method="GET" autocomplete="off" novalidate>
         <ul class="fields">
             {% for field in searchform %}
                 {% include "wagtailadmin/shared/field_as_li.html" with field=field %}

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/chooser/choose.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/chooser/choose.html
@@ -5,7 +5,7 @@
 <div class="nice-padding">
     {# Need to keep the form in the HTML, even if the snippet is not searchable #}
     {# This is to allow pagination links to be generated from the form action URL #}
-    <form class="snippet-search search-bar" action="{% url 'wagtailsnippets:choose' model_opts.app_label model_opts.model_name %}" method="GET">
+    <form class="snippet-search search-bar" action="{% url 'wagtailsnippets:choose' model_opts.app_label model_opts.model_name %}" method="GET" novalidate>
         {% if is_searchable %}
             <ul class="fields">
                 {% for field in search_form %}

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/create.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/create.html
@@ -5,7 +5,7 @@
     {% trans "New" as new_str %}
     {% include "wagtailadmin/shared/header.html" with title=new_str subtitle=model_opts.verbose_name icon="snippet" tabbed=1 merged=1 %}
 
-    <form action="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+    <form action="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
 

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/create.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/create.html
@@ -1,11 +1,11 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n wagtailadmin_tags %}
+{% load i18n %}
 {% block titletag %}{% blocktrans with snippet_type_name=model_opts.verbose_name %}New  {{ snippet_type_name }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "New" as new_str %}
     {% include "wagtailadmin/shared/header.html" with title=new_str subtitle=model_opts.verbose_name icon="snippet" tabbed=1 merged=1 %}
 
-    <form action="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data" {% novalidate_on_django_1_10 %}{% endif %}>
+    <form action="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
 

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
@@ -5,7 +5,7 @@
     {% trans "Editing" as editing_str %}
     {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=instance icon="snippet" usage_object=instance tabbed=1 merged=1 %}
 
-    <form action="{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name instance.id %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+    <form action="{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name instance.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
 

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
@@ -1,11 +1,11 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n wagtailadmin_tags %}
+{% load i18n %}
 {% block titletag %}{% blocktrans with snippet_type_name=model_opts.verbose_name %}Editing {{ snippet_type_name }} - {{ instance }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Editing" as editing_str %}
     {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=instance icon="snippet" usage_object=instance tabbed=1 merged=1 %}
 
-    <form action="{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name instance.id %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data" {% novalidate_on_django_1_10 %}{% endif %}>
+    <form action="{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name instance.id %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
 

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/type_index.html
@@ -21,7 +21,7 @@
                 <h1 class="icon icon-snippet">{% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}</h1>
 
                 {% if is_searchable %}
-                    <form class="col search-form" action="{% url 'wagtailsnippets:list' model_opts.app_label model_opts.model_name %}" method="get">
+                    <form class="col search-form" action="{% url 'wagtailsnippets:list' model_opts.app_label model_opts.model_name %}" method="get" novalidate>
                         <ul class="fields">
                             {% for field in search_form %}
                                 {% include "wagtailadmin/shared/field_as_li.html" with field=field field_classes="field-small iconfield" input_classes="icon-search" %}

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/create.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/create.html
@@ -15,7 +15,7 @@
     {% include "wagtailadmin/shared/header.html" with title=add_group_str icon="group" %}
 
     <div class="nice-padding">
-        <form action="{% url 'wagtailusers_groups:add' %}" method="POST">
+        <form action="{% url 'wagtailusers_groups:add' %}" method="POST" novalidate>
             {% csrf_token %}
 
             <ul class="fields">

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/edit.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/edit.html
@@ -15,7 +15,7 @@
     {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=group.name icon="group" %}
 
     <div class="nice-padding">
-        <form action="{% url 'wagtailusers_groups:edit' group.id %}" method="POST">
+        <form action="{% url 'wagtailusers_groups:edit' group.id %}" method="POST" novalidate>
             {% csrf_token %}
 
             <ul class="fields">

--- a/wagtail/wagtailusers/templates/wagtailusers/users/create.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/create.html
@@ -12,7 +12,7 @@
         <li><a href="#roles">{% trans "Roles" %}</a></li>
     </ul>
 
-    <form action="{% url 'wagtailusers_users:add' %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+    <form action="{% url 'wagtailusers_users:add' %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         <div class="tab-content">
             {% csrf_token %}
             <section id="account" class="active nice-padding">

--- a/wagtail/wagtailusers/templates/wagtailusers/users/create.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/create.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailimages_tags wagtailadmin_tags %}
+{% load wagtailimages_tags %}
 {% load i18n %}
 {% block titletag %}{% trans "Add user" %}{% endblock %}
 {% block content %}
@@ -12,7 +12,7 @@
         <li><a href="#roles">{% trans "Roles" %}</a></li>
     </ul>
 
-    <form action="{% url 'wagtailusers_users:add' %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data" {% novalidate_on_django_1_10 %}{% endif %}>
+    <form action="{% url 'wagtailusers_users:add' %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         <div class="tab-content">
             {% csrf_token %}
             <section id="account" class="active nice-padding">

--- a/wagtail/wagtailusers/templates/wagtailusers/users/edit.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/edit.html
@@ -12,7 +12,7 @@
         <li><a href="#roles">{% trans "Roles" %}</a></li>
     </ul>
 
-    <form action="{% url 'wagtailusers_users:edit' user.pk %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+    <form action="{% url 'wagtailusers_users:edit' user.pk %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         <div class="tab-content">
             {% csrf_token %}
 

--- a/wagtail/wagtailusers/templates/wagtailusers/users/edit.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/edit.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailimages_tags wagtailadmin_tags %}
+{% load wagtailimages_tags %}
 {% load i18n %}
 {% block titletag %}{% trans "Editing" %} {{ user.get_username}}{% endblock %}
 {% block content %}
@@ -12,7 +12,7 @@
         <li><a href="#roles">{% trans "Roles" %}</a></li>
     </ul>
 
-    <form action="{% url 'wagtailusers_users:edit' user.pk %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data" {% novalidate_on_django_1_10 %}{% endif %}>
+    <form action="{% url 'wagtailusers_users:edit' user.pk %}" method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         <div class="tab-content">
             {% csrf_token %}
 


### PR DESCRIPTION
Client-side validation fails to handle all the nuances of how forms are
used in Wagtail, such as indicating errors across tabbed forms, and generally
results in a worse user experience than our existing server-side validation.

This PR disables validation on all forms throughout the wagtail admin that use the django.forms framework, by adding a `novalidate` attribute.

Fixes #2934; also reverts #2913 (which disabled validation selectively for forms with file upload fields on Django 1.10).