### PR TITLE
Move `get_image_model`, add `get_image_model_string`

### DIFF
--- a/docs/advanced_topics/images/custom_image_model.rst
+++ b/docs/advanced_topics/images/custom_image_model.rst
@@ -1,5 +1,6 @@
 .. _custom_image_model:
 
+===================
 Custom image models
 ===================
 
@@ -23,7 +24,7 @@ Here's an example:
     from django.db import models
     from django.db.models.signals import post_delete
     from django.dispatch import receiver
-    
+
     from wagtail.wagtailimages.models import Image, AbstractImage, AbstractRendition
 
 
@@ -87,3 +88,12 @@ Then set the ``WAGTAILIMAGES_IMAGE_MODEL`` setting to point to it:
 
     Any templates that reference the builtin image model will still continue to
     work as before but would need to be updated in order to see any new images.
+
+Referring to the image model
+============================
+
+.. module:: wagtail.wagtailimages
+
+.. autofunction:: get_image_model
+
+.. autofunction:: get_image_model_string

--- a/wagtail/api/v2/signal_handlers.py
+++ b/wagtail/api/v2/signal_handlers.py
@@ -7,7 +7,7 @@ from wagtail.contrib.wagtailfrontendcache.utils import purge_url_from_cache
 from wagtail.wagtailcore.models import get_page_models
 from wagtail.wagtailcore.signals import page_published, page_unpublished
 from wagtail.wagtaildocs.models import get_document_model
-from wagtail.wagtailimages.models import get_image_model
+from wagtail.wagtailimages import get_image_model
 
 from .utils import get_base_url
 

--- a/wagtail/api/v2/tests/test_images.py
+++ b/wagtail/api/v2/tests/test_images.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from wagtail.api.v2 import signal_handlers
-from wagtail.wagtailimages.models import get_image_model
+from wagtail.wagtailimages import get_image_model
 
 
 class TestImageListing(TestCase):

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -36,7 +36,8 @@ from wagtail.wagtailadmin import messages
 from wagtail.wagtailadmin.edit_handlers import (
     ObjectList, extract_panel_definitions_from_model_class)
 from wagtail.wagtaildocs.models import get_document_model
-from wagtail.wagtailimages.models import Filter, get_image_model
+from wagtail.wagtailimages import get_image_model
+from wagtail.wagtailimages.models import Filter
 
 from .forms import ParentChooserForm
 

--- a/wagtail/contrib/wagtailapi/endpoints.py
+++ b/wagtail/contrib/wagtailapi/endpoints.py
@@ -13,7 +13,7 @@ from rest_framework.viewsets import GenericViewSet
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.utils import resolve_model_string
 from wagtail.wagtaildocs.models import get_document_model
-from wagtail.wagtailimages.models import get_image_model
+from wagtail.wagtailimages import get_image_model
 
 from .filters import ChildOfFilter, DescendantOfFilter, FieldsFilter, OrderingFilter, SearchFilter
 from .pagination import WagtailPagination

--- a/wagtail/contrib/wagtailapi/signal_handlers.py
+++ b/wagtail/contrib/wagtailapi/signal_handlers.py
@@ -7,7 +7,7 @@ from wagtail.contrib.wagtailfrontendcache.utils import purge_url_from_cache
 from wagtail.wagtailcore.models import get_page_models
 from wagtail.wagtailcore.signals import page_published, page_unpublished
 from wagtail.wagtaildocs.models import get_document_model
-from wagtail.wagtailimages.models import get_image_model
+from wagtail.wagtailimages import get_image_model
 
 from .utils import get_base_url
 

--- a/wagtail/contrib/wagtailapi/tests/test_images.py
+++ b/wagtail/contrib/wagtailapi/tests/test_images.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from wagtail.contrib.wagtailapi import signal_handlers
-from wagtail.wagtailimages.models import get_image_model
+from wagtail.wagtailimages import get_image_model
 
 
 class TestImageListing(TestCase):

