### PR TITLE
Fix checkbox initial values on group permission edit form on Django 1.10

### DIFF
--- a/wagtail/wagtailusers/forms.py
+++ b/wagtail/wagtailusers/forms.py
@@ -218,6 +218,9 @@ class GroupForm(forms.ModelForm):
     class Meta:
         model = Group
         fields = ("name", "permissions", )
+        widgets = {
+            'permissions': forms.CheckboxSelectMultiple(),
+        }
 
     def clean_name(self):
         # Since Group.name is unique, this check is redundant,

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/includes/formatted_permissions.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/includes/formatted_permissions.html
@@ -19,25 +19,13 @@
         <tr>
             <td class="title"><h3>{{ content_perms_dict.object|capfirst }}</h3></td>
             <td>
-                {% with content_perms_dict.add as perm_tuple %}
-                    {% if perm_tuple %}
-                        <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1|safe }} value="{{ perm_tuple.0.id }}">
-                    {% endif %}
-                {% endwith %}
+                {% if content_perms_dict.add %}{{ content_perms_dict.add.tag }}{% endif %}
             </td>
             <td>
-                {% with content_perms_dict.change as perm_tuple %}
-                    {% if perm_tuple %}
-                        <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1|safe }} value="{{ perm_tuple.0.id }}">
-                    {% endif %}
-                {% endwith %}
+                {% if content_perms_dict.change %}{{ content_perms_dict.change.tag }}{% endif %}
             </td>
             <td>
-                {% with content_perms_dict.delete as perm_tuple %}
-                    {% if perm_tuple %}
-                        <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1|safe }} value="{{ perm_tuple.0.id }}">
-                    {% endif %}
-                {% endwith %}
+                {% if content_perms_dict.delete %}{{ content_perms_dict.delete.tag }}{% endif %}
             </td>
         </tr>
         {% endfor %}
@@ -57,11 +45,9 @@
     <tbody>
         {% for perm_tuple in other_perms %}
             <tr>
-                <td>{{ perm_tuple.0.name }}</td>
+                <td class="title"><label for="{{ perm_tuple.1.id_for_label }}" class="plain-checkbox-label">{{ perm_tuple.0.name }}</label></td>
                 <td>
-                    <label for="id_permissions_{{ perm_tuple.0.id }}">
-                        <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1|safe }} value="{{ perm_tuple.0.id }}">
-                    </label>
+                    {{ perm_tuple.1.tag }}
                 </td>
             </tr>
         {% endfor %}

--- a/wagtail/wagtailusers/templates/wagtailusers/groups/includes/formatted_permissions.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/groups/includes/formatted_permissions.html
@@ -21,21 +21,21 @@
             <td>
                 {% with content_perms_dict.add as perm_tuple %}
                     {% if perm_tuple %}
-                        <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1 }} value="{{ perm_tuple.0.id }}">
+                        <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1|safe }} value="{{ perm_tuple.0.id }}">
                     {% endif %}
                 {% endwith %}
             </td>
             <td>
                 {% with content_perms_dict.change as perm_tuple %}
                     {% if perm_tuple %}
-                        <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1 }} value="{{ perm_tuple.0.id }}">
+                        <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1|safe }} value="{{ perm_tuple.0.id }}">
                     {% endif %}
                 {% endwith %}
             </td>
             <td>
                 {% with content_perms_dict.delete as perm_tuple %}
                     {% if perm_tuple %}
-                        <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1 }} value="{{ perm_tuple.0.id }}">
+                        <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1|safe }} value="{{ perm_tuple.0.id }}">
                     {% endif %}
                 {% endwith %}
             </td>
@@ -60,7 +60,7 @@
                 <td>{{ perm_tuple.0.name }}</td>
                 <td>
                     <label for="id_permissions_{{ perm_tuple.0.id }}">
-                        <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1 }} value="{{ perm_tuple.0.id }}">
+                        <input id="id_permissions_{{ perm_tuple.0.id }}" name="permissions" type="checkbox" {{ perm_tuple.1|safe }} value="{{ perm_tuple.0.id }}">
                     </label>
                 </td>
             </tr>

