### PR TITLE
ElasticSearch index default settings override

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,8 @@ Changelog
  * Fix: `InlinePanel` now accepts a `classname` parameter as per the documentation (emg36, Matt Westcott)
  * Fix: Disabled use of escape key to revert content of rich text fields, which could cause accidental data loss (Matt Westcott)
  * Fix: Setting `USE_THOUSAND_SEPARATOR = True` no longer breaks the rendering of numbers in JS code for InlinePanel (Mattias Loverot, Matt Westcott)
+ * Fix: Extra options for the Elasticsearch constructor should be now defined with the new key ``OPTIONS`` of the WAGTAILSEARCH_BACKENDS setting (PyMan Claudio Marinozzi)
+ * Added the ability to override the default index settings for ElasticSearch (PyMan Claudio Marinozzi)
 
 
 1.6.3 (XX.XX.2016)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -170,6 +170,7 @@ Contributors
 * Stein Strindhaug
 * Žan Anderle
 * Mattias Loverot
+* PyMan Claudio Marinozzi
 
 Translators
 ===========

--- a/docs/releases/1.7.rst
+++ b/docs/releases/1.7.rst
@@ -47,6 +47,7 @@ Minor features
  * Added ability to annotate search results with score - see :ref:`wagtailsearch_annotating_results_with_score` (Karl Hobley)
  * Added ability to limit access to form submissions - see :ref:`filter_form_submissions_for_user` (Mikalai Radchuk)
  * Added the ability to configure the number of days search logs are kept for, through the :ref:`WAGTAILSEARCH_HITS_MAX_AGE <wagtailsearch_hits_max_age>` setting (Stephen Rice)
+ * Added the ability to override the default index settings for ElasticSearch. See :ref:`wagtailsearch_backends_elasticsearch` (PyMan Claudio Marinozzi)
 
 
 Bug fixes

--- a/docs/releases/1.7.rst
+++ b/docs/releases/1.7.rst
@@ -109,3 +109,8 @@ The data model for image renditions will be changed in Wagtail 1.8 to eliminate 
     ]
 
    replacing ``myapp`` and ``CustomRendition`` with the app and model name for the custom rendition model.
+
+Extra options for the Elasticsearch constructor should be now defined with the new key ``OPTIONS`` of the WAGTAILSEARCH_BACKENDS setting 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For the ElasticSearch backend all extra keys defined WAGTAILSEARCH_BACKENDS are passed directly to the Elasticsearch constructor. All these keys now should be moved inside the new ``OPTIONS`` dictionary. The old behaviour is still supported, but deprecated.

--- a/docs/releases/1.7.rst
+++ b/docs/releases/1.7.rst
@@ -114,4 +114,4 @@ The data model for image renditions will be changed in Wagtail 1.8 to eliminate 
 Extra options for the Elasticsearch constructor should be now defined with the new key ``OPTIONS`` of the WAGTAILSEARCH_BACKENDS setting 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For the ElasticSearch backend all extra keys defined WAGTAILSEARCH_BACKENDS are passed directly to the Elasticsearch constructor. All these keys now should be moved inside the new ``OPTIONS`` dictionary. The old behaviour is still supported, but deprecated.
+For the Elasticsearch backend, all extra keys defined in ``WAGTAILSEARCH_BACKENDS`` are passed directly to the Elasticsearch constructor. All these keys now should be moved inside the new ``OPTIONS`` dictionary. The old behaviour is still supported, but deprecated.

--- a/docs/topics/search/backends.rst
+++ b/docs/topics/search/backends.rst
@@ -114,10 +114,14 @@ The backend is configured in settings:
           'URLS': ['http://localhost:9200'],
           'INDEX': 'wagtail',
           'TIMEOUT': 5,
+          'OPTIONS': {},
+          'INDEX_SETTINGS': {},
       }
   }
 
-Other than ``BACKEND``, the keys are optional and default to the values shown. In addition, any other keys are passed directly to the Elasticsearch constructor as case-sensitive keyword arguments (e.g. ``'max_retries': 1``).
+Other than ``BACKEND``, the keys are optional and default to the values shown. Any defined key in ``OPTIONS`` is passed directly to the Elasticsearch constructor as case-sensitive keyword argument (e.g. ``'max_retries': 1``).
+
+``INDEX_SETTINGS`` is a dictionary used to override the default settings to create the index. The default settings are defined inside the ``ElasticsearchSearchBackend`` class in the module ``wagtail/wagtail/wagtailsearch/backends/elasticsearch.py``. Actually any new key is added, any existing key, if not a dictionary, is replaced with the new value.
 
 If you prefer not to run an Elasticsearch server in development or production, there are many hosted services available, including `Bonsai`_, who offer a free account suitable for testing and development. To use Bonsai:
 

--- a/docs/topics/search/backends.rst
+++ b/docs/topics/search/backends.rst
@@ -121,7 +121,29 @@ The backend is configured in settings:
 
 Other than ``BACKEND``, the keys are optional and default to the values shown. Any defined key in ``OPTIONS`` is passed directly to the Elasticsearch constructor as case-sensitive keyword argument (e.g. ``'max_retries': 1``).
 
