### PR TITLE
restructured and added to contribution guide

### DIFF
--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -1,3 +1,5 @@
+.. _developing:
+
 Development
 -----------
 

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -6,10 +6,21 @@ Issues
 
 The easiest way to contribute to Wagtail is to tell us how to improve it! First, check to see if your bug or feature request has already been submitted at `github.com/torchbox/wagtail/issues <https://github.com/torchbox/wagtail/issues>`_. If it has, and you have some supporting information which may help us deal with it, comment on the existing issue. If not, please `create a new one <https://github.com/torchbox/wagtail/issues/new>`_, providing as much relevant context as possible. For example, if you're experiencing problems with installation, detail your environment and the steps you've already taken. If something isn't displaying correctly, tell us what browser you're using, and include a screenshot if possible.
 
+.. toctree::
+    :maxdepth: 2
+
+    issue_tracking
+
 Pull requests
 ~~~~~~~~~~~~~
 
-If you're a Python or Django developer, `fork <https://github.com/torchbox/wagtail/>`_ and get stuck in! Send us a useful pull request and we'll post you a `t-shirt <https://twitter.com/WagtailCMS/status/432166799464210432/photo/1>`_. We welcome all contributions, whether they solve problems which are specific to you or they address existing issues. If you're stuck for ideas, pick something from the `issue list <https://github.com/torchbox/wagtail/issues?state=open>`_, or email us directly on `hello@wagtail.io <mailto:hello@wagtail.io>`_ if you'd like us to suggest something!
+If you're a Python or Django developer, `fork it <https://github.com/torchbox/wagtail/>`_ and read the :ref:`developing docs <developing>` to get stuck in! Send us a useful pull request and we'll post you a `t-shirt <https://twitter.com/WagtailCMS/status/432166799464210432/photo/1>`_. We welcome all contributions, whether they solve problems which are specific to you or they address existing issues. If you're stuck for ideas, pick something from the `issue list <https://github.com/torchbox/wagtail/issues?state=open>`_, or email us directly on `hello@wagtail.io <mailto:hello@wagtail.io>`_ if you'd like us to suggest something!
+
+.. toctree::
+    :maxdepth: 2
+
+    developing
+    committing
 
 
 Translations
@@ -26,15 +37,14 @@ Other contributions
 We welcome contributions to all aspects of Wagtail. If you would like to improve the design of the user interface, or extend the documentation, please submit a pull request as above. If you're not familiar with Github or pull requests, `contact us directly <mailto:hello@wagtail.io>`_ and we'll work something out.
 
 
+More information
+~~~~~~~~~~~~~~~~
 
 .. toctree::
     :maxdepth: 2
 
-    developing
     styleguide
     python_guidelines
     css_guidelines
     javascript_guidelines
-    issue_tracking
-    committing
     release_process


### PR DESCRIPTION
As a new contributor I found some of the information for contributing hard to
find easily. I think this restructure should fix that, by bringing relevant
menus under their headings and adding an additional heading for 'more
information' instead of just 'other contributions'.