### PR TITLE
Trim trailing whitespace in all files but Markdown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 [*.{css,js,json,py,yml}]
 indent_style = space
@@ -15,3 +16,6 @@ indent_size = 4
 
 [*.{js,json,yml}]
 indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
It is common to use [EditorConfig](http://editorconfig.org/) to trim trailing whitespaces at the end of files (for example, [Django does it](https://github.com/django/django/blob/master/.editorconfig)).

It is disabled for Markdown because there trailing whitespace is used to indicate line breaks (not something I would advise on using, but I'd rather not break existing documentation).