### PR TITLE
Eliminate dependencies on __latest__ migrations

### DIFF
--- a/docs/releases/1.7.rst
+++ b/docs/releases/1.7.rst
@@ -55,3 +55,22 @@ Bug fixes
 
 Upgrade considerations
 ======================
+
+Project template's initial migration should not depend on ``wagtailcore.__latest__``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On projects created under previous releases of Wagtail, the ``home/migrations/0001_initial.py`` migration created by the ``wagtail start`` command contains the following dependency line:
+
+.. code-block:: python
+
+    dependencies = [
+        ('wagtailcore', '__latest__'),
+    ]
+
+This may produce ``InconsistentMigrationHistory`` errors under Django 1.10 when upgrading Wagtail, since Django interprets this to mean that no new migrations can legally be added to wagtailcore after this migration is applied. This line should be changed to:
+
+.. code-block:: python
+
+    dependencies = [
+        ('wagtailcore', '0029_unicode_slugfield_dj19'),
+    ]

--- a/wagtail/project_template/home/migrations/0001_initial.py
+++ b/wagtail/project_template/home/migrations/0001_initial.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('wagtailcore', '__latest__'),
+        ('wagtailcore', '0029_unicode_slugfield_dj19'),
     ]
 
     operations = [

--- a/wagtail/wagtaildocs/migrations/0001_initial.py
+++ b/wagtail/wagtaildocs/migrations/0001_initial.py
@@ -11,7 +11,7 @@ import wagtail.wagtailsearch.index
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('taggit', '__latest__'),
+        ('taggit', '0001_initial'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 

--- a/wagtail/wagtailimages/migrations/0001_initial.py
+++ b/wagtail/wagtailimages/migrations/0001_initial.py
@@ -12,7 +12,7 @@ import wagtail.wagtailsearch.index
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('taggit', '__latest__'),
+        ('taggit', '0001_initial'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 


### PR DESCRIPTION
See https://groups.google.com/d/msg/wagtail/a1lbdKe-QPk/GefsBFnRBgAJ

Using `__latest__` prevents us from ever applying migrations that are subsequently added to the referenced apps, since logically those migrations must have been applied before the current one (which they weren't, because they didn't exist). This logic is enforced as of Django 1.10.