### PR TITLE
Make the tests less noisy

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python
 
-import sys
+from __future__ import absolute_import, unicode_literals
+
+import argparse
 import os
 import shutil
+import sys
 import warnings
-import argparse
 
 from django.core.management import execute_from_command_line
-
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'wagtail.tests.settings'
 
 
 def make_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--deprecation', choices=['all', 'pending', 'imminent', 'none'], default='pending')
+    parser.add_argument('--deprecation', choices=['all', 'pending', 'imminent', 'none'], default='imminent')
     parser.add_argument('--postgres', action='store_true')
     parser.add_argument('--elasticsearch', action='store_true')
     parser.add_argument('--elasticsearch2', action='store_true')

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -1,12 +1,15 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+
 import django
 
 WAGTAIL_ROOT = os.path.dirname(os.path.dirname(__file__))
 STATIC_ROOT = os.path.join(WAGTAIL_ROOT, 'tests', 'test-static')
 MEDIA_ROOT = os.path.join(WAGTAIL_ROOT, 'tests', 'test-media')
 MEDIA_URL = '/media/'
+
+TIME_ZONE = 'Asia/Tokyo'
 
 DATABASES = {
     'default': {

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -115,10 +115,11 @@ def clear_edit_handler(page_cls):
         def decorated(self):
             # Clear any old EditHandlers generated
             page_cls.get_edit_handler.cache_clear()
-            fn(self)
-            # Clear the bad EditHandler generated just now
-            page_cls.get_edit_handler.cache_clear()
-        return decorated
+            try:
+                fn(self)
+            finally:
+                # Clear the bad EditHandler generated just now
+                page_cls.get_edit_handler.cache_clear()
     return decorator
 
 

--- a/wagtail/wagtailadmin/tests/test_rich_text.py
+++ b/wagtail/wagtailadmin/tests/test_rich_text.py
@@ -8,7 +8,34 @@ from django.test.utils import override_settings
 from wagtail.tests.testapp.rich_text import CustomRichTextArea
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailadmin.rich_text import HalloRichTextArea, get_rich_text_editor_widget
-from wagtail.wagtailcore.models import Page
+from wagtail.wagtailcore.models import Page, get_page_models
+
+
+class BaseRichTextEditHandlerTestCase(TestCase):
+    def _clear_edit_handler_cache(self):
+        """
+        These tests generate new EditHandlers with different settings. The
+        cached edit handlers should be cleared before and after each test run
+        to ensure that no changes leak through to other tests.
+        """
+        from wagtail.tests.testapp.models import DefaultRichBlockFieldPage
+
+        block_page_edit_handler = DefaultRichBlockFieldPage.get_edit_handler()
+        if block_page_edit_handler._form_class:
+            rich_text_block = block_page_edit_handler._form_class.base_fields['body'].block.child_blocks['rich_text']
+            if hasattr(rich_text_block, 'field'):
+                del rich_text_block.field
+
+        for page_class in get_page_models():
+            page_class.get_edit_handler.cache_clear()
+
+    def setUp(self):
+        super(BaseRichTextEditHandlerTestCase, self).setUp()
+        self._clear_edit_handler_cache()
+
+    def tearDown(self):
+        self._clear_edit_handler_cache()
+        super(BaseRichTextEditHandlerTestCase, self).tearDown()
 
 
 class TestGetRichTextEditorWidget(TestCase):
@@ -50,9 +77,10 @@ class TestGetRichTextEditorWidget(TestCase):
 
 
 @override_settings()
-class TestDefaultRichText(TestCase, WagtailTestUtils):
+class TestDefaultRichText(BaseRichTextEditHandlerTestCase, WagtailTestUtils):
 
     def setUp(self):
+        super(TestDefaultRichText, self).setUp()
         # Find root page
         self.root_page = Page.objects.get(id=2)
 
@@ -61,19 +89,6 @@ class TestDefaultRichText(TestCase, WagtailTestUtils):
         # Simulate the absence of a setting
         if hasattr(settings, 'WAGTAILADMIN_RICH_TEXT_EDITORS'):
             del settings.WAGTAILADMIN_RICH_TEXT_EDITORS
-
-    def tearDown(self):
-        from wagtail.tests.testapp.models import DefaultRichBlockFieldPage
-        from wagtail.tests.testapp.models import DefaultRichTextFieldPage
-
-        DefaultRichTextFieldPage.get_edit_handler()._form_class = None
-
-        block_page_edit_handler = DefaultRichBlockFieldPage.get_edit_handler()
-        if block_page_edit_handler._form_class:
-            rich_text_block = block_page_edit_handler._form_class.base_fields['body'].block.child_blocks['rich_text']
-            if hasattr(rich_text_block, 'field'):
-                del rich_text_block.field
-        block_page_edit_handler._form_class = None
 
     def test_default_editor_in_rich_text_field(self):
         response = self.client.get(reverse(
@@ -103,26 +118,15 @@ class TestDefaultRichText(TestCase, WagtailTestUtils):
         'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
     },
 })
-class TestOverriddenDefaultRichText(TestCase, WagtailTestUtils):
+class TestOverriddenDefaultRichText(BaseRichTextEditHandlerTestCase, WagtailTestUtils):
 
     def setUp(self):
+        super(TestOverriddenDefaultRichText, self).setUp()
+
         # Find root page
         self.root_page = Page.objects.get(id=2)
 
         self.login()
-
-    def tearDown(self):
-        from wagtail.tests.testapp.models import DefaultRichBlockFieldPage
-        from wagtail.tests.testapp.models import DefaultRichTextFieldPage
-
-        DefaultRichTextFieldPage.get_edit_handler()._form_class = None
-
-        block_page_edit_handler = DefaultRichBlockFieldPage.get_edit_handler()
-        if block_page_edit_handler._form_class:
-            rich_text_block = block_page_edit_handler._form_class.base_fields['body'].block.child_blocks['rich_text']
-            if hasattr(rich_text_block, 'field'):
-                del rich_text_block.field
-        block_page_edit_handler._form_class = None
 
     def test_overridden_default_editor_in_rich_text_field(self):
         response = self.client.get(reverse(
@@ -157,20 +161,15 @@ class TestOverriddenDefaultRichText(TestCase, WagtailTestUtils):
         'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
     },
 })
