### PR TITLE
set_url_paths Django 1.10 friendly, add a test

### DIFF
--- a/wagtail/wagtailcore/management/commands/set_url_paths.py
+++ b/wagtail/wagtailcore/management/commands/set_url_paths.py
@@ -1,17 +1,31 @@
 from __future__ import absolute_import, unicode_literals
 
-from django.core.management.base import NoArgsCommand
+
+# Django < 1.10
+try:
+    from django.core.management.base import NoArgsCommand as BaseCommand
+except ImportError:
+    from django.core.management.base import BaseCommand
+
 
 from wagtail.wagtailcore.models import Page
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
+
+    help = 'Resets url_path fields on each page recursively'
+
     def set_subtree(self, root, root_path):
         root.url_path = root_path
         root.save(update_fields=['url_path'])
         for child in root.get_children():
             self.set_subtree(child, root_path + child.slug + '/')
 
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         for node in Page.get_root_nodes():
             self.set_subtree(node, '/')
+    
+    def handle_noargs(self, **options):
+        """Django < 1.10"""
+        self.handle(**options)
+

--- a/wagtail/wagtailcore/tests/test_management_commands.py
+++ b/wagtail/wagtailcore/tests/test_management_commands.py
@@ -132,6 +132,17 @@ class TestMovePagesCommand(TestCase):
             self.assertEqual(Page.objects.get(id=page_id).get_parent(), about_us)
 
 
+class TestSetUrlPathsCommand(TestCase):
+    
+    fixtures = ['test.json']
+
+    def run_command(self):
+        management.call_command('set_url_paths', interactive=False, stdout=StringIO())
+
+    def test_set_url_paths(self):
+        self.run_command()
+
+
 class TestReplaceTextCommand(TestCase):
     fixtures = ['test.json']
 


### PR DESCRIPTION
Fixes  #3092 

Stumbled upon this bug, I probably don't need the management command, but I guess this kind of fixes it.