### PR TITLE
Update pull request message to encourage linting / tests / docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,8 @@
-### Thanks for contributing to Wagtail! 🎉
+Thanks for contributing to Wagtail! 🎉
 
-Please review [the contributor guidelines](http://docs.wagtail.io/en/latest/contributing/index.html) and confirm that [the tests pass](http://docs.wagtail.io/en/latest/contributing/developing.html#testing) in case of Python changes.
+Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:
+
+* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
+* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
+* (For Python changes:) Have you added tests to cover the new/fixed behaviour?
+* (For new features:) Has the documentation been updated accordingly?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,5 +4,5 @@ Before submitting, please review the contributor guidelines <http://docs.wagtail
 
 * Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
 * Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
-* (For Python changes:) Have you added tests to cover the new/fixed behaviour?
-* (For new features:) Has the documentation been updated accordingly?
+* For Python changes: Have you added tests to cover the new/fixed behaviour?
+* For new features: Has the documentation been updated accordingly?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ for support - use our [Wagtail support group](https://groups.google.com/forum/#!
 ## New code
 
 Please review the 
-[coding guidelines](http://docs.wagtail.io/en/latest/contributing/developing.html#coding-guidelines). 
+[contributing guidelines](http://docs.wagtail.io/en/latest/contributing/index.html). 
 You might like to start by checking issues with the 
 [difficulty:Easy](https://github.com/torchbox/wagtail/labels/difficulty%3AEasy) label.
 

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,6 @@ Contributing
 ~~~~~~~~~~~~
 If you're a Python or Django developer, fork the repo and get stuck in! We run a separate group for developers of Wagtail itself at https://groups.google.com/forum/#!forum/wagtail-developers (please note that this is not for support requests).
 
-You might like to start by reviewing the `coding guidelines <http://docs.wagtail.io/en/latest/contributing/developing.html#coding-guidelines>`_ and checking issues with the `difficulty:Easy <https://github.com/torchbox/wagtail/labels/difficulty%3AEasy>`_ label.
+You might like to start by reviewing the `contributing guidelines <http://docs.wagtail.io/en/latest/contributing/index.html>`_ and checking issues with the `difficulty:Easy <https://github.com/torchbox/wagtail/labels/difficulty%3AEasy>`_ label.
 
 We also welcome translations for Wagtail's interface. Translation work should be submitted through `Transifex <https://www.transifex.com/projects/p/wagtail/>`_.

--- a/docs/contributing/python_guidelines.rst
+++ b/docs/contributing/python_guidelines.rst
@@ -10,7 +10,7 @@ We ask that all Python contributions adhere to the `PEP8 <http://www.python.org/
 Python 2 and 3 compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-All contributions should support Python 2 and 3 and we recommend using the `six <https://pythonhosted.org/six/>`_ compatibility library (use the pip version installed as a dependency, not the version bundled with Django).
+All contributions should support Python 2 and 3 and we recommend using the `six <https://pythonhosted.org/six/>`_ compatibility library (use the version bundled with Django, ``django.utils.six``).
 
 Django compatibility
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Some suggested tweaks to our Github pull request message, to address some current PR bugbears: people forgetting about tests and docs, and commit noise from people not running the linter locally and having to fix things up retrospectively.

Feedback welcomed - I'm keen to not make it too preachy :-)

(Also some less controversial fixes: fixing 'coding guidelines' links to point to the main contributing page, and not pointing people to a copy of `six` that isn't there any more...)