### PR TITLE
Optimise JPEG images when generating renditions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     "beautifulsoup4>=4.5.1",
     "html5lib>=0.999,<1",
     "Unidecode>=0.04.14",
-    "Willow>=0.3b4,<0.4",
+    "Willow>=0.4,<0.5",
 ]
 
 # Testing dependencies

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -416,7 +416,7 @@ class Filter(models.Model):
                 else:
                     quality = 85
 
-                return willow.save_as_jpeg(output, quality=quality)
+                return willow.save_as_jpeg(output, quality=quality, progressive=True, optimize=True)
             elif original_format == 'gif':
                 # Convert image to PNG if it's not animated
                 if not willow.has_animation():


### PR DESCRIPTION
We've recently added support in Willow to make use of Pillow's image optimisation (not yet in a released version). This commit enables this in Wagtail.

All JPEGs are now optimised and saved in progressive format.

Before:
```
  7194 David_Mitchell_by_Kubik.width-200.jpg
 46720 grey_wagtail_by_lip_kee.width-1000.jpg
  6435 grey_wagtail_by_lip_kee.width-200.jpg
  8600 James_Joyce_in_1915.width-200.jpg
  7030 pied_wagtail_by_Marie_Hale.width-200.jpg
 81835 wagtail_at_Borovoye_Kazakhstan_by_Ken_and_Nye.width-1000.jpg
  8607 wagtail_by_fs-phil.width-200.jpg
  7238 wagtail_collects_insects_by_Maggi_94.width-200.jpg
 44082 wagtail_sproing_by_Jim_Bendon.width-1000.jpg
```

After:
```
  6989 David_Mitchell_by_Kubik.width-200.jpg
 43760 grey_wagtail_by_lip_kee.width-1000.jpg
  6122 grey_wagtail_by_lip_kee.width-200.jpg
  8125 James_Joyce_in_1915.width-200.jpg
  6680 pied_wagtail_by_Marie_Hale.width-200.jpg
 75575 wagtail_at_Borovoye_Kazakhstan_by_Ken_and_Nye.width-1000.jpg
  8121 wagtail_by_fs-phil.width-200.jpg
  6901 wagtail_collects_insects_by_Maggi_94.width-200.jpg
 41375 wagtail_sproing_by_Jim_Bendon.width-1000.jpg
```

Approximately 7% improvement.