### PR TITLE
Hide non explorable breadcrumb

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/breadcrumb.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/breadcrumb.html
@@ -1,8 +1,18 @@
 {% load i18n wagtailadmin_tags %}
 
 <ul class="breadcrumb">
-    {% for page in page.get_ancestors %}
-        {% if page.is_root %}
+    {% if choosing %}
+        {% current_users_choosable_ancestors page request as ancestors %}
+    {% else %}
+        {% current_users_explorable_ancestors page request as ancestors %}
+    {% endif %}
+    {% for page in ancestors %}
+        {% if choosing %}
+            {% is_current_users_choosable_root page request as page_is_permitted_root %}
+        {% else %}
+            {% is_current_users_explorable_root page request as page_is_permitted_root %}
+        {% endif %}
+        {% if page_is_permitted_root %}
             <li class="home"><a href="{% if choosing %}{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}{% else %}{% url 'wagtailadmin_explore_root' %}{% endif %}" class="{% if choosing %}navigate-pages{% endif %} icon icon-home text-replace">{% trans 'Home' %}</a></li>
         {% else %}
             <li><a href="{% if choosing %}{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}{% else %}{% url 'wagtailadmin_explore' page.id %}{% endif %}" {% if choosing %}class="navigate-pages"{% endif %}>{{ page.get_admin_display_title }}</a></li>

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -332,6 +332,7 @@ def message_tags(message):
     else:
         return ''
 
+
 @register.assignment_tag
 def current_users_explorable_ancestors(page, request):
     """
@@ -342,6 +343,7 @@ def current_users_explorable_ancestors(page, request):
     """
     return page.get_permitted_ancestors(request)
 
+
 @register.assignment_tag
 def current_users_choosable_ancestors(page, request):
     """
@@ -351,6 +353,7 @@ def current_users_choosable_ancestors(page, request):
     that for us.
     """
     return page.get_permitted_ancestors(request, choosable=True)
+
 
 @register.assignment_tag
 def is_current_users_explorable_root(page, request):
@@ -370,6 +373,7 @@ def is_current_users_choosable_root(page, request):
     can't call it directly from the template. This template tag does that for us.
     """
     return page.is_permitted_root(request, choosable=True)
+
 
 @register.simple_tag
 def replace_page_param(query, page_number, page_key='p'):

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -332,6 +332,44 @@ def message_tags(message):
     else:
         return ''
 
+@register.assignment_tag
+def current_users_explorable_ancestors(page, request):
+    """
+    Example: {% current_users_explorable_ancestors page_obj request as ancestors %}
+    Since the Page.get_explorable_ancestors function takes a request object as
+    input, we can't call it directly from the template. This template tag does
+    that for us.
+    """
+    return page.get_permitted_ancestors(request)
+
+@register.assignment_tag
+def current_users_choosable_ancestors(page, request):
+    """
+    Example: {% current_users_choosable_ancestors page_obj request as ancestors %}
+    Since the Page.get_choosable_ancestors function takes a request object as
+    input, we can't call it directly from the template. This template tag does
+    that for us.
+    """
+    return page.get_permitted_ancestors(request, choosable=True)
+
+@register.assignment_tag
+def is_current_users_explorable_root(page, request):
+    """
+    Example: {% is_current_users_explorable_root page_obj request as page_is_explorable_root %}
+    Since the Page.is_explorable_root function takes a request object as input, we
+    can't call directly from the template. This template tag does that for us.
+    """
+    return page.is_permitted_root(request)
+
+
+@register.assignment_tag
+def is_current_users_choosable_root(page, request):
+    """
+    Example: {% is_current_users_choosable_root page_obj request as page_is_choosable_root %}
+    Since the Page.is_choosable_root function takes a request object as input, we
+    can't call it directly from the template. This template tag does that for us.
+    """
+    return page.is_permitted_root(request, choosable=True)
 
 @register.simple_tag
 def replace_page_param(query, page_number, page_key='p'):

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -330,6 +330,7 @@ class TestPageExplorerSignposting(TestCase, WagtailTestUtils):
         # There should be no warning message here
         self.assertNotContains(response, "Pages created here will not be accessible")
 
+
 class TestExplorablePageVisibility(TestCase, WagtailTestUtils):
     """
     Test the way that the Explorable Pages functionality manifests within the Explorer.

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -330,6 +330,82 @@ class TestPageExplorerSignposting(TestCase, WagtailTestUtils):
         # There should be no warning message here
         self.assertNotContains(response, "Pages created here will not be accessible")
 