--- a/wagtail/wagtailadmin/tests/api/test_images.py
+++ b/wagtail/wagtailadmin/tests/api/test_images.py
@@ -5,7 +5,7 @@ import json
 from django.core.urlresolvers import reverse
 
 from wagtail.api.v2.tests.test_images import TestImageDetail, TestImageListing
-from wagtail.wagtailimages.models import get_image_model
+from wagtail.wagtailimages import get_image_model
 from wagtail.wagtailimages.tests.utils import get_test_image_file
 
 from .utils import AdminAPITestCase

--- a/wagtail/wagtailimages/__init__.py
+++ b/wagtail/wagtailimages/__init__.py
@@ -8,12 +8,21 @@ default_app_config = 'wagtail.wagtailimages.apps.WagtailImagesAppConfig'
 
 
 def get_image_model_string():
-    """Get the dotted app.Model name for the image model"""
+    """
+    Get the dotted ``app.Model`` name for the image model as a string.
+    Useful for developers making Wagtail plugins that need to refer to the
+    image model, such as in foreign keys, but the model itself is not required.
+    """
     return getattr(settings, 'WAGTAILIMAGES_IMAGE_MODEL', 'wagtailimages.Image')
 
 
 def get_image_model():
-    """Get the image model from WAGTAILIMAGES_IMAGE_MODEL."""
+    """
+    Get the image model from the ``WAGTAILIMAGES_IMAGE_MODEL`` setting.
+    Useful for developers making Wagtail plugins that need the image model.
+    Defaults to the standard :class:`~wagtail.wagtailimages.models.Image` model
+    if no custom model is defined.
+    """
     from django.apps import apps
     model_string = get_image_model_string()
     try:

--- a/wagtail/wagtailimages/__init__.py
+++ b/wagtail/wagtailimages/__init__.py
@@ -1,1 +1,26 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+
 default_app_config = 'wagtail.wagtailimages.apps.WagtailImagesAppConfig'
+
+
+def get_image_model_string():
+    """Get the dotted app.Model name for the image model"""
+    return getattr(settings, 'WAGTAILIMAGES_IMAGE_MODEL', 'wagtailimages.Image')
+
+
+def get_image_model():
+    """Get the image model from WAGTAILIMAGES_IMAGE_MODEL."""
+    from django.apps import apps
+    model_string = get_image_model_string()
+    try:
+        return apps.get_model(model_string)
+    except ValueError:
+        raise ImproperlyConfigured("WAGTAILIMAGES_IMAGE_MODEL must be of the form 'app_label.model_name'")
+    except LookupError:
+        raise ImproperlyConfigured(
+            "WAGTAILIMAGES_IMAGE_MODEL refers to model '%s' that has not been installed" % model_string
+        )

--- a/wagtail/wagtailimages/api/v2/endpoints.py
+++ b/wagtail/wagtailimages/api/v2/endpoints.py
@@ -3,9 +3,8 @@ from __future__ import absolute_import, unicode_literals
 from wagtail.api.v2.endpoints import BaseAPIEndpoint
 from wagtail.api.v2.filters import FieldsFilter, OrderingFilter, SearchFilter
 
-from ...models import get_image_model
+from ... import get_image_model
 from .serializers import ImageSerializer
-
 
 
 class ImagesAPIEndpoint(BaseAPIEndpoint):

--- a/wagtail/wagtailimages/blocks.py
+++ b/wagtail/wagtailimages/blocks.py
@@ -10,7 +10,7 @@ from .shortcuts import get_rendition_or_not_found
 class ImageChooserBlock(ChooserBlock):
     @cached_property
     def target_model(self):
-        from wagtail.wagtailimages.models import get_image_model
+        from wagtail.wagtailimages import get_image_model
         return get_image_model()
 
     @cached_property

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -10,7 +10,6 @@ from contextlib import contextmanager
 import django
 from django.conf import settings
 from django.core import checks
-from django.core.exceptions import ImproperlyConfigured
 from django.core.files import File
 from django.core.urlresolvers import reverse
 from django.db import models
@@ -27,7 +26,7 @@ from taggit.managers import TaggableManager
 from unidecode import unidecode
 from willow.image import Image as WillowImage
 
