### PR TITLE
Adds an Issue and a Pull request template to Github

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,19 @@
+Found a bug? Please fill out the sections below. 👍
+
+### Issue Summary
+
+A summary of the issue.
+
+### Steps to Reproduce
+
+1. This is the first step
+2. This is the second step, etc.
+
+Any other relevant information. For e.g. Why do you consider this a bug and what did you expect to happen instead?
+
+### Technical details
+
+* Python version:
+* Django version:
+* Wagtail version:
+* Browser version:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,7 +9,7 @@ A summary of the issue.
 1. This is the first step
 2. This is the second step, etc.
 
-Any other relevant information. For e.g. Why do you consider this a bug and what did you expect to happen instead?
+Any other relevant information. For example, why do you consider this a bug and what did you expect to happen instead?
 
 ### Technical details
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+### Thanks for contributing to Wagtail! 🎉
+
+Please review [the contributor guidelines](http://docs.wagtail.io/en/latest/contributing/index.html) and confirm that [the tests pass](http://docs.wagtail.io/en/latest/contributing/developing.html#testing) in case of Python changes.


### PR DESCRIPTION
Hi! I think we can benefit from having a Github issue and pull request template. When browsing around some issues the first response mainly contains the question of which version of Wagtail or Django version someone is running. 

I have a put a issue template in place for this and also added a pull request template which refers to our contributing guidelines / running tests in the (latest) docs.