-``INDEX_SETTINGS`` is a dictionary used to override the default settings to create the index. The default settings are defined inside the ``ElasticsearchSearchBackend`` class in the module ``wagtail/wagtail/wagtailsearch/backends/elasticsearch.py``. Actually any new key is added, any existing key, if not a dictionary, is replaced with the new value.
+``INDEX_SETTINGS`` is a dictionary used to override the default settings to create the index. The default settings are defined inside the ``ElasticsearchSearchBackend`` class in the module ``wagtail/wagtail/wagtailsearch/backends/elasticsearch.py``. Any new key is added, any existing key, if not a dictionary, is replaced with the new value. Here's a sample on how to configure the number of shards and setting the italian LanguageAnalyzer as the default analyzer:
+
+.. code-block:: python
+
+  WAGTAILSEARCH_BACKENDS = {
+      'default': {
+          ...,
+          'INDEX_SETTINGS': {
+          	'settings': {
+          		'number_of_shards': 2,
+          		'index': {
+          			'analysis': {
+          				'analyzer': {
+          					'default': {
+          						'type': 'italian'
+          					}
+          				}
+          			}
+          		}
+          	}
+          },
+      }
+  }
 
 If you prefer not to run an Elasticsearch server in development or production, there are many hosted services available, including `Bonsai`_, who offer a free account suitable for testing and development. To use Bonsai:
 

--- a/docs/topics/search/backends.rst
+++ b/docs/topics/search/backends.rst
@@ -129,21 +129,21 @@ Other than ``BACKEND``, the keys are optional and default to the values shown. A
       'default': {
           ...,
           'INDEX_SETTINGS': {
-          	'settings': {
-          		'number_of_shards': 2,
-          		'index': {
-          			'analysis': {
-          				'analyzer': {
-          					'default': {
-          						'type': 'italian'
-          					}
-          				}
-          			}
-          		}
-          	}
-          },
+              'settings': {
+                  'number_of_shards': 2,
+                      'index': {
+                          'analysis': {
+                              'analyzer': {
+                                  'default': {
+                                      'type': 'italian'
+                                  }
+                              }
+                          }
+                      }
+                  }
+              },
+          }
       }
-  }
 
 If you prefer not to run an Elasticsearch server in development or production, there are many hosted services available, including `Bonsai`_, who offer a free account suitable for testing and development. To use Bonsai:
 

--- a/wagtail/utils/utils.py
+++ b/wagtail/utils/utils.py
@@ -1,5 +1,6 @@
 import collections
 
+
 def deep_update(source, overrides):
     """Update a nested dictionary or similar mapping.
 

--- a/wagtail/utils/utils.py
+++ b/wagtail/utils/utils.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import sys
 import collections
 
 
@@ -8,7 +9,10 @@ def deep_update(source, overrides):
 
     Modify ``source`` in place.
     """
-    for key, value in overrides.iteritems():
+    if sys.version_info >= (3, 0):
+        items = overrides.items()
+        items = overrides.iteritems()
+    for key, value in items:
         if isinstance(value, collections.Mapping) and value:
             returned = deep_update(source.get(key, {}), value)
             source[key] = returned

--- a/wagtail/utils/utils.py
+++ b/wagtail/utils/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import collections
 
 

--- a/wagtail/utils/utils.py
+++ b/wagtail/utils/utils.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
-import sys
 import collections
+import sys
 
 
 def deep_update(source, overrides):

--- a/wagtail/utils/utils.py
+++ b/wagtail/utils/utils.py
@@ -1,0 +1,14 @@
+import collections
+
+def deep_update(source, overrides):
+    """Update a nested dictionary or similar mapping.
+
+    Modify ``source`` in place.
+    """
+    for key, value in overrides.iteritems():
+        if isinstance(value, collections.Mapping) and value:
+            returned = deep_update(source.get(key, {}), value)
+            source[key] = returned
+        else:
+            source[key] = overrides[key]
+    return source

