### PR TITLE
Add `data-object_pk` attribute to rows in contrib.modeladmin.IndexView

### DIFF
--- a/docs/reference/contrib/modeladmin/indexview.rst
+++ b/docs/reference/contrib/modeladmin/indexview.rst
@@ -362,6 +362,50 @@ For example:
             return qs.filter(managed_by=request.user)
 
 
+.. _modeladmin_get_extra_attrs_for_row:
+
+----------------------------------------------------
+``ModelAdmin.get_extra_attrs_for_row()``
+----------------------------------------------------
+
+**Must return**: A dictionary
+
+The `get_extra_attrs_for_row` method allows you to add html attributes to
+the opening `<tr>` tag for each result, in addition to the `data-object_pk` and
+`class` attributes already added by the `result_row_display` tag.
+
+If you want to add additional CSS classes, simply provide those class names 
+as a string value using the `class` key, and the `odd`/`even` will be appended
+to your custom class names when rendering.
+
+For example, if you wanted to add some additional class names based on field
+values, you could do something like:
+
+.. code-block:: python
+
+    from decimal import Decimal
+    from django.db import models
+    from wagtail.contrib.modeladmin.options import ModelAdmin
+
+    class BankAccount(models.Model):
+        name = models.CharField(max_length=50)
+        account_number = models.CharField(max_length=50)
+        balance = models.DecimalField(max_digits=5, num_places=2)
+
+
+    class BankAccountAdmin(ModelAdmin):
+        list_display = ('name', 'account_number', 'balance')
+
+        def get_extra_attrs_for_row(self, obj, context):
+            if obj.balance < Decimal('0.00'):
+                classname = 'balance-negative'
+            else:
+                classname = 'balance-positive'
+            return {
+                'class': classname,
+            }
+
+
 .. _modeladmin_get_extra_class_names_for_field_col:
 
 ----------------------------------------------------

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -259,6 +259,14 @@ class ModelAdmin(WagtailRegisterable):
         """
         return self.search_fields or ()
 
+    def get_extra_attrs_for_row(self, obj, context):
+        """
+        Return a dictionary of HTML attributes to be added to the `<tr>`
+        element for the suppled `obj` when rendering the results table in
+        `index_view`. `data-object-pk` is already added by default.
+        """
+        return {}
+
     def get_extra_class_names_for_field_col(self, obj, field_name):
         """
         Return a list of additional CSS class names to be added to the table

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_list.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_list.html
@@ -14,9 +14,7 @@
     </thead>
     <tbody>
     {% for result in results %}
-        <tr class="{% cycle 'odd' 'even' %}">
-            {% result_row_display forloop.counter0 %}
-        </tr>
+        {% result_row_display forloop.counter0 %}
     {% endfor %}
 </tbody>
 </table>

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_row.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_row.html
@@ -1,4 +1,6 @@
 {% load modeladmin_tags %}
-{% for item in result %}
-    {% result_row_value_display forloop.counter0 %}
-{% endfor %}
+<tr {{ row_attrs }}>
+    {% for item in result %}
+        {% result_row_value_display forloop.counter0 %}
+    {% endfor %}
+</tr>

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_row.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_row.html
@@ -1,5 +1,5 @@
 {% load modeladmin_tags %}
-<tr {{ row_attrs }}>
+<tr{{ row_attrs }}>
     {% for item in result %}
         {% result_row_value_display forloop.counter0 %}
     {% endfor %}

--- a/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
+++ b/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
@@ -158,7 +158,11 @@ def result_row_display(context, index):
     view = context['view']
     row_attrs_dict = view.model_admin.get_extra_attrs_for_row(obj, context)
     row_attrs_dict['data-object_pk'] = obj.pk
