### PR TITLE
Adding in_site convenience method to PageQuerySet

### DIFF
--- a/docs/reference/pages/queryset_reference.rst
+++ b/docs/reference/pages/queryset_reference.rst
@@ -71,6 +71,15 @@ Reference
 
     .. automethod:: not_in_menu
 
+    .. automethod:: in_site
+
+        Example:
+
+        .. code-block:: python
+
+            # Get all the EventPages in the current site
+            site_events = EventPage.objects.in_site(request.site)
+
     .. automethod:: page
 
         Example:

--- a/wagtail/wagtailcore/query.py
+++ b/wagtail/wagtailcore/query.py
@@ -350,6 +350,12 @@ class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
         else:
             return self._clone(klass=SpecificQuerySet)
 
+    def in_site(self, site):
+        """
+        This returns all pages of type self in a site.
+        """
+        return self.descendant_of(site.root_page, inclusive=True)
+
 
 def specific_iterator(qs):
     """

--- a/wagtail/wagtailcore/query.py
+++ b/wagtail/wagtailcore/query.py
@@ -352,7 +352,7 @@ class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
 
     def in_site(self, site):
         """
-        This filters the QuerySet to only contain pages of type self in a specific site.
+        This filters the QuerySet to only contain pages within the specified site
         """
         return self.descendant_of(site.root_page, inclusive=True)
 

--- a/wagtail/wagtailcore/query.py
+++ b/wagtail/wagtailcore/query.py
@@ -352,7 +352,7 @@ class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
 
     def in_site(self, site):
         """
