### PR TITLE
Fixed #3078 -- Add empty panel attributes

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -395,6 +395,12 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
 
     # Do not allow plain Page instances to be created through the Wagtail admin
     is_creatable = False
+    
+    # Define these attributes early to avoid masking errors. (Issue #3078)
+    # The canonical definition is in wagtailadmin.edit_handlers.
+    content_panels = []
+    promote_panels = []
+    settings_panels = []
 
     def __init__(self, *args, **kwargs):
         super(Page, self).__init__(*args, **kwargs)

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -395,7 +395,7 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
 
     # Do not allow plain Page instances to be created through the Wagtail admin
     is_creatable = False
-    
+
     # Define these attributes early to avoid masking errors. (Issue #3078)
     # The canonical definition is in wagtailadmin.edit_handlers.
     content_panels = []


### PR DESCRIPTION
Accessing any of these attributes before importing `wagtailadmin.edit_handlers` would raise a `AttributeError`. In some cases this would mask the actual error; e.g. forgetting to import `wagtailadmin.edit_handlers`.