### PR TITLE
Added getters for templates in `AbstractForm`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changelog
 ~~~~~~~~~~~~~~~~
 
 * Added support of a custom `edit_handler` in site settings (Axel Haustant)
+* Added getters for templates in `AbstractForm` (Gagaro)
 
 
 1.7 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/reference/contrib/forms.rst
+++ b/docs/reference/contrib/forms.rst
@@ -74,7 +74,7 @@ You now need to create two templates named ``form_page.html`` and ``form_page_la
         </body>
     </html>
 
-``form_page_landing.html`` is a regular Wagtail template, displayed after the user makes a successful form submission.
+``form_page_landing.html`` is a regular Wagtail template, displayed after the user makes a successful form submission. If you want to dynamically override the landing page template, you can do so with the ``get_landing_page_template`` method (in the same way that you would with ``get_template``).
 
 
 .. _wagtailforms_formsubmissionpanel:

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -207,6 +207,9 @@ class AbstractForm(Page):
 
         return form_class(*args, **form_params)
 
+    def get_landing_page_template(self, request, *args, **kwargs):
+        return self.landing_page_template
+
     def get_submission_class(self):
         """
         Returns submission class.
@@ -242,7 +245,7 @@ class AbstractForm(Page):
                 # TODO: It is much better to redirect to it
                 return render(
                     request,
-                    self.landing_page_template,
+                    self.get_landing_page_template(request),
                     self.get_context(request)
                 )
         else:
@@ -252,7 +255,7 @@ class AbstractForm(Page):
         context['form'] = form
         return render(
             request,
-            self.template,
+            self.get_template(request),
             context
         )
 
@@ -265,7 +268,7 @@ class AbstractForm(Page):
         if mode == 'landing':
             return render(
                 request,
-                self.landing_page_template,
+                self.get_landing_page_template(request),
                 self.get_context(request)
             )
         else:


### PR DESCRIPTION
I added getters for the two templates in `AbstractForm` in order to be able to dynamically override them much easier.