### PR TITLE
Don't repeat set_url_path logic

### DIFF
--- a/wagtail/wagtailcore/management/commands/set_url_paths.py
+++ b/wagtail/wagtailcore/management/commands/set_url_paths.py
@@ -9,12 +9,12 @@ class Command(BaseCommand):
 
     help = 'Resets url_path fields on each page recursively'
 
-    def set_subtree(self, root, root_path):
-        root.url_path = root_path
+    def set_subtree(root, parent=None):
+        root.specific.set_url_path(parent)
         root.save(update_fields=['url_path'])
         for child in root.get_children():
-            self.set_subtree(child, root_path + child.slug + '/')
+            set_subtree(child.specific, root)
 
     def handle(self, *args, **options):
         for node in Page.get_root_nodes():
-            self.set_subtree(node, '/')
+            set_subtree(node)

--- a/wagtail/wagtailcore/management/commands/set_url_paths.py
+++ b/wagtail/wagtailcore/management/commands/set_url_paths.py
@@ -13,8 +13,8 @@ class Command(BaseCommand):
         root.specific.set_url_path(parent)
         root.save(update_fields=['url_path'])
         for child in root.get_children():
-            set_subtree(child.specific, root)
+            self.set_subtree(child.specific, root)
 
     def handle(self, *args, **options):
         for node in Page.get_root_nodes():
-            set_subtree(node)
+            self.set_subtree(node)

--- a/wagtail/wagtailcore/management/commands/set_url_paths.py
+++ b/wagtail/wagtailcore/management/commands/set_url_paths.py
@@ -9,7 +9,7 @@ class Command(BaseCommand):
 
     help = 'Resets url_path fields on each page recursively'
 
-    def set_subtree(root, parent=None):
+    def set_subtree(self, root, parent=None):
         root.specific.set_url_path(parent)
         root.save(update_fields=['url_path'])
         for child in root.get_children():


### PR DESCRIPTION
Classes that extend and override logic for set_url_path need to be respected by this command.

set_url_path is lot more useful when you can namespace a whole lot of pages with this command.

Use case:
We want to namespace our blog urls with the publish date. We would love to go to old posts and change all the url_paths for 1000+ posts.

Also this is a more DRY approach.
