### PR TITLE
Fix PEP8 E305 errors

### DIFF
--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -77,5 +77,6 @@ def main():
     else:
         parser.error("Unrecognised command: " + command)
 
+
 if __name__ == "__main__":
     main()

--- a/wagtail/contrib/settings/registry.py
+++ b/wagtail/contrib/settings/registry.py
@@ -80,5 +80,6 @@ class Registry(list):
             return None
         return Model
 
+
 registry = Registry()
 register_setting = registry.register_decorator

--- a/wagtail/tests/customuser/models.py
+++ b/wagtail/tests/customuser/models.py
@@ -107,6 +107,7 @@ def steal_method(name):
         func = func.__func__
     setattr(EmailUser, name, func)
 
+
 methods = ['get_group_permissions', 'get_all_permissions', 'has_perm',
            'has_perms', 'has_module_perms']
 for method in methods:

--- a/wagtail/tests/demosite/models.py
+++ b/wagtail/tests/demosite/models.py
@@ -460,6 +460,7 @@ class EventPageSpeaker(Orderable, AbstractLinkFields):
         MultiFieldPanel(AbstractLinkFields.panels, "Link"),
     ]
 
+
 EventPage.content_panels = Page.content_panels + [
     FieldPanel('date_from'),
     FieldPanel('date_to'),

--- a/wagtail/tests/snippets/models.py
+++ b/wagtail/tests/snippets/models.py
@@ -40,6 +40,8 @@ class ZuluSnippet(models.Model):
 
 class RegisterFunction(models.Model):
     pass
+
+
 register_snippet(RegisterFunction)
 
 

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -228,6 +228,7 @@ class EventPage(Page):
 
     password_required_template = 'tests/event_page_password_required.html'
 
+
 EventPage.content_panels = [
     FieldPanel('title', classname="full title"),
     FieldPanel('date_from'),
@@ -275,6 +276,7 @@ class SingleEventPage(EventPage):
         else:
             # fall back to default routing rules
             return super(SingleEventPage, self).route(request, path_components)
+
 
 SingleEventPage.content_panels = [FieldPanel('excerpt')] + EventPage.content_panels
 
@@ -335,6 +337,7 @@ class EventIndex(Page):
             }
         ]
 
