### PR TITLE
Removing eval statement from modal-workflow.js

### DIFF
--- a/wagtail/wagtailadmin/modal_workflow.py
+++ b/wagtail/wagtailadmin/modal_workflow.py
@@ -19,6 +19,6 @@ def render_modal_workflow(request, html_template, js_template, template_vars=Non
 
     if js_template:
         js = render_to_string(js_template, template_vars or {}, request=request)
-        response_keyvars.update({'onload': js.replace('\n','')})
+        response_keyvars.update({'onload': js.replace('\n', '')})
 
-    return HttpResponse(json.dumps(response_keyvars) , content_type="text/javascript")
+    return HttpResponse(json.dumps(response_keyvars), content_type="text/javascript")

--- a/wagtail/wagtailadmin/modal_workflow.py
+++ b/wagtail/wagtailadmin/modal_workflow.py
@@ -11,16 +11,14 @@ def render_modal_workflow(request, html_template, js_template, template_vars=Non
     Render a response consisting of an HTML chunk and a JS onload chunk
     in the format required by the modal-workflow framework.
     """
-    response_keyvars = []
+    response_keyvars = {}
 
     if html_template:
         html = render_to_string(html_template, template_vars or {}, request=request)
-        response_keyvars.append("'html': %s" % json.dumps(html))
+        response_keyvars.update({'html': html})
 
     if js_template:
         js = render_to_string(js_template, template_vars or {}, request=request)
-        response_keyvars.append("'onload': %s" % js)
+        response_keyvars.update({'onload': js.replace('\n','')})
 
-    response_text = "{%s}" % ','.join(response_keyvars)
-
-    return HttpResponse(response_text, content_type="text/javascript")
+    return HttpResponse(json.dumps(response_keyvars) , content_type="text/javascript")

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/modal-workflow.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/modal-workflow.js
@@ -51,9 +51,15 @@ function ModalWorkflow(opts) {
     };
 
     self.loadResponseText = function(responseText) {
-        var response = eval('(' + responseText + ')');
+        var response;
 
-        self.loadBody(response);
+        try {
+            response = JSON.parse( responseText );
+        } catch ( error ) {
+            window.location = window.location.host;
+        }
+
+        self.loadBody( response );
     };
 
     self.loadBody = function(response) {
@@ -63,9 +69,15 @@ function ModalWorkflow(opts) {
             container.modal('show');
         }
 
+        // if the response contains an `onload` function, call the function with the current
+        // context as a parameter.
         if (response.onload) {
-            // if the response is a function
-            response.onload(self);
+            var onLoadFunction = new Function('', 'return ' + response.onload)();
+            if (typeof onLoadFunction === 'function') {
+                onLoadFunction(self);
+            } else {
+                throw new Error('ModalWorkflow.loadBody: Error evaluating onload function');
+            }
         }
     };
 

--- a/wagtail/wagtailadmin/tests/test_page_chooser.py
+++ b/wagtail/wagtailadmin/tests/test_page_chooser.py
@@ -318,27 +318,27 @@ class TestChooserExternalLink(TestCase, WagtailTestUtils):
     def test_create_link(self):
         response = self.post({'url': 'http://www.example.com/', 'link_text': 'example'})
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "'onload'")  # indicates success / post back to calling page
+        self.assertContains(response, "onload")  # indicates success / post back to calling page
         self.assertContains(response, "'url': 'http://www.example.com/'")
         self.assertContains(response, "'title': 'example'")  # When link text is given, it is used
 
     def test_create_link_without_text(self):
         response = self.post({'url': 'http://www.example.com/'})
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "'onload'")  # indicates success / post back to calling page
+        self.assertContains(response, "onload")  # indicates success / post back to calling page
         self.assertContains(response, "'url': 'http://www.example.com/'")
         self.assertContains(response, "'title': 'http://www.example.com/'")  # When no text is given, it uses the url
 
     def test_invalid_url(self):
         response = self.post({'url': 'ntp://www.example.com', 'link_text': 'example'})
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "'html'")  # indicates failure / show error message
+        self.assertContains(response, "html")  # indicates failure / show error message
         self.assertContains(response, "Enter a valid URL.")
 
     def test_allow_local_url(self):
         response = self.post({'url': '/admin/', 'link_text': 'admin'})
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "'onload'")  # indicates success / post back to calling page
+        self.assertContains(response, "onload")  # indicates success / post back to calling page
         self.assertContains(response, "'url': '/admin/',")
         self.assertContains(response, "'title': 'admin'")
 


### PR DESCRIPTION

## Changes
 - Modied `wagtail/wagtailadmin/static_src/wagtailadmin/js/modal-workflow.js` to use `JSON.parse` instead of `eval`.  Wrapped `JSON.parse` statement in a `try / catch` block to handle scenarios where the server returns HTML instead of JSON (session timeouts).
 

 - Modified `wagtail/wagtailadmin/modal_workflow.py` to return valid JSON. JSON keys can only be  wrapped in double quotes per http://www.json.org/.  Also added code to remove newlines, which were affecting parsing of the JSON string using `JSON.parse`.