-class TestCustomDefaultRichText(TestCase, WagtailTestUtils):
+class TestCustomDefaultRichText(BaseRichTextEditHandlerTestCase, WagtailTestUtils):
 
     def setUp(self):
+        super(TestCustomDefaultRichText, self).setUp()
+
         # Find root page
         self.root_page = Page.objects.get(id=2)
 
         self.login()
-
-    def tearDown(self):
-        from wagtail.tests.testapp.models import CustomRichBlockFieldPage
-        from wagtail.tests.testapp.models import CustomRichTextFieldPage
-
-        CustomRichBlockFieldPage.get_edit_handler()._form_class = None
-        CustomRichTextFieldPage.get_edit_handler()._form_class = None
 
     def test_custom_editor_in_rich_text_field(self):
         response = self.client.get(reverse(

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -85,7 +85,7 @@ class TestValidation(TestCase):
 
     def test_get_admin_display_title(self):
         homepage = Page.objects.get(url_path='/home/')
-        self.assertEquals(homepage.title, homepage.get_admin_display_title())
+        self.assertEqual(homepage.title, homepage.get_admin_display_title())
 
 
 @override_settings(ALLOWED_HOSTS=['localhost', 'events.example.com', 'about.example.com', 'unknown.site.com'])


### PR DESCRIPTION
The tests print a whole bunch of deprecation warnings, most of which are just ignored. This makes finding actual warnings very difficult.

The default logging level for tests has been changed to `imminent`, so that only DeprecationWarnings are printed. PendingDeprecationWarnings are ignored. This makes the test output usable again on all tests except for those against latest Django. The warnings against latest Django should be dealt with.

With the test output now usable, a few warnings were found and squashed.