+
 EventIndex.content_panels = [
     FieldPanel('title', classname="full title"),
     FieldPanel('intro', classname="full"),
@@ -350,6 +353,7 @@ class FormPage(AbstractEmailForm):
         context = super(FormPage, self).get_context(request)
         context['greeting'] = "hello world"
         return context
+
 
 FormPage.content_panels = [
     FieldPanel('title', classname="full title"),
@@ -370,6 +374,7 @@ class JadeFormField(AbstractFormField):
 
 class JadeFormPage(AbstractEmailForm):
     template = "tests/form_page.jade"
+
 
 JadeFormPage.content_panels = [
     FieldPanel('title', classname="full title"),
@@ -543,6 +548,7 @@ StandardIndex.promote_panels = []
 class StandardChild(Page):
     pass
 
+
 # Test overriding edit_handler with a custom one
 StandardChild.edit_handler = TabbedInterface([
     ObjectList(StandardChild.content_panels, heading='Content'),
@@ -583,6 +589,7 @@ class TaggedPageTag(TaggedItemBase):
 
 class TaggedPage(Page):
     tags = ClusterTaggableManager(through=TaggedPageTag, blank=True)
+
 
 TaggedPage.content_panels = [
     FieldPanel('title', classname="full title"),

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -16,21 +16,28 @@ def editor_css():
 
 def editor_js():
     return """<script src="/path/to/my/custom.js"></script>"""
-hooks.register('insert_editor_js', editor_js)
-# And the other using old-style function calls
 
+
+hooks.register('insert_editor_js', editor_js)
+
+
+# And the other using old-style function calls
 
 def whitelister_element_rules():
     return {
         'blockquote': allow_without_attributes,
         'a': attribute_rule({'href': check_url, 'target': True}),
     }
+
+
 hooks.register('construct_whitelister_element_rules', whitelister_element_rules)
 
 
 def block_googlebot(page, request, serve_args, serve_kwargs):
     if request.META.get('HTTP_USER_AGENT') == 'GoogleBot':
         return HttpResponse("<h1>bad googlebot no cookie</h1>")
+
+
 hooks.register('before_serve_page', block_googlebot)
 
 

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -196,6 +196,7 @@ class EscapeScriptNode(template.Node):
         parser.delete_first_token()
         return cls(nodelist)
 
+
 register.tag(EscapeScriptNode.TAG_NAME, EscapeScriptNode.handle)
 
 

--- a/wagtail/wagtailadmin/views/account.py
+++ b/wagtail/wagtailadmin/views/account.py
@@ -79,6 +79,7 @@ def _wrap_password_reset_view(view_func):
         return view_func(*args, **kwargs)
     return wrapper
 
+
 password_reset = _wrap_password_reset_view(auth_views.password_reset)
 password_reset_done = _wrap_password_reset_view(auth_views.password_reset_done)
 password_reset_confirm = _wrap_password_reset_view(auth_views.password_reset_confirm)

--- a/wagtail/wagtailcore/__init__.py
+++ b/wagtail/wagtailcore/__init__.py
@@ -10,4 +10,5 @@ def setup():
 
     warnings.simplefilter("default", removed_in_next_version_warning)
 
+
 setup()

--- a/wagtail/wagtailcore/admin.py
+++ b/wagtail/wagtailcore/admin.py
@@ -21,6 +21,7 @@ class GroupPagePermissionInline(admin.TabularInline):
 class GroupAdminWithPagePermissions(GroupAdmin):
     inlines = GroupAdmin.inlines + [GroupPagePermissionInline]
 
+
 if admin.site.is_registered(Group):
     admin.site.unregister(Group)
 admin.site.register(Group, GroupAdminWithPagePermissions)

--- a/wagtail/wagtailcore/hooks.py
+++ b/wagtail/wagtailcore/hooks.py
@@ -31,6 +31,7 @@ def register(hook_name, fn=None):
         _hooks[hook_name] = []
     _hooks[hook_name].append(fn)
 
+
 _searched_for_hooks = False
 
 

--- a/wagtail/wagtailcore/jinja2tags.py
+++ b/wagtail/wagtailcore/jinja2tags.py
@@ -57,5 +57,6 @@ class WagtailCoreExtension(Extension):
 
         return jinja2.Markup(value)
 
+
 # Nicer import names
 core = WagtailCoreExtension

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -248,6 +248,7 @@ class BasePageManager(models.Manager):
     def get_queryset(self):
         return PageQuerySet(self.model).order_by('path')
 
+
 PageManager = BasePageManager.from_queryset(PageQuerySet)
 
 
@@ -1840,6 +1841,7 @@ class PageViewRestriction(models.Model):
 class BaseCollectionManager(models.Manager):
     def get_queryset(self):
         return TreeQuerySet(self.model).order_by('path')
+
 
 CollectionManager = BaseCollectionManager.from_queryset(TreeQuerySet)
 

--- a/wagtail/wagtailcore/whitelist.py
+++ b/wagtail/wagtailcore/whitelist.py
@@ -61,6 +61,7 @@ def attribute_rule(allowed_attrs):
 
     return fn
 
+
 allow_without_attributes = attribute_rule({})
 
 

--- a/wagtail/wagtailembeds/oembed_providers.py
+++ b/wagtail/wagtailembeds/oembed_providers.py
@@ -317,6 +317,7 @@ def compile_endpoints():
 
     return endpoints
 
+
 OEMBED_ENDPOINTS_COMPILED = compile_endpoints()
 
 

--- a/wagtail/wagtailimages/tests/test_image_operations.py
+++ b/wagtail/wagtailimages/tests/test_image_operations.py
@@ -130,6 +130,7 @@ class TestDoNothingOperation(ImageOperationTestCase):
         ('original', dict(width=1000, height=1000), []),
     ]
 
+
 TestDoNothingOperation.setup_test_methods()
 
 
@@ -298,6 +299,7 @@ class TestFillOperation(ImageOperationTestCase):
         ]),
     ]
 
+
 TestFillOperation.setup_test_methods()
 
 
@@ -330,6 +332,7 @@ class TestMinMaxOperation(ImageOperationTestCase):
         ]),
     ]
 
+
 TestMinMaxOperation.setup_test_methods()
 
 
@@ -358,6 +361,7 @@ class TestWidthHeightOperation(ImageOperationTestCase):
             ('resize', ((800, 400), ), {}),
         ]),
     ]
+
 
 TestWidthHeightOperation.setup_test_methods()
 


### PR DESCRIPTION
[pycodestyle 2.2.0](https://pypi.python.org/pypi/pycodestyle) now enforces two blank lines after top-level `class` / `def` blocks.