-        This returns all pages of type self in a site.
+        This filters the QuerySet to only contain pages of type self in a specific site.
         """
         return self.descendant_of(site.root_page, inclusive=True)
 

--- a/wagtail/wagtailcore/tests/test_page_queryset.py
+++ b/wagtail/wagtailcore/tests/test_page_queryset.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.test import TestCase
 
-from wagtail.tests.testapp.models import EventPage, SingleEventPage
+from wagtail.tests.testapp.models import EventPage, SingleEventPage, SimplePage
 from wagtail.wagtailcore.models import Page, PageViewRestriction, Site
 from wagtail.wagtailcore.signals import page_unpublished
 
@@ -397,18 +397,38 @@ class TestPageQuerySet(TestCase):
         # Check that the event is in the results
         self.assertTrue(pages.filter(id=event.id).exists())
 
-    def test_in_site(self):
-        site = Site.objects.get(id=2)
 
-        all_events = EventPage.objects.all()
-        site_2_events = EventPage.objects.in_site(site)
+class TestPageQueryInSite(TestCase):
+    fixtures = ['test.json']
+
+    def setUp(self):
+        self.site_2_page = SimplePage.objects.create(
+            title="Site 2 page",
+            slug="site_2_page",
+            content="Hello",
+            path='00010002',
+            depth=1
+        )
+
+        self.site_2 = Site.objects.create(
+            hostname='example.com',
+            port=8080,
+            root_page=Page.objects.get(pk=self.site_2_page.pk),
+            is_default_site=False
+        )
+
+    def test_in_site(self):
+        all_simple_pages = SimplePage.objects.all()
+        print len(all_simple_pages)
+        site_2_pages = SimplePage.objects.in_site(self.site_2)
+        print len(site_2_pages)
 
         # Check that there are more events in all_events and in site_2_events
-        self.assertTrue(len(all_events) > len(site_2_events))
+        self.assertTrue(len(all_simple_pages) > len(site_2_pages))
 
         # Check that site_2_events are actually under the 2nd site
-        for event in site_2_events:
-            self.assertTrue(event.get_site() == site)
+        for page in site_2_pages:
+            self.assertTrue(page.get_site() == self.site_2)
 
 
 class TestPageQuerySetSearch(TestCase):

--- a/wagtail/wagtailcore/tests/test_page_queryset.py
+++ b/wagtail/wagtailcore/tests/test_page_queryset.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from django.test import TestCase, RequestFactory
+from django.test import TestCase
 
 from wagtail.tests.testapp.models import EventPage, SingleEventPage
 from wagtail.wagtailcore.models import Page, PageViewRestriction, Site
@@ -9,9 +9,6 @@ from wagtail.wagtailcore.signals import page_unpublished
 
 class TestPageQuerySet(TestCase):
     fixtures = ['test.json']
-
-    def setUp(self):
-        self.factory = RequestFactory()
 
     def test_live(self):
         pages = Page.objects.live()

--- a/wagtail/wagtailcore/tests/test_page_queryset.py
+++ b/wagtail/wagtailcore/tests/test_page_queryset.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.test import TestCase
 
-from wagtail.tests.testapp.models import EventPage, SingleEventPage, SimplePage
+from wagtail.tests.testapp.models import EventPage, SimplePage, SingleEventPage
 from wagtail.wagtailcore.models import Page, PageViewRestriction, Site
 from wagtail.wagtailcore.signals import page_unpublished
 

--- a/wagtail/wagtailcore/tests/test_page_queryset.py
+++ b/wagtail/wagtailcore/tests/test_page_queryset.py
@@ -419,9 +419,7 @@ class TestPageQueryInSite(TestCase):
 
     def test_in_site(self):
         all_simple_pages = SimplePage.objects.all()
-        print len(all_simple_pages)
         site_2_pages = SimplePage.objects.in_site(self.site_2)
-        print len(site_2_pages)
 
         # Check that there are more events in all_events and in site_2_events
         self.assertTrue(len(all_simple_pages) > len(site_2_pages))

--- a/wagtail/wagtailcore/tests/test_page_queryset.py
+++ b/wagtail/wagtailcore/tests/test_page_queryset.py
@@ -1,14 +1,17 @@
 from __future__ import absolute_import, unicode_literals
 
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
 
 from wagtail.tests.testapp.models import EventPage, SingleEventPage
-from wagtail.wagtailcore.models import Page, PageViewRestriction
+from wagtail.wagtailcore.models import Page, PageViewRestriction, Site
 from wagtail.wagtailcore.signals import page_unpublished
 
 
 class TestPageQuerySet(TestCase):
     fixtures = ['test.json']
+
+    def setUp(self):
+        self.factory = RequestFactory()
 
     def test_live(self):
         pages = Page.objects.live()
@@ -398,15 +401,17 @@ class TestPageQuerySet(TestCase):
         self.assertTrue(pages.filter(id=event.id).exists())
 
     def test_in_site(self):
+        site = Site.objects.get(id=2)
+
         all_events = EventPage.objects.all()
-        site_2_events = EventPage.objects.in_site(request.site)
+        site_2_events = EventPage.objects.in_site(site)
 
         # Check that there are more events in all_events and in site_2_events
         self.assertTrue(len(all_events) > len(site_2_events))
 
         # Check that site_2_events are actually under the 2nd site
         for event in site_2_events:
-            self.assertTrue(event.get_site() == "site2")
+            self.assertTrue(event.get_site() == site)
 
 class TestPageQuerySetSearch(TestCase):
     fixtures = ['test.json']

--- a/wagtail/wagtailcore/tests/test_page_queryset.py
+++ b/wagtail/wagtailcore/tests/test_page_queryset.py
@@ -413,6 +413,7 @@ class TestPageQuerySet(TestCase):
         for event in site_2_events:
             self.assertTrue(event.get_site() == site)
 
+
 class TestPageQuerySetSearch(TestCase):
     fixtures = ['test.json']
 

--- a/wagtail/wagtailcore/tests/test_page_queryset.py
+++ b/wagtail/wagtailcore/tests/test_page_queryset.py
@@ -397,6 +397,16 @@ class TestPageQuerySet(TestCase):
         # Check that the event is in the results
         self.assertTrue(pages.filter(id=event.id).exists())
 
+    def test_in_site(self):
+        all_events = EventPage.objects.all()
+        site_2_events = EventPage.objects.in_site(request.site)
+
+        # Check that there are more events in all_events and in site_2_events
+        self.assertTrue(len(all_events) > len(site_2_events))
+
+        # Check that site_2_events are actually under the 2nd site
+        for event in site_2_events:
+            self.assertTrue(event.get_site() == "site2")
 
 class TestPageQuerySetSearch(TestCase):
     fixtures = ['test.json']


### PR DESCRIPTION
Addresses https://github.com/torchbox/wagtail/issues/3070

**Test are failing because the appropriate fixtures are not in place.**

What is the best way to add to test.json in the testapp? This test requires an additional site and an event page.

I tried to edit the JSON by hand, but just ended up breaking a whole load of other tests.