### PR TITLE
Configure Travis to test against Django's stable/1.10.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,10 @@ matrix:
      python: 3.5
    - env: TOXENV=py35-dj110-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
      python: 3.5
+   - env: TOXENV=py35-dj110head-postgres-noelasticsearch
+     python: 3.5
+   - env: TOXENV=py35-dj110head-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
+     python: 3.5
      sudo: true
   allow_failures:
     - env: TOXENV=py27-dj18-sqlite-elasticsearch
@@ -80,6 +84,7 @@ matrix:
     - env: TOXENV=py34-dj19-sqlite-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
     - env: TOXENV=py27-dj110-mysql-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
     - env: TOXENV=py35-dj110-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
+    - env: TOXENV=py35-dj110head-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
 
 
 # Services

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 usedevelop = True
 
 envlist = py{27,33,34,35}-dj{18,19}-{sqlite,postgres,mysql}-{elasticsearch2,elasticsearch,noelasticsearch},
-          py{27,34,35}-dj110-{sqlite,postgres,mysql}-{elasticsearch2,elasticsearch,noelasticsearch},
+          py{27,34,35}-dj{110,110head}-{sqlite,postgres,mysql}-{elasticsearch2,elasticsearch,noelasticsearch},
           flake8
 
 [testenv]
@@ -26,6 +26,7 @@ deps =
     dj18: Django>=1.8.1,<1.9
     dj19: Django>=1.9,<1.10
     dj110: Django>=1.10a1,<1.11
+    dj110head: git+https://github.com/django/django.git@stable/1.10.x#egg=Django
     postgres: psycopg2>=2.6
     mysql: mysqlclient==1.3.6
     elasticsearch2: elasticsearch>=2,<3


### PR DESCRIPTION
Fixes #2592

There are probably better ways of doing this - logically this ought to be a CI task that tracks the Django repo so that any failures are tied to the Django commit that caused them, rather than a (probably) unrelated Wagtail commit. But that requires more Travis/Drone-fu than I've got, so this will do for now :-)