-from wagtail.utils.deprecation import RemovedInWagtail19Warning
+from wagtail.utils.deprecation import RemovedInWagtail19Warning, RemovedInWagtail110Warning
 from wagtail.wagtailadmin.utils import get_object_usage
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import CollectionMember
@@ -46,6 +45,14 @@ class SourceImageIOError(IOError):
 
 class ImageQuerySet(SearchableQuerySetMixin, models.QuerySet):
     pass
+
+
+def get_image_model():
+    warnings.warn("wagtail.wagtailimages.models.get_image_model "
+                  "has been moved to wagtail.wagtailimages.get_image_model",
+                  RemovedInWagtail110Warning)
+    from wagtail.wagtailimages import get_image_model
+    return get_image_model()
 
 
 def get_upload_to(instance, filename):
@@ -357,26 +364,6 @@ def image_feature_detection(sender, instance, **kwargs):
 def image_delete(sender, instance, **kwargs):
     # Pass false so FileField doesn't save the model.
     instance.file.delete(False)
-
-
-def get_image_model():
-    from django.conf import settings
-    from django.apps import apps
-
-    try:
-        app_label, model_name = settings.WAGTAILIMAGES_IMAGE_MODEL.split('.')
-    except AttributeError:
-        return Image
-    except ValueError:
-        raise ImproperlyConfigured("WAGTAILIMAGES_IMAGE_MODEL must be of the form 'app_label.model_name'")
-
-    image_model = apps.get_model(app_label, model_name)
-    if image_model is None:
-        raise ImproperlyConfigured(
-            "WAGTAILIMAGES_IMAGE_MODEL refers to model '%s' that has not been installed" %
-            settings.WAGTAILIMAGES_IMAGE_MODEL
-        )
-    return image_model
 
 
 class Filter(models.Model):

--- a/wagtail/wagtailimages/permissions.py
+++ b/wagtail/wagtailimages/permissions.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import, unicode_literals
 
 from wagtail.wagtailcore.permission_policies.collections import CollectionOwnershipPermissionPolicy
-from wagtail.wagtailimages.models import Image, get_image_model
+from wagtail.wagtailimages import get_image_model
+from wagtail.wagtailimages.models import Image
 
 permission_policy = CollectionOwnershipPermissionPolicy(
     get_image_model(),

--- a/wagtail/wagtailimages/rich_text.py
+++ b/wagtail/wagtailimages/rich_text.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
+from wagtail.wagtailimages import get_image_model
 from wagtail.wagtailimages.formats import get_image_format
-from wagtail.wagtailimages.models import get_image_model
 
 
 class ImageEmbedHandler(object):

--- a/wagtail/wagtailimages/tests/test_rich_text.py
+++ b/wagtail/wagtailimages/tests/test_rich_text.py
@@ -2,9 +2,10 @@ from __future__ import absolute_import, unicode_literals
 
 from bs4 import BeautifulSoup
 from django.test import TestCase
-from mock import patch
 
 from wagtail.wagtailimages.rich_text import ImageEmbedHandler
+
+from .utils import Image, get_test_image_file
 
 
 class TestImageEmbedHandler(TestCase):
@@ -27,9 +28,8 @@ class TestImageEmbedHandler(TestCase):
         )
         self.assertEqual(result, '<img>')
 
