### PR TITLE
Fix header buttons on root page

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/_privacy_switch.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/_privacy_switch.html
@@ -5,6 +5,7 @@
     {% page_permissions page as page_perms %}
 {% endif %}
 
+{% if not page.is_root %}
 <div class="privacy-indicator {% if is_public %}public{% else %}private{% endif %}">
     {% trans "Privacy" %}
     {% if page_perms.can_set_view_restrictions %}
@@ -21,3 +22,4 @@
         {% endif %}
     {% endif %}
 </div>
+{% endif %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_buttons.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_buttons.html
@@ -1,3 +1,5 @@
 {% for button in buttons %}
+    {% if button.show %}
     <li>{{ button|safe }}</li>
+    {% endif %}
 {% endfor %}

--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -105,5 +105,6 @@ def page_listing_more_buttons(page, page_perms, is_parent=False):
     if page_perms.can_unpublish():
         yield Button(_('Unpublish'), reverse('wagtailadmin_pages:unpublish', args=[page.id]),
                      attrs={'title': _('Unpublish this page')}, priority=40)
-    yield Button(_('Revisions'), reverse('wagtailadmin_pages:revisions_index', args=[page.id]),
-                 attrs={'title': _("View this page's revision history")}, priority=50)
+    if not page.is_root():
+        yield Button(_('Revisions'), reverse('wagtailadmin_pages:revisions_index', args=[page.id]),
+                     attrs={'title': _("View this page's revision history")}, priority=50)


### PR DESCRIPTION
Addresses #3138

- Hides 'revisions' entry on root page.
- Makes the 'more' dropdown menu not display when it is empty, which in practice will be the root page.
- Hides the 'privacy' link/icon on root page.

I was tempted to leave the 'privacy' button alone, as the fact that it's not a link (because `page_perms.can_set_view_restrictions` is `False`) meant it was harmless, but my opinion is that leaving it there is more confusing than not: 'public' suggests viewable, which the root page isn't.