### PR TITLE
Fix flake8 complaint in group_models_by_index

### DIFF
--- a/wagtail/wagtailsearch/management/commands/update_index.py
+++ b/wagtail/wagtailsearch/management/commands/update_index.py
@@ -46,8 +46,8 @@ def group_models_by_index(backend, models):
             models_by_index[index.name].append(model)
 
     return collections.OrderedDict([
-        (indices[index_name], models)
-        for index_name, models in models_by_index.items()
+        (indices[index_name], index_models)
+        for index_name, index_models in models_by_index.items()
     ])
 
 


### PR DESCRIPTION
This change fixes flake8 message that is thrown while running "make lint":

F812 list comprehension redefines 'models' from line 13