### PR TITLE
Improves general consistency of modeladmin views

### DIFF
--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -210,7 +210,6 @@ class InstanceSpecificView(WMABaseView):
 
 class IndexView(WMABaseView):
 
-    # IndexView settings
     ORDER_VAR = 'o'
     ORDER_TYPE_VAR = 'ot'
     PAGE_VAR = 'p'

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -925,16 +925,13 @@ class InspectView(InstanceSpecificView):
         return fields
 
     def get_context_data(self, **kwargs):
-        context = super(InspectView, self).get_context_data(**kwargs)
         buttons = self.button_helper.get_buttons_for_obj(
             self.instance, exclude=['inspect'])
-        context.update({
-            'view': self,
+        kwargs.update({
             'fields': self.get_fields_dict(),
             'buttons': buttons,
-            'instance': self.instance,
         })
-        return context
+        return super(InspectView, self).get_context_data(**kwargs)
 
     def get_template_names(self):
         return self.model_admin.get_inspect_template()

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -19,7 +19,7 @@ from django.db.models.constants import LOOKUP_SEP
 from django.db.models.fields import FieldDoesNotExist
 from django.db.models.fields.related import ForeignObjectRel, ManyToManyField
 from django.db.models.sql.constants import QUERY_TERMS
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, redirect
 from django.template.defaultfilters import filesizeformat
 from django.utils import six
 from django.utils.decorators import method_decorator
@@ -99,6 +99,13 @@ class WMABaseView(TemplateView):
     def get_base_queryset(self, request=None):
         return self.model_admin.get_queryset(request or self.request)
 
+    def get_context_data(self, **kwargs):
+        kwargs.update({
+            'view': self,
+            'model_admin': self.model_admin,
+        })
+        return super(WMABaseView, self).get_context_data(**kwargs)
+
 
 class ModelFormView(WMABaseView, FormView):
 
@@ -132,18 +139,15 @@ class ModelFormView(WMABaseView, FormView):
         )
 
     def get_context_data(self, **kwargs):
-        context = super(ModelFormView, self).get_context_data(**kwargs)
         instance = self.get_instance()
         edit_handler_class = self.get_edit_handler_class()
         form = self.get_form()
-        context.update({
-            'view': self,
-            'model_admin': self.model_admin,
+        kwargs.update({
             'is_multipart': form.is_multipart(),
             'edit_handler': edit_handler_class(instance=instance, form=form),
             'form': form,
         })
-        return context
+        return super(ModelFormView, self).get_context_data(**kwargs)
 
     def get_success_message(self, instance):
         return _("{model_name} '{instance}' created.").format(
@@ -198,6 +202,10 @@ class InstanceSpecificView(WMABaseView):
     @cached_property
     def delete_url(self):
         return self.url_helper.get_action_url('delete', self.pk_quoted)
+
+    def get_context_data(self, **kwargs):
+        kwargs['instance'] = self.instance
+        return super(InstanceSpecificView, self).get_context_data(**kwargs)
 
 
 class IndexView(WMABaseView):
@@ -618,7 +626,7 @@ class IndexView(WMABaseView):
         except InvalidPage:
             page_obj = paginator.page(1)
 
-        context = {
+        kwargs.update({
             'view': self,
             'all_count': all_count,
             'result_count': result_count,
@@ -626,18 +634,18 @@ class IndexView(WMABaseView):
             'page_obj': page_obj,
             'object_list': page_obj.object_list,
             'user_can_create': self.permission_helper.user_can_create(user)
-        }
+        })
 
         if self.is_pagemodel:
             models = self.model.allowed_parent_page_models()
             allowed_parent_types = [m._meta.verbose_name for m in models]
             valid_parents = self.permission_helper.get_valid_parent_pages(user)
             valid_parent_count = valid_parents.count()
-            context.update({
+            kwargs.update({
                 'no_valid_parents': not valid_parent_count,
                 'required_parent_types': allowed_parent_types,
             })
-        return context
+        return super(IndexView, self).get_context_data(**kwargs)
 
     def get_template_names(self):
         return self.model_admin.get_index_template()
@@ -727,20 +735,25 @@ class ChooseParentView(WMABaseView):
 
     def get(self, request, *args, **kwargs):
         form = self.get_form(request)
-        context = {'view': self, 'form': form}
-        return render(request, self.get_template(), context)
+        context = self.get_context_data(form=form)
+        return self.render_to_response(context)
 
     def post(self, request, *args, **kargs):
         form = self.get_form(request)
         if form.is_valid():
-            parent_pk = quote(form.cleaned_data['parent_page'].pk)
-            return redirect(self.url_helper.get_action_url(
-                'add', self.app_label, self.model_name, parent_pk))
+            return self.form_valid(form)
+        return self.form_invalid(form)
 
-        context = {'view': self, 'form': form}
-        return render(request, self.get_template(), context)
+    def form_valid(self, form):
+        parent_pk = quote(form.cleaned_data['parent_page'].pk)
+        return redirect(self.url_helper.get_action_url(
+            'add', self.app_label, self.model_name, parent_pk))
 
-    def get_template(self):
+    def form_invalid(self, form):
+        context = self.get_context_data(form=form)
+        return self.render_to_response(context)
+
+    def get_template_names(self):
         return self.model_admin.get_choose_parent_template()
 
 
@@ -769,10 +782,6 @@ class DeleteView(InstanceSpecificView):
             "site are related to it, they may also be affected."
         ) % self.verbose_name
 
-    def get(self, request, *args, **kwargs):
-        context = {'view': self, 'instance': self.instance}
-        return self.render_to_response(context)
-
     def delete_instance(self):
         self.instance.delete()
 
@@ -793,13 +802,10 @@ class DeleteView(InstanceSpecificView):
                     qs = getattr(self.instance, rel.get_accessor_name())
                     for obj in qs.all():
                         linked_objects.append(obj)
-
-            context = {
-                'view': self,
-                'instance': self.instance,
-                'protected_error': True,
-                'linked_objects': linked_objects,
-            }
+            context = self.get_context_data(
+                protected_error=True,
+                linked_objects=linked_objects
+            )
             return self.render_to_response(context)
 
     def get_template_names(self):


### PR DESCRIPTION
As @kaedroho rightly pointed out in issue #2984, there are some inconsistencies in the views, which this pull aims to correct.

In addition to calling `get_context_data` in `ChooseParentView` and `DeleteView`, I've also:

- Altered the way each view extends `get_context_data` to be tidier and more consistent
- Added `form_valid()` and `form_invalid()` methods to `ChooseParentView` to be in-line with the other views with forms
- Make use of `self.render_to_response()` on `ChooseParentView` instead of repeating that same functionality by calling `render()` directly
- Avoid unnecessary redefinition of `view` and `instance` in context values
