### PR TITLE
Upgrade BeautifulSoup→4.5.1; restore html5lib import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ install_requires = [
     "django-treebeard>=3.0,<5.0",
     "djangorestframework>=3.1.3",
     "Pillow>=2.6.1",
-    "beautifulsoup4>=4.4.1",
-    "html5lib==0.999999",
+    "beautifulsoup4>=4.5.1",
+    "html5lib>=0.999,<1",
     "Unidecode>=0.04.14",
     "Willow>=0.3b4,<0.4",
 ]


### PR DESCRIPTION
It seems that #2842 was a temporary measure. BeautifulSoup 4.5.1 fixes the html5lib dependency itself, see https://bugs.launchpad.net/beautifulsoup/+bug/1603299. This change removes the temporary html5lib explicit version specification.