### PR TITLE
Increase legibility by increasing contrast

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
@@ -45,6 +45,8 @@ $color-grey-3: #d9d9d9;
 $color-grey-4: #e6e6e6;
 $color-grey-5: #fafafa;
 
+$color-menu-text: #cacaca; // was #aaa wich was too low contrast
+
 $color-thead-bg: $color-grey-5;
 $color-header-bg: $color-teal; // #ff6a58;
 $color-fieldset-hover: $color-grey-5;
@@ -78,6 +80,3 @@ $font-serif: Roboto Slab, Georgia, serif;
 // misc sizing
 $thumbnail-width: 130px;
 $menu-width: 180px;
-
-
-

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -485,7 +485,7 @@ input[type=checkbox]:checked:before {
 .button-small {
     padding: 0 0.8em;
     height: 2em;
-    font-size: 0.85em;
+    font-size: 0.95em;
 }
 
     .button-secondary {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_listing.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_listing.scss
@@ -6,7 +6,7 @@ ul.listing {
 
 .listing {
     margin-bottom: 2em;
-    color: lighten($color-text-base, 20%);
+    color: lighten($color-text-base, 10%);
     font-size: 0.95em;
 
     ul {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -51,11 +51,14 @@ $submenu-color: darken($color-grey-1, 5%);
         -webkit-font-smoothing: auto;
         text-decoration: none;
         display: block;
-        color: #aaa;
+        color: $color-menu-text;
         padding: 0.8em 1.7em;
-        font-size: 0.95em;
-        font-weight: 300;
-
+        font-size: 1em;
+        font-weight: normal;
+        // Note, font-weights lower than normal,
+        // and font-size smaller than 1em (80% ~= 12.8px),
+        // makes the strokes thinner than 1px on non-retina screens
+        // making the text semi-transparent
         &:hover,
         &:focus {
             outline: none;
@@ -83,7 +86,7 @@ $submenu-color: darken($color-grey-1, 5%);
             position: absolute;
             right: 0.5em;
             top: 0.5em;
-            margin-top: 0.15em;
+            margin-top: 0;
         }
 
     }
@@ -146,7 +149,7 @@ $submenu-color: darken($color-grey-1, 5%);
 .explorer {
     // position: absolute;
     // margin-top: 70px;
-    font-size: 0.95em;
+    font-size: 1em;
 }
 
 .nav-search {
@@ -169,7 +172,7 @@ $submenu-color: darken($color-grey-1, 5%);
         cursor: pointer;
         border: 1px solid darken($color-grey-2, 10%);
         background-color: darken($color-grey-2, 15%);
-        color: #aaa;
+        color: $color-menu-text;
         padding: 0.8em 2.5em 0.8em 1em;
 
         &:hover {
@@ -352,7 +355,7 @@ body.explorer-open {
             font-weight: 500;
             text-transform: none;
             text-align: center;
-            color: #aaa;
+            color: $color-menu-text;
 
             &:before {
                 font-size: 4em;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_typography.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_typography.scss
@@ -81,7 +81,7 @@ dl {
 }
 
 dt {
-    color: darken($color-grey-3, 5%);
+    color: darken($color-grey-3, 15%);
     text-transform: uppercase;
     font-size: 0.9em;
 }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -85,6 +85,7 @@
     > h2 {
         -webkit-font-smoothing: auto;
         background: $color-salmon-light;
+        color: #200200;
         text-transform: uppercase;
         padding: 0.9em 0 0.9em 4.1em;
         font-size: 0.95em;


### PR DESCRIPTION
Improves legibility by raising the font color contrast slightly,  by adjusting font-weight from 300 up to normal for small text, and increasing font size (from 12.2px to 12.8px in the menu) for the smallest texts.

This small change in font size makes a big difference in font opacity as the strokes goes from significantly less than a pixel to approaching one pixel in width; as fractional pixels will be rendered as semi-transparent pixels.

Fix (or at least an improvement) for https://github.com/torchbox/wagtail/issues/2976