### PR TITLE
Image signals should listen to post_delete instead of pre_delete

### DIFF
--- a/docs/advanced_topics/images/custom_image_model.rst
+++ b/docs/advanced_topics/images/custom_image_model.rst
@@ -21,7 +21,7 @@ Here's an example:
 
     # models.py
     from django.db import models
-    from django.db.models.signals import pre_delete
+    from django.db.models.signals import post_delete
     from django.dispatch import receiver
     
     from wagtail.wagtailimages.models import Image, AbstractImage, AbstractRendition
@@ -49,13 +49,13 @@ Here's an example:
 
 
     # Delete the source image file when an image is deleted
-    @receiver(pre_delete, sender=CustomImage)
+    @receiver(post_delete, sender=CustomImage)
     def image_delete(sender, instance, **kwargs):
         instance.file.delete(False)
 
 
     # Delete the rendition image file when a rendition is deleted
-    @receiver(pre_delete, sender=CustomRendition)
+    @receiver(post_delete, sender=CustomRendition)
     def rendition_delete(sender, instance, **kwargs):
         instance.file.delete(False)
 

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.db import models
-from django.db.models.signals import pre_delete
+from django.db.models.signals import post_delete
 from django.dispatch import Signal
 from django.dispatch.dispatcher import receiver
 from django.utils.encoding import python_2_unicode_compatible
@@ -110,8 +110,8 @@ def get_document_model():
     return document_model
 
 
-# Receive the pre_delete signal and delete the file associated with the model instance.
-@receiver(pre_delete, sender=Document)
+# Receive the post_delete signal and delete the file associated with the model instance.
+@receiver(post_delete, sender=Document)
 def document_delete(sender, instance, **kwargs):
     # Pass false so FileField doesn't save the model.
     instance.file.delete(False)

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files import File
 from django.core.urlresolvers import reverse
 from django.db import models
-from django.db.models.signals import pre_delete, pre_save
+from django.db.models.signals import post_delete, pre_save
 from django.dispatch.dispatcher import receiver
 from django.forms.widgets import flatatt
 from django.utils.encoding import python_2_unicode_compatible
@@ -343,8 +343,8 @@ def image_feature_detection(sender, instance, **kwargs):
             instance.set_focal_point(instance.get_suggested_focal_point())
 
 
-# Receive the pre_delete signal and delete the file associated with the model instance.
-@receiver(pre_delete, sender=Image)
+# Receive the post_delete signal and delete the file associated with the model instance.
+@receiver(post_delete, sender=Image)
 def image_delete(sender, instance, **kwargs):
     # Pass false so FileField doesn't save the model.
     instance.file.delete(False)
@@ -518,8 +518,8 @@ class Rendition(AbstractRendition):
         )
 
 
-# Receive the pre_delete signal and delete the file associated with the model instance.
-@receiver(pre_delete, sender=Rendition)
+# Receive the post_delete signal and delete the file associated with the model instance.
+@receiver(post_delete, sender=Rendition)
 def rendition_delete(sender, instance, **kwargs):
     # Pass false so FileField doesn't save the model.
     instance.file.delete(False)


### PR DESCRIPTION
Fix for #950 (Rendition delete receiver should listen to post_delete instead of pre_delete).
In this case it is also relevant for deleting images (not just renditions) + documents. 
So I applied the change there as well. 