--- a/wagtail/utils/utils.py
+++ b/wagtail/utils/utils.py
@@ -11,7 +11,9 @@ def deep_update(source, overrides):
     """
     if sys.version_info >= (3, 0):
         items = overrides.items()
+    else:
         items = overrides.iteritems()
+
     for key, value in items:
         if isinstance(value, collections.Mapping) and value:
             returned = deep_update(source.get(key, {}), value)

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -742,6 +742,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                     'http_auth': http_auth,
                 })
 
+        self.settings = self.settings.copy() # Make the class settings attribute as instance settings attribute
         self.settings = deep_update(self.settings, params.pop("INDEX_SETTINGS", {}))
 
         # Get Elasticsearch interface

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -742,7 +742,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                     'http_auth': http_auth,
                 })
 
-        self.settings = self.settings.copy() # Make the class settings attribute as instance settings attribute
+        self.settings = self.settings.copy()  # Make the class settings attribute as instance settings attribute
         self.settings = deep_update(self.settings, params.pop("INDEX_SETTINGS", {}))
 
         # Get Elasticsearch interface

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -743,10 +743,19 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
 
         # Get Elasticsearch interface
         # Any remaining params are passed into the Elasticsearch constructor
+        options = params.pop('OPTIONS', {})
+        if not options and params:
+            options = params
+
+            warnings.warn(
+                "Any extra parameter for the ElasticSearch constructor must be passed through the OPTIONS dictionary.",
+                category=RemovedInWagtail18Warning, stacklevel=2
+            )
+
         self.es = Elasticsearch(
             hosts=self.hosts,
             timeout=self.timeout,
-            **params)
+            **options)
 
     def get_index_for_model(self, model):
         return self.index_class(self, self.index_name)

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -10,6 +10,7 @@ from elasticsearch import Elasticsearch, NotFoundError
 from elasticsearch.helpers import bulk
 
 from wagtail.utils.deprecation import RemovedInWagtail18Warning
+from wagtail.utils.utils import deep_update
 from wagtail.wagtailsearch.backends.base import (
     BaseSearchBackend, BaseSearchQuery, BaseSearchResults)
 from wagtail.wagtailsearch.index import (
@@ -740,6 +741,8 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                     'verify_certs': use_ssl,
                     'http_auth': http_auth,
                 })
+
+        self.settings = deep_update(self.settings, params.pop("INDEX_SETTINGS", {}))
 
         # Get Elasticsearch interface
         # Any remaining params are passed into the Elasticsearch constructor

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -985,6 +985,13 @@ class TestBackendConfiguration(TestCase):
 
     def test_default_index_settings_override(self):
         backend = ElasticsearchSearchBackend(params={
+            'INDEX_SETTINGS': {
+                "settings": {  # Already existing key
+                    "number_of_shards": 2,  # New key
+                    "analysis": {  # Already existing key
+                        "analyzer": {  # Already existing key
+                            "edgengram_analyzer": {  # Already existing key
+                                "tokenizer": "standard"  # Key redefinition
                             }
                         }
                     }

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -983,6 +983,26 @@ class TestBackendConfiguration(TestCase):
         self.assertEqual(backend.hosts[3]['use_ssl'], True)
         self.assertEqual(backend.hosts[3]['url_prefix'], '/hello')
 
+    def test_default_index_settings_override(self):
+        backend = ElasticsearchSearchBackend(params={
+                            }
+                        }
+                    }
+                }
+            }
+        })
+
+        # Check structure
+        self.assertIn("number_of_shards", backend.settings["settings"].keys())
+        self.assertIn("analysis", backend.settings["settings"].keys())
+        self.assertIn("analyzer", backend.settings["settings"]["analysis"].keys())
+        self.assertIn("edgengram_analyzer", backend.settings["settings"]["analysis"]["analyzer"].keys())
+        self.assertIn("tokenizer", backend.settings["settings"]["analysis"]["analyzer"]["edgengram_analyzer"].keys())
+        # Check values
+        self.assertEqual(backend.settings["settings"]["number_of_shards"], 2)
+        self.assertEqual(backend.settings["settings"]["analysis"]["analyzer"]["edgengram_analyzer"]["tokenizer"], "standard")
+        self.assertEqual(backend.settings["settings"]["analysis"]["analyzer"]["edgengram_analyzer"]["type"], "custom")  # Check if a default setting still exists
+
 
 @unittest.skipUnless(os.environ.get('ELASTICSEARCH_URL', False), "ELASTICSEARCH_URL not set")
 @unittest.skipUnless(os.environ.get('ELASTICSEARCH_VERSION', '1') == '1', "ELASTICSEARCH_VERSION not set to 1")


### PR DESCRIPTION
Introduced a new optional INDEX_OPTIONS key for WAGTAILSEARCH_BACKENDS
setting.

INDEX_OPTIONS should be a dictionary whose data is used to be merged
with ElasticsearchSearchBackend.settings (data used when a index is
being created)

Sample to set 'number_of_shards' and 'number_of_replicas' and to set a new default LanguageAnalyzer for the index.

```
WAGTAILSEARCH_BACKENDS = {
      'default': {
            'BACKEND': 'wagtail.wagtailsearch.backends.elasticsearch',
            'INDEX': 'wagtail',
            'URLS': ['http://localhost:9200'],
            'TIMEOUT': 5,
            'INDEX_SETTINGS' : {
                "settings" : {
                    "number_of_shards" : 2,
                    "number_of_replicas" : 1,
                    "index" : {
                        "analysis" : {
                            "analyzer" : {
                                "default" : {
                                    "type" : "italian"
                                }
                            }
                        }
                    }
                }
            }
        }
    }
```

@kaedroho This modification alse includes and closes #2778 (extra ES params are now passed through new OPTIONS key in the
WAGTAILSEARCH_BACKENDS setting. Backward compatible with deprecation warning)