-    row_attrs_dict['class'] = 'odd' if (index % 2 == 0) else 'even'
+    odd_or_even = 'odd' if (index % 2 == 0) else 'even'
+    if 'class' in row_attrs_dict:
+        row_attrs_dict['class'] += ' %s' % odd_or_even
+    else:
+        row_attrs_dict['class'] = odd_or_even
     row_attrs = ''.join(
         ' %s="%s"' % (key, val) for key, val in row_attrs_dict.items())
     context.update({

--- a/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
+++ b/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
@@ -156,8 +156,14 @@ def admin_list_filter(view, spec):
 def result_row_display(context, index):
     obj = context['object_list'][index]
     view = context['view']
+    row_attrs_dict = view.model_admin.get_extra_attrs_for_row(obj, context)
+    row_attrs_dict['data-object_pk'] = obj.pk
+    row_attrs_dict['class'] = 'odd' if (index % 2 == 0) else 'even'
+    row_attrs = ''.join(
+        ' %s="%s"' % (key, val) for key, val in row_attrs_dict.items())
     context.update({
         'obj': obj,
+        'row_attrs': mark_safe(row_attrs),
         'action_buttons': view.get_buttons_for_obj(obj),
     })
     return context

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -31,12 +31,15 @@ class TestIndexView(TestCase, WagtailTestUtils):
     def test_tr_attributes(self):
         response = self.get()
 
-        # Charlie & The Chocolate factory should be 1st book in the list (odd)
-        # `data-author_yob` should be added, the 'book' class should appear
-        # as well add 'odd', and `data-object_pk` should be set also.
+        # Charlie & The Chocolate factory should be in the list with the
+        # `data-author_yob` and `data-object_pk` attributes added
         self.assertContains(response, 'data-author_yob="1916"')
         self.assertContains(response, 'data-object_pk="3"')
-        self.assertContains(response, 'class="book odd"')
+
+        # There should be two odd rows and two even ones, and 'book' should be
+        # add to the `class` attribute for every one.
+        self.assertContains(response, 'class="book odd"', count=2)
+        self.assertContains(response, 'class="book even"', count=2)
 
     def test_filter(self):
         # Filter by author 1 (JRR Tolkien)

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -31,15 +31,12 @@ class TestIndexView(TestCase, WagtailTestUtils):
     def test_tr_attributes(self):
         response = self.get()
 
-        # Charlie & The Chocolate factory should be 1st
-        self.assertContains(
-            response,
-            '<tr data-author-yob="1916" class="odd" data-object_pk="3">')
-
-        # The Chonicles of Narnia should be 2nd
-        self.assertContains(
-            response,
-            '<tr data-author-yob="1898" class="even" data-object_pk="4">')
+        # Charlie & The Chocolate factory should be 1st book in the list (odd)
+        # `data-author_yob` should be added, the 'book' class should appear
+        # as well add 'odd', and `data-object_pk` should be set also.
+        self.assertContains(response, 'data-author_yob="1916"')
+        self.assertContains(response, 'data-object_pk="3"')
+        self.assertContains(response, 'class="book odd"')
 
     def test_filter(self):
         # Filter by author 1 (JRR Tolkien)

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -30,14 +30,16 @@ class TestIndexView(TestCase, WagtailTestUtils):
 
     def test_tr_attributes(self):
         response = self.get()
-        # The Chonicles of Narnia should be first
+
+        # Charlie & The Chocolate factory should be 1st
         self.assertContains(
             response,
-            '<tr data-author-yob="1898" class="odd" data-object_pk="4">')
-        # Charlie & The Chocolate factory should be 2nd
+            '<tr data-author-yob="1916" class="odd" data-object_pk="3">')
+
+        # The Chonicles of Narnia should be 2nd
         self.assertContains(
             response,
-            '<tr data-author-yob="1916" class="even" data-object_pk="3">')
+            '<tr data-author-yob="1898" class="even" data-object_pk="4">')
 
     def test_filter(self):
         # Filter by author 1 (JRR Tolkien)

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -28,6 +28,17 @@ class TestIndexView(TestCase, WagtailTestUtils):
         # User has add permission
         self.assertEqual(response.context['user_can_create'], True)
 
+    def test_tr_attributes(self):
+        response = self.get()
+        # The Chonicles of Narnia should be first
+        self.assertContains(
+            response,
+            '<tr data-author-yob="1898" class="odd" data-object_pk="4">')
+        # Charlie & The Chocolate factory should be 2nd
+        self.assertContains(
+            response,
+            '<tr data-author-yob="1916" class="even" data-object_pk="3">')
+
     def test_filter(self):
         # Filter by author 1 (JRR Tolkien)
         response = self.get(author__id__exact=1)

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -28,7 +28,8 @@ class BookModelAdmin(ModelAdmin):
 
     def get_extra_attrs_for_row(self, obj, context):
         return {
-            'data-author-yob': obj.author.date_of_birth.year
+            'data-author_yob': obj.author.date_of_birth.year,
+            'class': 'book',
         }
 
 

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -25,6 +25,11 @@ class BookModelAdmin(ModelAdmin):
     inspect_view_enabled = True
     inspect_view_fields_exclude = ('title', )
 
+    def get_extra_attrs_for_row(self, obj, context):
+        return {
+            'data-author-yob': obj.author.date_of_birth.year
+        }
+
 
 class TokenModelAdmin(ModelAdmin):
     model = Token

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -21,6 +21,7 @@ class BookModelAdmin(ModelAdmin):
     menu_order = 300
     list_display = ('title', 'author')
     list_filter = ('author', )
+    ordering = ('title', )
     search_fields = ('title', )
     inspect_view_enabled = True
     inspect_view_fields_exclude = ('title', )


### PR DESCRIPTION
In an effort to improve the extendability of ModelAdmin (specifically for things like #2941 and #2719).

The `<tr>` element for each row in `IndexView` is now rendered by the `result_row_display` template tag, making it possible to do more with it.

A new `get_extra_attrs_for_row()` method on the `ModelAdmin` class is called by `result_row_display` tag to check for additional html attributes to be added for each row, so developers can override that to add custom attributes to the `<tr>` element.
