### PR TITLE
Use better JS source maps during development

### DIFF
--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -4,6 +4,7 @@ var config = base('development');
 
 // development overrides go here
 config.watch = true;
-config.devtool = 'cheap-module-eval-source-map';
+// See http://webpack.github.io/docs/configuration.html#devtool
+config.devtool = 'inline-source-map';
 
 module.exports = config;


### PR DESCRIPTION
The current webpack source map configuration isn't very useful when debugging transpiled/bundled JS code.

Before – the DevTools do not mention file name, and point to an empty file:

![cheap-module-eval-source-map](https://cloud.githubusercontent.com/assets/877585/18754597/ea0c5aa4-80f1-11e6-83b5-3eb34ca6b37b.png)

After – the DevTools have the correct file name, and point to the right file content (original code before transformations):

![inline-source-map](https://cloud.githubusercontent.com/assets/877585/18754601/effdb49e-80f1-11e6-9050-0cb445fb8624.png)

There is a development build speed cost to using those "proper" source maps – on my modern MacBook Pro, initial build is ±25% slower (12s -> 15s) and rebuild is ±2x slower (1s -> 2s). I think this is a reasonable trade-off for valuable dev logging.

See http://webpack.github.io/docs/configuration.html#devtool for all of the options (crazy how complicated these things can be!).