### PR TITLE
Custom Page Manager documentation fix

### DIFF
--- a/docs/topics/pages.rst
+++ b/docs/topics/pages.rst
@@ -476,4 +476,4 @@ Alternately, if you only need to add extra ``QuerySet`` methods, you can inherit
     class EventPage(Page):
         start_date = models.DateField()
 
-        objects = PageManager.from_queryset(EventPageQuerySet)
+        objects = PageManager.from_queryset(EventPageQuerySet)()


### PR DESCRIPTION
The `from_queryset` classmethod seems to be a factory, and returns a class, not an instance. The Django documentation example for this has an extra pair of brackets to instantiate the returned class. https://docs.djangoproject.com/en/1.10/topics/db/managers/#from-queryset

Copying the Wagtail documentation example verbatim causes: 

```
SystemCheckError: System check identified some issues:

ERRORS:
events.EventPage: (wagtailcore.E002) Manager does not inherit from PageManager
        HINT: Ensure that custom Page managers inherit from django.db.models.manager.BasePageManagerFromPageQuerySet
```

More info

``` python
>>> cls
<class 'events.models.EventPage'>
>>> cls.objects
<class 'django.db.models.manager.BasePageManagerFromPageQuerySetFromEventPageQuerySet'>
>>> issubclass(cls.objects, PageManager)
True
>>> isinstance(cls.objects, PageManager)
False
>>> isinstance(cls.objects(), PageManager)
True
```

