### PR TITLE
Remove useless SelectorFormat rule in scss-lint

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -86,22 +86,11 @@ linters:
     SelectorDepth:
         enabled: false
 
+    # There is currently no de facto standard for selector format in Wagtail, due to:
+    # a) the conversion of django field/widget names to underscored class names
+    # b) the use of third party code such as Hallo.js which uses classes with snakeCaseClasses.
     SelectorFormat:
-        convention: hyphenated_BEM
-        ignored_names:
-            - js_class
-        ignored_types:
-            - element
-        # There are regretably quite a few exlusions here, made necessary by
-        # a) the conversion of django field/widget names to underscored class names
-        # b) the use of third party code such as Hallo.js which uses classes with snakeCaseClasses.
-        exclude:
-            - '**/rich-text.scss'
-            - '**/_forms.scss'
-            - '**/_streamfield.scss'
-            - '**/page-editor.scss'
-            - '**/_datetimepicker.scss'
-            - '**/choose_parent_page.scss'
+        convention: '.*'  # allow anything
 
     PlaceholderInExtend:
         enabled: false


### PR DESCRIPTION
Prompted by this Drone CI failure:

https://github.com/torchbox/wagtail/pull/3035/commits/0098d6a21fe06a017d6e925967a831328f17702d
http://46.101.88.142/torchbox/wagtail/438

As the existing comment admits, we're de-facto _not_ adopting the hyphenated-BEM convention in our CSS, due to the auto-generated underscored class names on form widgets - so having that rule in place at all (with an ever-growing list of files that are allowed to break it in order to do their job) is a waste of time.
