### PR TITLE
Fix #2789: Convert embed filter to templatetag

### DIFF
--- a/wagtail/wagtailembeds/blocks.py
+++ b/wagtail/wagtailembeds/blocks.py
@@ -12,7 +12,7 @@ class EmbedValue(object):
     Native value of an EmbedBlock. Should, at minimum, have a 'url' property
     and render as the embed HTML when rendered in a template.
     NB We don't use a wagtailembeds.model.Embed object for this, because
-    we want to be able to do {{ value.url|embed:max_width=500 }} without
+    we want to be able to do {% embed value.url 500 %} without
     doing a redundant fetch of the embed at the default width.
     """
     def __init__(self, url):

--- a/wagtail/wagtailembeds/templatetags/wagtailembeds_tags.py
+++ b/wagtail/wagtailembeds/templatetags/wagtailembeds_tags.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import, unicode_literals
 
+import warnings
+
 from django import template
 from django.utils.safestring import mark_safe
 
+from wagtail.utils.deprecation import RemovedInWagtail18Warning
 from wagtail.wagtailembeds import embeds
 from wagtail.wagtailembeds.exceptions import EmbedException
 
@@ -11,6 +14,17 @@ register = template.Library()
 
 @register.filter
 def embed(url, max_width=None):
+    warnings.warn(
+        "The embed filter has been converted to a template tag. "
+        "Use {% embed my_embed_url %} instead.",
+        category=RemovedInWagtail18Warning, stacklevel=2
+    )
+
+    return embed_tag(url, max_width)
+
+
+@register.simple_tag(name='embed')
+def embed_tag(url, max_width=None):
     try:
         embed = embeds.get_embed(url, max_width=max_width)
         return mark_safe(embed.html)

--- a/wagtail/wagtailembeds/tests.py
+++ b/wagtail/wagtailembeds/tests.py
@@ -22,7 +22,8 @@ from wagtail.wagtailembeds.finders.embedly import AccessDeniedEmbedlyException, 
 from wagtail.wagtailembeds.finders.oembed import oembed as wagtail_oembed
 from wagtail.wagtailembeds.models import Embed
 from wagtail.wagtailembeds.rich_text import MediaEmbedHandler
-from wagtail.wagtailembeds.templatetags.wagtailembeds_tags import embed as embed_filter, embed_tag
+from wagtail.wagtailembeds.templatetags.wagtailembeds_tags import embed as embed_filter
+from wagtail.wagtailembeds.templatetags.wagtailembeds_tags import embed_tag
 
 try:
     import embedly  # noqa

--- a/wagtail/wagtailembeds/tests.py
+++ b/wagtail/wagtailembeds/tests.py
@@ -22,7 +22,7 @@ from wagtail.wagtailembeds.finders.embedly import AccessDeniedEmbedlyException, 
 from wagtail.wagtailembeds.finders.oembed import oembed as wagtail_oembed
 from wagtail.wagtailembeds.models import Embed
 from wagtail.wagtailembeds.rich_text import MediaEmbedHandler
-from wagtail.wagtailembeds.templatetags.wagtailembeds_tags import embed as embed_filter
+from wagtail.wagtailembeds.templatetags.wagtailembeds_tags import embed as embed_filter, embed_tag
 
 try:
     import embedly  # noqa
@@ -355,6 +355,34 @@ class TestEmbedFilter(TestCase):
         get_embed.side_effect = EmbedNotFoundException
 
         temp = template.Template('{% load wagtailembeds_tags %}{{ "http://www.youtube.com/watch/"|embed }}')
+        result = temp.render(template.Context())
+
+        self.assertEqual(result, '')
+
+
+class TestEmbedTag(TestCase):
+    @patch('wagtail.wagtailembeds.embeds.get_embed')
+    def test_direct_call(self, get_embed):
+        get_embed.return_value = Embed(html='<img src="http://www.example.com" />')
+
+        result = embed_tag('http://www.youtube.com/watch/')
+
+        self.assertEqual(result, '<img src="http://www.example.com" />')
+
+    @patch('wagtail.wagtailembeds.embeds.get_embed')
+    def test_call_from_template(self, get_embed):
+        get_embed.return_value = Embed(html='<img src="http://www.example.com" />')
+
+        temp = template.Template('{% load wagtailembeds_tags %}{% embed "http://www.youtube.com/watch/" %}')
+        result = temp.render(template.Context())
+
+        self.assertEqual(result, '<img src="http://www.example.com" />')
+
+    @patch('wagtail.wagtailembeds.embeds.get_embed')
+    def test_catches_embed_not_found(self, get_embed):
+        get_embed.side_effect = EmbedNotFoundException
+
+        temp = template.Template('{% load wagtailembeds_tags %}{% embed "http://www.youtube.com/watch/" %}')
         result = temp.render(template.Context())
 
         self.assertEqual(result, '')


### PR DESCRIPTION
Fix for #2789 

I am not sure how we normally handle deprecation warnings in Wagtail. For convenience I've added for those who are already using the embed filter that it will be removed in 1.8 (maybe even 1.9?).

What are the next steps regarding deprecation of certain methods? 
Do we make a separate issue for cleanup?