### PR TITLE
Use capfirst() in Page.get_verbose_name()

### DIFF
--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -343,13 +343,13 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtailadmin_pages:add_subpage', args=(self.root_page.id, )))
         self.assertEqual(response.status_code, 200)
 
-        self.assertContains(response, "Simple Page")
+        self.assertContains(response, "Simple page")
         # List of available page types should not contain pages with is_creatable = False
-        self.assertNotContains(response, "MTI Base Page")
+        self.assertNotContains(response, "MTI base page")
         # List of available page types should not contain abstract pages
-        self.assertNotContains(response, "Abstract Page")
+        self.assertNotContains(response, "Abstract page")
         # List of available page types should not contain pages whose parent_page_types forbid it
-        self.assertNotContains(response, "Business Child")
+        self.assertNotContains(response, "Business child")
 
     def test_add_subpage_with_subpage_types(self):
         # Add a BusinessIndex to test business rules in
@@ -362,9 +362,9 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtailadmin_pages:add_subpage', args=(business_index.id, )))
         self.assertEqual(response.status_code, 200)
 
-        self.assertContains(response, "Business Child")
+        self.assertContains(response, "Business child")
         # List should not contain page types not in the subpage_types list
-        self.assertNotContains(response, "Simple Page")
+        self.assertNotContains(response, "Simple page")
 
     def test_add_subpage_with_one_valid_subpage_type(self):
         # Add a BusinessSubIndex to test business rules in
@@ -3307,7 +3307,7 @@ class TestRevisions(TestCase, WagtailTestUtils):
         response = self.client.get(last_christmas_preview_url)
         self.assertEqual(response.status_code, 200)
 
-        self.assertContains(response, "Editing Event Page")
+        self.assertContains(response, "Editing Event page")
         self.assertContains(response, "You are viewing a previous revision of this page")
 
         # Form should show the content of the revision, not the current draft

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -26,7 +26,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
 from django.utils.six import StringIO
 from django.utils.six.moves.urllib.parse import urlparse
-from django.utils.text import slugify
+from django.utils.text import capfirst, slugify
 from django.utils.translation import ugettext_lazy as _
 from modelcluster.models import ClusterableModel, get_all_child_relations
 from treebeard.mp_tree import MP_Node
@@ -1002,11 +1002,11 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
     @classmethod
     def get_verbose_name(cls):
         """
-            Returns the human-readable "verbose name" of this page model e.g "Blog page".
+        Returns the human-readable "verbose name" of this page model e.g "Blog page".
         """
         # This is similar to doing cls._meta.verbose_name.title()
         # except this doesn't convert any characters to lowercase
-        return ' '.join([word[0].upper() + word[1:] for word in cls._meta.verbose_name.split()])
+        return capfirst(cls._meta.verbose_name)
 
     @property
     def status_string(self):


### PR DESCRIPTION
Just a minor cleanup. ~~This shouldn't have any behavioural effect on the ``get_verbose_name`` method~~. Much more expressive than before though.

**EDIT:** as pointed out in https://github.com/torchbox/wagtail/pull/3157#issuecomment-260325582 this will  only capitalise the first word instead of every word as before (so "blog page" becomes "Blog page" instead of "Blog Page"). We've agreed that the new format is slightly better.