--- a/wagtail/wagtailusers/templatetags/wagtailusers_tags.py
+++ b/wagtail/wagtailusers/templatetags/wagtailusers_tags.py
@@ -11,31 +11,40 @@ register = template.Library()
 @register.inclusion_tag('wagtailusers/groups/includes/formatted_permissions.html')
 def format_permissions(permission_bound_field):
     """
-        Given a bound field with a queryset of Permission objects, constructs a
-        list of dictionaries for 'objects':
+        Given a bound field with a queryset of Permission objects - which must be using
+        the CheckboxSelectMultiple widget - construct a list of dictionaries for 'objects':
 
         'objects': [
             {
                 'object': name_of_some_content_object,
-                'add': (add_permission_for_object, checked_str)
-                'change': (change_permission_for_object, checked_str)
-                'delete': (delete_permission_for_object, checked_str)
+                'add': checkbox
+                'change': checkbox
+                'delete': checkbox
             },
         ]
 
         and a list of other permissions:
 
         'others': [
-            (any_non_add_change_delete_permission, checked_str),
+            (any_non_add_change_delete_permission, checkbox),
         ]
 
-        and returns a table template formatted with this list.
+        (where 'checkbox' is an instance of django.forms.widgets.CheckboxChoiceInput, renderable
+        as HTML using checkbox.tag() )
+
+        - and returns a table template formatted with this list.
 
     """
     permissions = permission_bound_field.field._queryset
     # get a distinct list of the content types that these permissions relate to
     content_type_ids = set(permissions.values_list('content_type_id', flat=True))
-    initial = permission_bound_field.form.initial.get('permissions', [])
+
+    # iterate over permission_bound_field to build a lookup of individual renderable
+    # checkbox objects
+    checkboxes_by_id = {
+        int(checkbox.choice_value): checkbox
+        for checkbox in permission_bound_field
+    }
 
     object_perms = []
     other_perms = []
@@ -44,14 +53,15 @@ def format_permissions(permission_bound_field):
         content_perms = permissions.filter(content_type_id=content_type_id)
         content_perms_dict = {}
         for perm in content_perms:
-            checked = 'checked="checked"' if perm.id in initial else ''
+            checkbox = checkboxes_by_id[perm.id]
             # identify the three main categories of permission, and assign to
             # the relevant dict key, else bung in the 'other_perms' list
-            if perm.codename.split('_')[0] in ['add', 'change', 'delete']:
+            permission_action = perm.codename.split('_')[0]
+            if permission_action in ['add', 'change', 'delete']:
                 content_perms_dict['object'] = perm.content_type.name
-                content_perms_dict[perm.codename.split('_')[0]] = (perm, checked)
+                content_perms_dict[permission_action] = checkbox
             else:
-                other_perms.append((perm, checked))
+                other_perms.append((perm, checkbox))
         if content_perms_dict:
             object_perms.append(content_perms_dict)
     return {

--- a/wagtail/wagtailusers/tests.py
+++ b/wagtail/wagtailusers/tests.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
+from bs4 import BeautifulSoup
+
 from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
@@ -748,6 +750,20 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
                 permission__content_type__app_label='wagtaildocs'
             ).count(),
             0
+        )
+
+    def test_group_edit_loads_with_django_permissions_shown(self):
+        # the checkbox for self.existing_permission should be ticked
+        response = self.get()
+
+        # Use BeautifulSoup to search for a checkbox element with name="permissions", checked="checked",
+        # value=<existing_permission.id>. Can't use assertContains here because the id attribute is unpredictable
+        soup = BeautifulSoup(response.content, 'html5lib')
+
+        self.assertTrue(
+            soup.find('input',
+                {'name': 'permissions', 'type': 'checkbox', 'checked': 'checked', 'value': self.existing_permission.id}
+            )
         )
 
     def test_group_edit_loads_with_page_permissions_shown(self):

--- a/wagtail/wagtailusers/tests.py
+++ b/wagtail/wagtailusers/tests.py
@@ -761,7 +761,8 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         soup = BeautifulSoup(response.content, 'html5lib')
 
         self.assertTrue(
-            soup.find('input',
+            soup.find(
+                'input',
                 {'name': 'permissions', 'type': 'checkbox', 'checked': 'checked', 'value': self.existing_permission.id}
             )
         )


### PR DESCRIPTION
Fixes #2962

Django 1.10 changed the internal representation of initial values of ModelChoiceFields; they are now model instances rather than IDs. This broke the format_permissions tag, which inspected the initial value of the field in order to reconstruct it as checkboxes. This internal poking-around is now avoided entirely, by setting GroupForm to use the CheckboxSelectMultiple widget itself; format_permissions simply has to reorganise those checkboxes appropriately, rather than building them from first principles.

**IMPORTANT:** The new form rendering relies on the `plain-checkbox-label` style added in a0efc0d10e176b52822376a7ff78ff5a0c61b90d. When backporting to stable/1.6.x, the CSS rule from there will need to be added to _forms.scss.