### PR TITLE
Small documentation fix

### DIFF
--- a/docs/reference/contrib/frontendcache.rst
+++ b/docs/reference/contrib/frontendcache.rst
@@ -113,7 +113,7 @@ In case you run multiple sites with Wagtail and each site has its CloudFront dis
         },
     }
 
-  .. note::
+.. note::
     In most cases, absolute URLs with ``www`` prefixed domain names should be used in your mapping. Only drop the ``www`` prefix if you're absolutely sure you're not using it (e.g. a subdomain).
 
 Advanced usage


### PR DESCRIPTION
Noticed there was a small markup error in the docs. This PR fixes so its parsed as a note.

![image](https://cloud.githubusercontent.com/assets/287422/20074648/64bfa7b6-a531-11e6-9a51-0597f63e0b8c.png)
