### PR TITLE
Allow links in rich text to contain non-text markup again

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
@@ -77,9 +77,18 @@
                                     linkHasExistingContent = true;
                                 } else if (!lastSelection.collapsed) {
                                     // Turning a selection into a link
+
                                     a = document.createElement('a');
                                     lastSelection.surroundContents(a);
-                                    // TODO: unlink all existing links in the selection
+
+                                    // unlink all previously existing links in the selection,
+                                    // now nested within 'a'
+                                    $('a[href]', a).each(function() {
+                                        var parent = this.parentNode;
+                                        while (this.firstChild) parent.insertBefore(this.firstChild, this);
+                                        parent.removeChild(this);
+                                    });
+
                                     linkHasExistingContent = true;
                                 } else {
                                     // Inserting a new link at the cursor position

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link_chosen.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link_chosen.js
@@ -1,7 +1,4 @@
 function(modal) {
-    modal.respond('pageChosen', {
-        'url': '{{ url|escapejs }}',
-        'title': '{{ link_text|escapejs }}'
-    });
+    modal.respond('pageChosen', {{ result_json|safe }});
     modal.close();
 }

--- a/wagtail/wagtailadmin/tests/test_page_chooser.py
+++ b/wagtail/wagtailadmin/tests/test_page_chooser.py
@@ -319,15 +319,15 @@ class TestChooserExternalLink(TestCase, WagtailTestUtils):
         response = self.post({'url': 'http://www.example.com/', 'link_text': 'example'})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "'onload'")  # indicates success / post back to calling page
-        self.assertContains(response, "'url': 'http://www.example.com/'")
-        self.assertContains(response, "'title': 'example'")  # When link text is given, it is used
+        self.assertContains(response, '"url": "http://www.example.com/"')
+        self.assertContains(response, '"title": "example"')  # When link text is given, it is used
 
     def test_create_link_without_text(self):
         response = self.post({'url': 'http://www.example.com/'})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "'onload'")  # indicates success / post back to calling page
-        self.assertContains(response, "'url': 'http://www.example.com/'")
-        self.assertContains(response, "'title': 'http://www.example.com/'")  # When no text is given, it uses the url
+        self.assertContains(response, '"url": "http://www.example.com/"')
+        self.assertContains(response, '"title": "http://www.example.com/"')  # When no text is given, it uses the url
 
     def test_invalid_url(self):
         response = self.post({'url': 'ntp://www.example.com', 'link_text': 'example'})
@@ -339,8 +339,8 @@ class TestChooserExternalLink(TestCase, WagtailTestUtils):
         response = self.post({'url': '/admin/', 'link_text': 'admin'})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "'onload'")  # indicates success / post back to calling page
-        self.assertContains(response, "'url': '/admin/',")
-        self.assertContains(response, "'title': 'admin'")
+        self.assertContains(response, '"url": "/admin/"')
+        self.assertContains(response, '"title": "admin"')
 
 
 class TestChooserEmailLink(TestCase, WagtailTestUtils):
@@ -363,10 +363,10 @@ class TestChooserEmailLink(TestCase, WagtailTestUtils):
 
     def test_create_link(self):
         request = self.post({'email_address': 'example@example.com', 'link_text': 'contact'})
-        self.assertContains(request, "'url': 'mailto:example@example.com',")
-        self.assertContains(request, "'title': 'contact'")  # When link text is given, it is used
+        self.assertContains(request, '"url": "mailto:example@example.com"')
+        self.assertContains(request, '"title": "contact"')  # When link text is given, it is used
 
     def test_create_link_without_text(self):
         request = self.post({'email_address': 'example@example.com'})
-        self.assertContains(request, "'url': 'mailto:example@example.com',")
-        self.assertContains(request, "'title': 'example@example.com'")  # When no link text is given, it uses the email
+        self.assertContains(request, '"url": "mailto:example@example.com"')
+        self.assertContains(request, '"title": "example@example.com"')  # When no link text is given, it uses the email

--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -163,6 +163,12 @@ def external_link(request):
             result = {
                 'url': form.cleaned_data['url'],
                 'title': form.cleaned_data['link_text'].strip() or form.cleaned_data['url'],
+                # If the user has explicitly entered / edited something in the link_text field,
+                # always use that text. If not, we should favour keeping the existing link/selection
+                # text, where applicable.
+                # (Normally this will match the link_text passed in the URL here anyhow,
+                # but that won't account for non-text content such as images.)
+                'prefer_this_title_as_link_text': ('link_text' in form.changed_data),
             }
 
             return render_modal_workflow(
@@ -197,6 +203,10 @@ def email_link(request):
             result = {
                 'url': 'mailto:' + form.cleaned_data['email_address'],
                 'title': form.cleaned_data['link_text'].strip() or form.cleaned_data['email_address'],
+                # If the user has explicitly entered / edited something in the link_text field,
+                # always use that text. If not, we should favour keeping the existing link/selection
+                # text, where applicable.
+                'prefer_this_title_as_link_text': ('link_text' in form.changed_data),
             }
             return render_modal_workflow(
                 request,


### PR DESCRIPTION
Fixes #3026

The link-handling logic introduced in Wagtail 1.5 (#2417) works by extracting the text content of the current link or selection, and then replacing it with a newly-constructed `<a>` element containing the (possibly-updated) link text. This didn't account for the possibility of the link/selection content containing non-text markup, such as images or bold/italic formatting.

This PR rewrites the link-handling logic to always preserve the existing DOM content, unless the user explicitly provides updated link text within the chooser modal. This involves adding a new `prefer_this_title_as_link_text` flag to the chooser's return value.