### PR TITLE
More helpful message if javascript is not activated.

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -61,7 +61,6 @@ body {
     padding: 1em 2em;
     margin: 0;
     position: relative;
-    width: 100%;
     text-align: center;
 
     a {

--- a/wagtail/wagtailadmin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/skeleton.html
@@ -22,7 +22,7 @@
     <![endif]-->
     <noscript class="capabilitymessage">
         {% blocktrans %}
-            For full functionality of this section it is necessary to enable JavaScript.
+            Javascript is required to use Wagtail, but it is currently disabled.<br />
             Here are the <a href="http://www.enable-javascript.com/" target="_blank" rel="noopener">instructions how to enable JavaScript in your web browser</a>.
         {% endblocktrans %}
     </noscript>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/skeleton.html
@@ -20,7 +20,12 @@
     <!--[if lt IE 9]>
         <p class="capabilitymessage">{% blocktrans %}You are using an <strong>outdated</strong> browser not supported by this software. Please <a href="http://browsehappy.com/">upgrade your browser</a>.{% endblocktrans %}</p>
     <![endif]-->
-    <noscript class="capabilitymessage">{% trans 'Javascript is required to use Wagtail, but it is currently disabled' %}</noscript>
+    <noscript class="capabilitymessage">
+        {% blocktrans %}
+            For full functionality of this section it is necessary to enable JavaScript.
+            Here are the <a href="http://www.enable-javascript.com/" target="_blank" rel="noopener">instructions how to enable JavaScript in your web browser</a>.
+        {% endblocktrans %}
+    </noscript>
 
     {% block js %}{% endblock %}
 


### PR DESCRIPTION
At the moment we give an error message without explaining how to fix the problem, although the likely fix is well known and documented. We should make it easier for people to do the right thing.

What it looks like - cf attachments
<img width="1277" alt="screen shot 2016-10-27 at 9 48 52 am" src="https://cloud.githubusercontent.com/assets/3360430/19744601/adfbbfc4-9c2a-11e6-9fb8-bd070d88958e.png">
<img width="438" alt="screen shot 2016-10-27 at 9 49 06 am" src="https://cloud.githubusercontent.com/assets/3360430/19744602/adfe55f4-9c2a-11e6-89a3-47482fbf0ade.png">

To test it, go into the settings of your developer tool bar and disable Javascript :)

@thibaudcolas for your review.
