### PR TITLE
Uses specific_class.url instead of Page.url on RichText

### DIFF
--- a/wagtail/wagtailcore/rich_text.py
+++ b/wagtail/wagtailcore/rich_text.py
@@ -38,6 +38,7 @@ class PageLinkHandler(object):
     def expand_db_attributes(attrs, for_editor):
         try:
             page = Page.objects.get(id=attrs['id'])
+            page = page.specific_class.objects.get(pk=page.pk)
 
             if for_editor:
                 editor_attrs = 'data-linktype="page" data-id="%d" ' % page.id


### PR DESCRIPTION
I was overriding the url method for my Article/Page subclass. "View online" works fine but not on Rich Text link handler.