### PR TITLE
Fix bug with forcing a user to exist on request

### DIFF
--- a/wagtail/wagtailadmin/templatetags/wagtailuserbar.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailuserbar.py
@@ -36,8 +36,14 @@ def wagtailuserbar(context, position='bottom-right'):
     except KeyError:
         return ''
 
+    # Don't render without a user because we can't check their permissions
+    try:
+        user = request.user
+    except AttributeError:
+        return ''
+
     # Don't render if user doesn't have permission to access the admin area
-    if not request.user.has_perm('wagtailadmin.access_admin'):
+    if not user.has_perm('wagtailadmin.access_admin'):
         return ''
 
     # Don't render if this is a preview. Since some routes can render the userbar without going through Page.serve(),


### PR DESCRIPTION
When testing a user doesn't always exist on the request. Currently to directly test a view one would have to mock an empty user for the request. 

This removes the need for an empty user without changing the original goal - i believe.

PS: first time submitting to wagtail. I looked for information on how to properly submit a pull request, for which i didn't find anything specific to a 3rd party trying to contribute. If i'm doing this wrong let me know happy to adjust. Apologizes in advance.