+class TestExplorablePageVisibility(TestCase, WagtailTestUtils):
+    """
+    Test the way that the Explorable Pages functionality manifests within the Explorer.
+    This is isolated in its own test case because it requires a custom page tree and custom set of
+    users and groups.
+    The fixture sets up this page tree:
+    ========================================================
+    ID Site          Path
+    ========================================================
+    1              /
+    2  testserver  /home/
+    3  testserver  /home/about-us/
+    4  example.com /home/
+    5  example.com /home/content/
+    6  example.com /home/content/page-1/
+    7  example.com /home/content/page-2/
+    9  example.com /home/content/page-2/child-1
+    8  example.com /home/other-content/
+    10 example.com /home-2/
+    ========================================================
+    Group 1 has explore and choose permissions rooted at testserver's homepage.
+    Group 2 has explore and choose permissions rooted at exammple.com's page-1.
+    Group 3 has explore and choose permissions rooted at exammple.com's other-content.
+    User "jane" is in Group 1.
+    User "bob" is in Group 2.
+    User "sam" is in Groups 1 and 2.
+    User "josh" is in Groups 2 and 3.
+    User "mary" is is no Groups, but she has the "access wagtail admin" permission.
+    User "superman" is an admin.
+    """
+
+    fixtures = ['test_explorable_pages.json']
+
+    # Integration tests adapted from @coredumperror
+
+    def test_admin_can_explore_every_page(self):
+        self.assertTrue(self.client.login(username='superman', password='password'))
+        for page in Page.objects.all():
+            response = self.client.get(reverse('wagtailadmin_explore', args=[page.pk]))
+            self.assertEqual(response.status_code, 200)
+
+    def test_admin_sees_root_page_as_explorer_root(self):
+        self.assertTrue(self.client.login(username='superman', password='password'))
+        response = self.client.get(reverse('wagtailadmin_explore_root'))
+        self.assertEqual(response.status_code, 200)
+        # Administrator should see the full list of children of the Root page.
+        self.assertContains(response, "Welcome to testserver!")
+        self.assertContains(response, "Welcome to example.com!")
+
+    def test_admin_sees_breadcrumbs_up_to_root_page(self):
+        self.assertTrue(self.client.login(username='superman', password='password'))
+        response = self.client.get(reverse('wagtailadmin_explore', args=[6]))
+        self.assertEqual(response.status_code, 200)
+
+        self.assertInHTML(
+            """<li class="home"><a href="/admin/pages/" class=" icon icon-home text-replace">Home</a></li>""",
+            str(response.content)
+        )
+        self.assertInHTML("""<li><a href="/admin/pages/4/">Welcome to example.com!</a></li>""", str(response.content))
+        self.assertInHTML("""<li><a href="/admin/pages/5/">Content</a></li>""", str(response.content))
+
+
+    def test_nonadmin_sees_breadcrumbs_up_to_cca(self):
+        self.assertTrue(self.client.login(username='josh', password='password'))
+        response = self.client.get(reverse('wagtailadmin_explore', args=[6]), HTTP_HOST='example.com')
+        self.assertEqual(response.status_code, 200)
+        # While at "Page 1", Josh should see the breadcrumbs leading only as far back as the example.com homepage,
+        # since it's his Closest Common Ancestor.
+        self.assertInHTML(
+            """<li class="home"><a href="/admin/pages/" class=" icon icon-home text-replace">Home</a></li>""",
+            str(response.content)
+        )
+        self.assertInHTML("""<li><a href="/admin/pages/5/">Content</a></li>""", str(response.content))
+        # The page title shouldn't appear because it's the "home" breadcrumb.
+        self.assertNotContains(response, "Welcome to example.com!")
+
 
 class TestPageCreation(TestCase, WagtailTestUtils):
     def setUp(self):

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1390,7 +1390,7 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
 
     def get_permitted_ancestors(self, request, choosable=False):
         """
-        Internal function that does the work for get_explorable_ancestors() and get_choosable_ancestors().
+        Returns the permitted ancestors for a user on a given request.
         """
         # Superusers see all the ancestors.
         if request.user.is_superuser:

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1415,6 +1415,7 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
         verbose_name = _('page')
         verbose_name_plural = _('pages')
 
+
 def get_closest_common_ancestor_path(request, choosable=False):
     """
     Global method that returns the Closest Common Ancestor for the specified User, or None if the User has no
@@ -1422,7 +1423,6 @@ def get_closest_common_ancestor_path(request, choosable=False):
     then their explorable pages.
     """
     permitted_paths = UserPagePermissionsProxy(request.user).permitted_paths(choosable)
-    required_ancestors = []
     # Calculate the "closest common ancestor" of all the permitted Pages by finding their common prefix, then
     # chopping off the end to make the length a multiple of Page.steplen.
     if permitted_paths:
@@ -1434,6 +1434,7 @@ def get_closest_common_ancestor_path(request, choosable=False):
     else:
         # The user is not permitted to see any pages, and therefore has no required ancestors, either.
         return None
+
 
 @receiver(pre_delete, sender=Page)
 def unpublish_page_before_delete(sender, instance, **kwargs):


### PR DESCRIPTION
Hello,

Continuation of #2463 by @coredumperror and #2869 by @gasman.  

Alters the breadcrumb to only show up to the highest explorable page.

Ex.
Root
|----Page 1
|----|----Child 1
|----|----Child 2
|----Page 2

User 1 has permissions on Page 1 and User 2 has permissions on Page 2. Previously, both users would see the breadcrumb for the entire installation up to the root, even if the pages were not explorable. Now each user will only see the breadcrumb up to their respective pages. 