### PR TITLE
Disabling editing if edit lock is locked

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -121,10 +121,10 @@ body {
 .page-locked {
 
     .tab-content {
-    cursor: not-allowed;
-    user-select: none;
+        cursor: not-allowed;
+        user-select: none;
 
-        & > * {
+        > * {
             pointer-events: none;
         }
     }
@@ -154,13 +154,13 @@ footer {
 
     .actions {
         width: 250px;
-        margin-right: $grid-gutter-width/2;
+        margin-right: $grid-gutter-width / 2;
     }
 
     .meta {
         float: right;
         text-align: right;
-        padding: 7px $grid-gutter-width/2;
+        padding: 7px $grid-gutter-width / 2;
         font-size: 0.85em;
 
         p {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -118,6 +118,18 @@ body {
     position: relative; // yuk. necessary for positions for jquery ui widgets
 }
 
+.page-locked {
+
+    .tab-content {
+    cursor: not-allowed;
+    user-select: none;
+
+        & > * {
+            pointer-events: none;
+        }
+    }
+}
+
 footer {
     // @include transition(all 0.2s ease);
     @include transition(bottom 0.5s ease 1s);

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -3,7 +3,7 @@
 {% load gravatar %}
 {% load i18n %}
 {% block titletag %}{% blocktrans with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }}: {{ title }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}page-editor {% if page.live %}page-is-live{% endif %} model-{{ content_type.model }}{% endblock %}
+{% block bodyclass %}page-editor {% if page.live %}page-is-live{% endif %} model-{{ content_type.model }} {% if page.locked %}page-locked{% endif %}{% endblock %}
 
 {% block content %}
     {% page_permissions page as page_perms %}
@@ -28,9 +28,7 @@
         {% csrf_token %}
 
         <input type="hidden" name="next" value="{{ next }}">
-        {% if page.locked %}<div class="page-locked">{% endif %}
-            {{ edit_handler.render_form_content }}
-        {% if page.locked %}</div>{% endif %}
+        {{ edit_handler.render_form_content }}
 
         {% if is_revision %}
             <input type="hidden" name="revision" value="{{ revision.id }}" />

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -26,8 +26,11 @@
 
     <form id="page-edit-form" action="{% url 'wagtailadmin_pages:edit' page.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
+
         <input type="hidden" name="next" value="{{ next }}">
-        {{ edit_handler.render_form_content }}
+        {% if page.locked %}<div class="page-locked">{% endif %}
+            {{ edit_handler.render_form_content }}
+        {% if page.locked %}</div>{% endif %}
 
         {% if is_revision %}
             <input type="hidden" name="revision" value="{{ revision.id }}" />


### PR DESCRIPTION
This PR renders fields and text unselectable on a page where page lock has been applied. Whilst the page lock removes the ability to save a page users can still edit the fields. This is a problem if a user doesn't understand what page lock means and starts editing fields (I've made this mistake myself and know it's tripped up other end-users!)

A user can still select the 'promote' and 'settings' tabs (or whatever custom tabs have been added) as well as the preview button and revisions link.

![capture d ecran 2016-10-29 a 20](https://cloud.githubusercontent.com/assets/11335309/19832146/fc186816-9e13-11e6-963c-4412e9c843dd.png)
