### PR TITLE
Intelligently select a parent in the page chooser modal

### DIFF
--- a/docs/reference/pages/queryset_reference.rst
+++ b/docs/reference/pages/queryset_reference.rst
@@ -240,3 +240,5 @@ Reference
             homepage.get_children().specific()
 
         See also: :py:attr:`Page.specific <wagtail.wagtailcore.models.Page.specific>`
+
+    .. automethod:: first_common_ancestor

--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -242,6 +242,9 @@ A control for selecting a page object, using Wagtail's page browser. The followi
 ``required`` (default: True)
   If true, the field cannot be left blank.
 
+``target_model`` (default: Page)
+  Restrict choices to a single Page type.
+
 ``can_choose_root`` (default: False)
   If true, the editor can choose the tree root as a page. Normally this would be undesirable, since the tree root is never a usable page, but in some specialised cases it may be appropriate. For example, a block providing a feed of related articles could use a PageChooserBlock to select which subsection of the site articles will be taken from, with the root corresponding to 'everywhere'.
 

--- a/wagtail/wagtailcore/query.py
+++ b/wagtail/wagtailcore/query.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import, unicode_literals
 
+import posixpath
 from collections import defaultdict
 
 from django import VERSION as DJANGO_VERSION
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Q
+from django.db.models import CharField, Q
+from django.db.models.functions import Length, Substr
 from treebeard.mp_tree import MP_NodeQuerySet
 
 from wagtail.wagtailsearch.queryset import SearchableQuerySetMixin
@@ -229,6 +231,105 @@ class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
         This filters the QuerySet to only contain pages that are in a private section
         """
         return self.exclude(self.public_q())
+
+    def first_common_ancestor(self, include_self=False, strict=False):
+        """
+        Find the first ancestor that all pages in this queryset have in common.
+        For example, consider a page heirarchy like::
+
+            - Home/
+                - Foo Event Index/
+                    - Foo Event Page 1/
+                    - Foo Event Page 2/
+                - Bar Event Index/
+                    - Bar Event Page 1/
+                    - Bar Event Page 2/
+
+        The common ancestors for some queries would be:
+
+        .. code-block:: python
+
+            >>> Page.objects\\
+            ...     .type(EventPage)\\
+            ...     .first_common_ancestor()
+            <Page: Home>
+            >>> Page.objects\\
+            ...     .type(EventPage)\\
+            ...     .filter(title__contains='Foo')\\
+            ...     .first_common_ancestor()
+            <Page: Foo Event Index>
+
+        This method tries to be efficient, but if you have millions of pages
+        scattered across your page tree, it will be slow.
+
+        If `include_self` is True, the ancestor can be one of the pages in the
+        queryset:
+
+        .. code-block:: python
+
+            >>> Page.objects\\
+            ...     .filter(title__contains='Foo')\\
+            ...     .first_common_ancestor()
+            <Page: Foo Event Index>
+            >>> Page.objects\\
+            ...     .filter(title__exact='Bar Event Index')\\
+            ...     .first_common_ancestor()
+            <Page: Bar Event Index>
+
+        A few invalid cases exist: when the queryset is empty, when the root
+        Page is in the queryset and ``include_self`` is False, and when there
+        are multiple page trees with no common root (a case Wagtail does not
+        support). If ``strict`` is False (the default), then the first root
+        node is returned in these cases. If ``strict`` is True, then a
+        ``ObjectDoesNotExist`` is raised.
+        """
+        # An empty queryset has no ancestors. This is a problem
+        if not self.exists():
+            if strict:
+                raise self.model.DoesNotExist('Can not find ancestor of empty queryset')
+            return self.model.get_first_root_node()
+
+        if include_self:
+            # Get all the paths of the matched pages.
+            paths = self.order_by().values_list('path', flat=True)
+        else:
+            # Find all the distinct parent paths of all matched pages.
+            # The empty `.order_by()` ensures that `Page.path` is not also
+            # selected to order the results, which makes `.distinct()` works.
+            paths = self.order_by()\
+                .annotate(parent_path=Substr(
+                    'path', 1, Length('path') - self.model.steplen,
+                    output_field=CharField(max_length=255)))\
+                .values_list('parent_path', flat=True)\
+                .distinct()
+
+        # This method works on anything, not just file system paths.
+        common_parent_path = posixpath.commonprefix(paths)
+
+        # That may have returned a path like (0001, 0002, 000), which is
+        # missing some chars off the end. Fix this by trimming the path to a
+        # multiple of `Page.steplen`
+        extra_chars = len(common_parent_path) % self.model.steplen
+        if extra_chars != 0:
+            common_parent_path = common_parent_path[:-extra_chars]
+
+        if common_parent_path is '':
+            # This should only happen when there are multiple trees,
+            # a situation that Wagtail does not support;
+            # or when the root node itself is part of the queryset.
+            if strict:
+                raise self.model.DoesNotExist('No common ancestor found!')
+
+            # Assuming the situation is the latter, just return the root node.
+            # The root node is not its own ancestor, so this is technically
+            # incorrect. If you want very correct operation, use `strict=True`
+            # and receive an error.
+            return self.model.get_first_root_node()
+
+        # Assuming the database is in a consistent state, this page should
+        # *always* exist. If your database is not in a consistent state, you've
+        # got bigger problems.
+        return self.model.objects.get(path=common_parent_path)
 
     def unpublish(self):
         """

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -20,6 +20,7 @@ from django.utils.translation import ugettext_lazy as __
 
 from wagtail.tests.testapp.blocks import LinkBlock as CustomLinkBlock
 from wagtail.tests.testapp.blocks import SectionBlock
