### PR TITLE
Allow to limit access to form submissions

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -223,9 +223,15 @@ Hooks for building new areas of the admin interface (alongside pages, images, do
 ``filter_form_submissions_for_user``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  Allows to limit access to form submissions. Doesn't affect page editing.
+  Allows access to form submissions to be customised on a per-user, per-form basis.
 
-  Return a queryset of ``Page`` objects to be shown in the Forms administration area.
+  This hook takes two parameters:
+   - The user attempting to access form submissions
+   - A ``QuerySet`` of form pages
+
+  The hook must return a ``QuerySet`` containing a subset of these form pages which the user is allowed to access the submissions for.
+
+  For example, to prevent non-superusers from accessing form submissions:
 
   .. code-block:: python
 

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -215,7 +215,30 @@ Hooks for building new areas of the admin interface (alongside pages, images, do
 ``register_permissions``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-  Return a queryset of Permission objects to be shown in the Groups administration area.
+  Return a queryset of ``Permission`` objects to be shown in the Groups administration area.
+
+
+.. _filter_form_submissions_for_user:
+
+``filter_form_submissions_for_user``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  Allows to limit access to form submissions. Doesn't affect page editing.
+
+  Return a queryset of ``Page`` objects to be shown in the Forms administration area.
+
+  .. code-block:: python
+
+    from wagtail.wagtailcore import hooks
+
+
+    @hooks.register('filter_form_submissions_for_user')
+    def construct_forms_for_user(user, queryset):
+        if not user.is_superuser:
+            queryset = queryset.none()
+
+        return queryset
+
 
 
 Editor interface

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -145,7 +145,7 @@ def get_forms_for_user(user):
     editable_forms = editable_forms.filter(content_type__in=get_form_types())
 
     # Apply hooks
-    for fn in hooks.get_hooks('construct_forms_for_user'):
+    for fn in hooks.get_hooks('filter_form_submissions_for_user'):
         editable_forms = fn(user, editable_forms)
 
     return editable_forms


### PR DESCRIPTION
This PR adds the `construct_forms_for_user` hook which allows us to limit access to form submissions.

I'll add tests and docs, if we decide that this is acceptable.

---

If this PR merged, we will be able to do something like

```python
@hooks.register('register_permissions')
def register_permissions():
    wagtailadmin_content_type = ContentType.objects.get(app_label='wagtailadmin', model='admin')

    Permission.objects.get_or_create(
        content_type=wagtailadmin_content_type,
        codename='access_form_submissions',
        name='Can access form submissions'
    )

    return Permission.objects.filter(content_type=wagtailadmin_content_type, codename='access_form_submissions')


@hooks.register('construct_forms_for_user')
def construct_forms_for_user(user, queryset):
    if not user.has_perm('wagtailadmin.access_form_submissions'):
        queryset = queryset.none()

    return queryset
```

or even simpler:


```python
@hooks.register('construct_forms_for_user')
def construct_forms_for_user(user, queryset):
    if not user.is_superuser:
        queryset = queryset.none()

    return queryset
```