-    @patch('wagtail.wagtailimages.models.Image')
-    @patch('django.core.files.File')
-    def test_expand_db_attributes_not_for_editor(self, mock_file, mock_image):
+    def test_expand_db_attributes_not_for_editor(self):
+        Image.objects.create(id=1, title='Test', file=get_test_image_file())
         result = ImageEmbedHandler.expand_db_attributes(
             {'id': 1,
              'alt': 'test-alt',
@@ -38,9 +38,8 @@ class TestImageEmbedHandler(TestCase):
         )
         self.assertIn('<img class="richtext-image left"', result)
 
-    @patch('wagtail.wagtailimages.models.Image')
-    @patch('django.core.files.File')
-    def test_expand_db_attributes_for_editor(self, mock_file, mock_image):
+    def test_expand_db_attributes_for_editor(self):
+        Image.objects.create(id=1, title='Test', file=get_test_image_file())
         result = ImageEmbedHandler.expand_db_attributes(
             {'id': 1,
              'alt': 'test-alt',

--- a/wagtail/wagtailimages/tests/tests.py
+++ b/wagtail/wagtailimages/tests/tests.py
@@ -2,8 +2,10 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 import unittest
+import warnings
 
 from django import forms, template
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.test import TestCase, override_settings
@@ -13,6 +15,8 @@ from taggit.forms import TagField, TagWidget
 
 from wagtail.tests.testapp.models import CustomImage, CustomImageFilePath
 from wagtail.tests.utils import WagtailTestUtils
+from wagtail.utils.deprecation import RemovedInWagtail110Warning
+from wagtail.wagtailimages import get_image_model, get_image_model_string
 from wagtail.wagtailimages.fields import WagtailImageField
 from wagtail.wagtailimages.formats import Format, get_image_format, register_image_format
 from wagtail.wagtailimages.forms import get_image_form
@@ -580,3 +584,49 @@ class TestDifferentUpload(TestCase):
         # The files should be uploaded based on it's content, not just
         # it's filename
         self.assertFalse(image.file.url == second_image.file.url)
+
+
+class TestGetImageModel(WagtailTestUtils, TestCase):
+    @override_settings(WAGTAILIMAGES_IMAGE_MODEL='tests.CustomImage')
+    def test_custom_get_image_model(self):
+        """Test get_image_model with a custom image model"""
+        self.assertIs(get_image_model(), CustomImage)
+
+    @override_settings(WAGTAILIMAGES_IMAGE_MODEL='tests.CustomImage')
+    def test_custom_get_image_model_string(self):
+        """Test get_image_model_string with a custom image model"""
+        self.assertEqual(get_image_model_string(), 'tests.CustomImage')
+
+    @override_settings()
+    def test_standard_get_image_model(self):
+        """Test get_image_model with no WAGTAILIMAGES_IMAGE_MODEL"""
+        del settings.WAGTAILIMAGES_IMAGE_MODEL
+        from wagtail.wagtailimages.models import Image
+        self.assertIs(get_image_model(), Image)
+
+    @override_settings()
+    def test_standard_get_image_model_string(self):
+        """Test get_image_model_STRING with no WAGTAILIMAGES_IMAGE_MODEL"""
+        del settings.WAGTAILIMAGES_IMAGE_MODEL
+        self.assertEqual(get_image_model_string(), 'wagtailimages.Image')
+
+    @override_settings(WAGTAILIMAGES_IMAGE_MODEL='tests.UnknownModel')
+    def test_unknown_get_image_model(self):
+        """Test get_image_model with an unknown model"""
+        with self.assertRaises(ImproperlyConfigured):
+            get_image_model()
+
+    @override_settings(WAGTAILIMAGES_IMAGE_MODEL='invalid-string')
+    def test_invalid_get_image_model(self):
+        """Test get_image_model with an invalid model string"""
+        with self.assertRaises(ImproperlyConfigured):
+            get_image_model()
+
+    def test_deprecated_get_image_model(self):
+        from wagtail.wagtailimages.models import get_image_model
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
+
+            self.assertIs(Image, get_image_model())
+            self.assertEqual(len(ws), 1)
+            self.assertIs(ws[0].category, RemovedInWagtail110Warning)

--- a/wagtail/wagtailimages/tests/utils.py
+++ b/wagtail/wagtailimages/tests/utils.py
@@ -4,7 +4,7 @@ import PIL.Image
 from django.core.files.images import ImageFile
 from django.utils.six import BytesIO
 
-from wagtail.wagtailimages.models import get_image_model
+from wagtail.wagtailimages import get_image_model
 
 Image = get_image_model()
 

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -10,9 +10,9 @@ from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 from wagtail.wagtailadmin.utils import PermissionPolicyChecker, popular_tags_for_model
 from wagtail.wagtailcore.models import Collection
+from wagtail.wagtailimages import get_image_model
 from wagtail.wagtailimages.formats import get_image_format
 from wagtail.wagtailimages.forms import ImageInsertionForm, get_image_form
-from wagtail.wagtailimages.models import get_image_model
 from wagtail.wagtailimages.permissions import permission_policy
 from wagtail.wagtailsearch import index as search_index
 

--- a/wagtail/wagtailimages/views/images.py
+++ b/wagtail/wagtailimages/views/images.py
@@ -14,9 +14,10 @@ from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailadmin.utils import (
     PermissionPolicyChecker, permission_denied, popular_tags_for_model)
 from wagtail.wagtailcore.models import Collection, Site
+from wagtail.wagtailimages import get_image_model
 from wagtail.wagtailimages.exceptions import InvalidFilterSpecError
 from wagtail.wagtailimages.forms import URLGeneratorForm, get_image_form
-from wagtail.wagtailimages.models import Filter, get_image_model
+from wagtail.wagtailimages.models import Filter
 from wagtail.wagtailimages.permissions import permission_policy
 from wagtail.wagtailimages.views.serve import generate_signature
 from wagtail.wagtailsearch import index as search_index

--- a/wagtail/wagtailimages/views/multiple.py
+++ b/wagtail/wagtailimages/views/multiple.py
@@ -9,9 +9,9 @@ from django.views.decorators.http import require_POST
 from django.views.decorators.vary import vary_on_headers
 
 from wagtail.wagtailadmin.utils import PermissionPolicyChecker
+from wagtail.wagtailimages import get_image_model
 from wagtail.wagtailimages.fields import ALLOWED_EXTENSIONS
 from wagtail.wagtailimages.forms import get_image_form
-from wagtail.wagtailimages.models import get_image_model
 from wagtail.wagtailimages.permissions import permission_policy
 from wagtail.wagtailsearch.backends import get_search_backends
 

--- a/wagtail/wagtailimages/views/serve.py
+++ b/wagtail/wagtailimages/views/serve.py
@@ -15,8 +15,9 @@ from django.utils.six import text_type
 from django.views.generic import View
 
 from wagtail.utils.sendfile import sendfile
+from wagtail.wagtailimages import get_image_model
 from wagtail.wagtailimages.exceptions import InvalidFilterSpecError
-from wagtail.wagtailimages.models import SourceImageIOError, get_image_model
+from wagtail.wagtailimages.models import SourceImageIOError
 
 
 def generate_signature(image_id, filter_spec, key=None):

--- a/wagtail/wagtailimages/wagtail_hooks.py
+++ b/wagtail/wagtailimages/wagtail_hooks.py
@@ -11,10 +11,9 @@ from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailadmin.search import SearchArea
 from wagtail.wagtailadmin.site_summary import SummaryItem
 from wagtail.wagtailcore import hooks
-from wagtail.wagtailimages import admin_urls, image_operations
+from wagtail.wagtailimages import admin_urls, get_image_model, image_operations
 from wagtail.wagtailimages.api.admin.endpoints import ImagesAdminAPIEndpoint
 from wagtail.wagtailimages.forms import GroupImagePermissionFormSet
-from wagtail.wagtailimages.models import get_image_model
 from wagtail.wagtailimages.permissions import permission_policy
 from wagtail.wagtailimages.rich_text import ImageEmbedHandler
 

--- a/wagtail/wagtailimages/widgets.py
+++ b/wagtail/wagtailimages/widgets.py
@@ -6,7 +6,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.wagtailadmin.widgets import AdminChooser
-from wagtail.wagtailimages.models import get_image_model
+from wagtail.wagtailimages import get_image_model
 
 
 class AdminImageChooser(AdminChooser):


### PR DESCRIPTION
Move get_image_model, add get_image_model_string
    
Having `get_image_model` at `wagtail.wagtailimages` is consistent with `django.contrib.auth.get_user_model`, and means developers can import `get_image_model` in an environment where models are not yet ready.
    
`get_image_model_string` has been added for uses where the model itself is not required, and might not be available, but a reference to the possibly swapped out Image model is required.
 