+from wagtail.tests.testapp.models import SimplePage
 from wagtail.wagtailcore import blocks
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.rich_text import RichText
@@ -2036,6 +2037,11 @@ class TestPageChooserBlock(TestCase):
         self.assertIn(expected_html, christmas_form_html)
         self.assertIn("pick a page, any page", christmas_form_html)
 
+    def test_form_render_with_target_model(self):
+        block = blocks.PageChooserBlock(help_text="pick a page, any page", target_model='tests.SimplePage')
+        empty_form_html = block.render_form(None, 'page')
+        self.assertIn('createPageChooser("page", ["tests.simplepage"], null, false);', empty_form_html)
+
     def test_form_render_with_can_choose_root(self):
         block = blocks.PageChooserBlock(help_text="pick a page, any page", can_choose_root=True)
         empty_form_html = block.render_form(None, 'page')
@@ -2062,6 +2068,26 @@ class TestPageChooserBlock(TestCase):
 
         self.assertEqual(nonrequired_block.clean(christmas_page), christmas_page)
         self.assertEqual(nonrequired_block.clean(None), None)
+
+    def test_target_model_string(self):
+        block = blocks.PageChooserBlock(target_model='tests.SimplePage')
+        self.assertEqual(block.target_model, SimplePage)
+
+    def test_target_model_literal(self):
+        block = blocks.PageChooserBlock(target_model=SimplePage)
+        self.assertEqual(block.target_model, SimplePage)
+
+    def test_deconstruct_target_model_string(self):
+        block = blocks.PageChooserBlock(target_model='tests.SimplePage')
+        self.assertEqual(block.deconstruct(), (
+            'wagtail.wagtailcore.blocks.PageChooserBlock',
+            (), {'target_model': 'tests.SimplePage'}))
+
+    def test_deconstruct_target_model_literal(self):
+        block = blocks.PageChooserBlock(target_model=SimplePage)
+        self.assertEqual(block.deconstruct(), (
+            'wagtail.wagtailcore.blocks.PageChooserBlock',
+            (), {'target_model': 'tests.SimplePage'}))
 
 
 class TestSystemCheck(TestCase):


### PR DESCRIPTION
This PR improves the page chooser modal when the valid page types are restricted. In the case of selecting an `EventPage`, all of which are under an `EventIndex` page, the modal will open at the `EventIndex` page, saving the editor much clicking.

Each commit adds one feature, and comes with its own tests and docs.