### PR TITLE
Fix: Use specific page model for the parent page in the explore index

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -37,6 +37,7 @@ Changelog
  * Fix: Non-text content is now preserved when adding or editing a link within rich text (Matt Westcott)
  * Fix: Fixed preview when `SECURE_SSL_REDIRECT = True` (Aymeric Augustin)
  * Fix: Prevent hang when truncating an image filename without an extension (Ricky Robinett)
+ * Fix: Use specific page model for the parent page in the explore index (Gagaro)
 
 
 1.6.3 (30.09.2016)

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -236,6 +236,12 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
 
         self.assertContains(response, '/new-event/pointless-suffix/')
 
+    def test_parent_page_is_specific(self):
+        response = self.client.get(reverse('wagtailadmin_explore', args=(self.child_page.id, )))
+        self.assertEqual(response.status_code, 200)
+
+        self.assertIsInstance(response.context['parent_page'], SimplePage)
+
 
 class TestPageExplorerSignposting(TestCase, WagtailTestUtils):
     fixtures = ['test.json']

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -38,9 +38,9 @@ def explorer_nav(request):
 
 def index(request, parent_page_id=None):
     if parent_page_id:
-        parent_page = get_object_or_404(Page, id=parent_page_id)
+        parent_page = get_object_or_404(Page, id=parent_page_id).specific
     else:
-        parent_page = Page.get_first_root_node()
+        parent_page = Page.get_first_root_node().specific
 
     pages = parent_page.get_children().prefetch_related('content_type')
 


### PR DESCRIPTION
Hi,

I have customized `get_url_parts` on my page models so that the URL is a bit different. However, the page used for the `parent_page` in the explore used the Page model and thus I get an incorrect URL for the live button.

The `parent_page` should be of the specific page model in this view (just like the pages are).

Thanks.