### PR TITLE
Force ChoiceBlock.get_searchable_content to text

### DIFF
--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -370,10 +370,10 @@ class ChoiceBlock(FieldBlock):
                 # This is an optgroup, so look inside the group for options
                 for k2, v2 in v:
                     if value == k2 or text_value == force_text(k2):
-                        return [k, v2]
+                        return [force_text(k), force_text(v2)]
             else:
                 if value == k or text_value == force_text(k):
-                    return [v]
+                    return [force_text(v)]
         return []  # Value was not found in the list of choices
 
     class Meta:

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -15,7 +15,6 @@ from django.template.loader import render_to_string
 from django.test import SimpleTestCase, TestCase
 from django.utils.html import format_html
 from django.utils.safestring import SafeData, mark_safe
-
 # non-standard import name for ugettext_lazy, to prevent strings from being picked up for translation
 from django.utils.translation import ugettext_lazy as __
 

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -15,7 +15,9 @@ from django.template.loader import render_to_string
 from django.test import SimpleTestCase, TestCase
 from django.utils.html import format_html
 from django.utils.safestring import SafeData, mark_safe
-from django.utils.translation import ugettext_lazy as _
+
+# non-standard import name for ugettext_lazy, to prevent strings from being picked up for translation
+from django.utils.translation import ugettext_lazy as __
 
 from wagtail.tests.testapp.blocks import LinkBlock as CustomLinkBlock
 from wagtail.tests.testapp.blocks import SectionBlock
@@ -612,8 +614,8 @@ class TestChoiceBlock(unittest.TestCase):
 
     def test_searchable_content_with_lazy_translation(self):
         block = blocks.ChoiceBlock(choices=[
-            ('choice-1', _("Choice 1")),
-            ('choice-2', _("Choice 2")),
+            ('choice-1', __("Choice 1")),
+            ('choice-2', __("Choice 2")),
         ])
         result = block.get_searchable_content("choice-1")
         # result must survive JSON (de)serialisation, which is not the case for
@@ -623,13 +625,13 @@ class TestChoiceBlock(unittest.TestCase):
 
     def test_optgroup_searchable_content_with_lazy_translation(self):
         block = blocks.ChoiceBlock(choices=[
-            (_('Section 1'), [
-                ('1-1', _("Block 1")),
-                ('1-2', _("Block 2")),
+            (__('Section 1'), [
+                ('1-1', __("Block 1")),
+                ('1-2', __("Block 2")),
             ]),
-            (_('Section 2'), [
-                ('2-1', _("Block 1")),
-                ('2-2', _("Block 2")),
+            (__('Section 2'), [
+                ('2-1', __("Block 1")),
+                ('2-2', __("Block 2")),
             ]),
         ])
         result = block.get_searchable_content("2-2")


### PR DESCRIPTION
Fixes #2928. The failure happens because the searchable content for a ChoiceBlock is taken from the label of the selected option; if this label is a lazy translation object, then indexing fails because the Elasticsearch library attempts to JSON-serialise it, and lazy translations are not JSON-serialisable.

Where translatable text is involved, indexing the label text probably isn't the most helpful thing to do (since it'll only get indexed in the installation's default language). But it'll do for now, since A) it matches the existing behaviour of non-translatable ChoiceBlocks, and B) for the purpose of this ticket we're more concerned about making it not crash rather than indexing the ChoiceBlock content accurately :-)