### PR TITLE
Page publish permission should not automatically give ability to delete

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1684,7 +1684,7 @@ class PagePermissionTester(object):
         if 'edit' in self.permissions:
             # if the user does not have publish permission, we also need to confirm that there
             # are no published pages here
-            if not ('publish' in self.permissions):
+            if 'publish' not in self.permissions:
                 pages_to_delete = self.page.get_descendants(inclusive=True)
                 if pages_to_delete.live().exists():
                     return False

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1677,21 +1677,30 @@ class PagePermissionTester(object):
         if self.page_is_root:  # root node is not a page and can never be deleted, even by superusers
             return False
 
-        if self.user.is_superuser or ('publish' in self.permissions):
-            # Users with publish permission can unpublish any pages that need to be unpublished to achieve deletion
+        if self.user.is_superuser:
+            # superusers require no further checks
             return True
 
-        elif 'edit' in self.permissions:
-            # user can only delete if there are no live pages in this subtree
-            return (not self.page.live) and (not self.page.get_descendants().filter(live=True).exists())
+        if 'edit' in self.permissions:
+            # if the user does not have publish permission, we also need to confirm that there
+            # are no published pages here
+            if not ('publish' in self.permissions):
+                pages_to_delete = self.page.get_descendants(inclusive=True)
+                if pages_to_delete.live().exists():
+                    return False
+
+            return True
 
         elif 'add' in self.permissions:
-            # user can only delete if all pages in this subtree are unpublished and owned by this user
-            return (
-                (not self.page.live) and
-                (self.page.owner_id == self.user.pk) and
-                (not self.page.get_descendants().exclude(live=False, owner=self.user).exists())
-            )
+            pages_to_delete = self.page.get_descendants(inclusive=True)
+            if 'publish' in self.permissions:
+                # we don't care about live state, but all pages must be owned by this user
+                # (i.e. eliminating pages owned by this user must give us the empty set)
+                return not pages_to_delete.exclude(owner=self.user).exists()
+            else:
+                # all pages must be owned by this user and non-live
+                # (i.e. eliminating non-live pages owned by this user must give us the empty set)
+                return not pages_to_delete.exclude(live=False, owner=self.user).exists()
 
         else:
             return False


### PR DESCRIPTION
The old permission logic allowed anyone with publish permission to delete pages, with no further checks applied. This is incorrect, because the permission rules applied elsewhere establish that 1) deletion is equivalent to editing, and 2) publish permission DOES NOT imply edit permission.

This PR updates the logic to be consistent with other actions: deleting a page is now only possible if you have edit rights on the page (either through explicit 'edit' permission, or implicitly by having 'add' permission and owning the page in question). For published pages, publish permission is required _in addition_ to this.

It's unlikely that this change will affect real-world sites (and even less likely that it will affect them negatively), because having publish-only users without corresponding edit rights is a pretty esoteric setup (and one that currently has some dubious behaviour at the UI level - e.g. options that appear to be available but lead to a 403 error). However, having consistent permission rules here is an important pre-requisite for adding a distinct 'bulk delete' permission level (#1667).
