### PR TITLE
Add before_(create,edit,delete)_page hooks

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -278,12 +278,12 @@ Hooks for customising the editing interface for pages and snippets.
   Add additional CSS files or snippets to all admin pages.
 
   .. code-block:: python
-  
+
     from django.utils.html import format_html
     from django.contrib.staticfiles.templatetags.staticfiles import static
-  
+
     from wagtail.wagtailcore import hooks
-  
+
     @hooks.register('insert_global_admin_css')
     def global_admin_css():
         return format_html('<link rel="stylesheet" href="{}">', static('my/wagtail/theme.css'))
@@ -364,6 +364,34 @@ Hooks for customising the way users are directed through the process of creating
         return HttpResponse("Congrats on making content!", content_type="text/plain")
 
 
+.. _before_create_page:
+
+``before_create_page``
+~~~~~~~~~~~~~~~~~~~~~
+
+  Called at the beginning of the "create page" view passing in the request, the parent page and page model class.
+
+  The function does not have to return anything, but if an object with a ``status_code`` property is returned, Wagtail will use it as a response object and skip the rest of the view.
+
+  Unlike, ``after_create_page``, this is run both for both ``GET`` and ``POST`` requests.
+
+  This can be used to completely override the editor on a per-view basis:
+
+  .. code-block:: python
+
+    from django.http import HttpResponse
+
+    from wagtail.wagtailcore import hooks
+
+    from .models import AwesomePage
+    from .admin_views import edit_awesome_page
+
+    @hooks.register('before_create_page')
+    def before_create_page(request, parent_page, page_class):
+        # Use a custom create view for the AwesomePage model
+        if page_class == AwesomePage:
+            return create_awesome_page(request, parent_page)
+
 .. _after_delete_page:
 
 ``after_delete_page``
@@ -372,12 +400,32 @@ Hooks for customising the way users are directed through the process of creating
   Do something after a ``Page`` object is deleted. Uses the same behavior as ``after_create_page``.
 
 
+.. _before_delete_page:
+
+``before_delete_page``
+~~~~~~~~~~~~~~~~~~~~~
+
+  Called at the beginning of the "delete page" view passing in the request and the page object.
+
+  Uses the same behavior as ``before_create_page``.
+
+
 .. _after_edit_page:
 
 ``after_edit_page``
 ~~~~~~~~~~~~~~~~~~~
 
   Do something with a ``Page`` object after it has been updated. Uses the same behavior as ``after_create_page``.
+
+
+.. _before_edit_page:
+
+``before_edit_page``
+~~~~~~~~~~~~~~~~~~~~~
+
+  Called at the beginning of the "edit page" view passing in the request and the page object.
+
+  Uses the same behavior as ``before_create_page``.
 
 
 .. _construct_wagtail_userbar:

--- a/wagtail/tests/utils.py
+++ b/wagtail/tests/utils.py
@@ -103,6 +103,16 @@ class WagtailTestUtils(object):
         """
         return _AssertLogsContext(self, logger, level)
 
+    @contextmanager
+    def register_hook(self, hook_name, fn):
+        from wagtail.wagtailcore import hooks
+
+        hooks.register(hook_name, fn)
+        try:
+            yield
+        finally:
+            hooks.get_hooks(hook_name).remove(fn)
+
 
 class WagtailPageTests(WagtailTestUtils, TestCase):
     """

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -490,6 +490,11 @@ def delete(request, page_id):
     if not page.permissions_for_user(request.user).can_delete():
         raise PermissionDenied
 
+    for fn in hooks.get_hooks('before_delete_page'):
+        result = fn(request, page)
+        if hasattr(result, 'status_code'):
+            return result
+
     next_url = get_valid_next_url_from_request(request)
 
     if request.method == 'POST':

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -294,6 +294,11 @@ def edit(request, page_id):
     if not page_perms.can_edit():
         raise PermissionDenied
 
+    for fn in hooks.get_hooks('before_edit_page'):
+        result = fn(request, page)
+        if hasattr(result, 'status_code'):
+            return result
+
     edit_handler_class = page_class.get_edit_handler()
     form_class = edit_handler_class.get_form_class(page_class)
 

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -179,6 +179,11 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
     if not page_class.can_create_at(parent_page):
         raise PermissionDenied
 
+    for fn in hooks.get_hooks('before_create_page'):
+        result = fn(request, parent_page, page_class)
+        if hasattr(result, 'status_code'):
+            return result
+
     page = page_class(owner=request.user)
     edit_handler_class = page_class.get_edit_handler()
     form_class = edit_handler_class.get_form_class(page_class)


### PR DESCRIPTION
This pull requests adds three more hooks for allowing customising editor workflow. This allows the developer to override the ``create``, ``edit`` and ``delete`` views for specific pages.

 - ``before_create_page``. Called in the ``create_page`` view. The request, parent page and page model class are passed in as parameters
 - ``before_edit_page``. Called in the ``edit_page`` view. The request and page to be edited are passed in as parameters
 - ``before_delete_page``. Called in the ``delete_page`` view. The request and page to be edited are passed in as parameters

If any of these hooks return a response object, that response is used and the rest of the view is skipped.