### PR TITLE
Fix errors by settings context processor in out-of-request templates

### DIFF
--- a/wagtail/contrib/settings/context_processors.py
+++ b/wagtail/contrib/settings/context_processors.py
@@ -55,4 +55,12 @@ class SettingModuleProxy(dict):
 
 
 def settings(request):
-    return {'settings': SettingsProxy(request.site)}
+    site = getattr(request, 'site', None)
+    if site is None:
+        # Can't assume SiteMiddleware already executed
+        # (e.g. middleware rendering a template before that)
+        # Unittest or email templates might also mock request
+        # objects that don't have a request.site.
+        return {}
+    else:
+        return {'settings': SettingsProxy(request.site)}


### PR DESCRIPTION
When templates are rendered outside the request cycle, the `settings` context processor fails because `request.site` is not created because `SiteMiddleware` was not processed.

This happens whenever requests are mocked for rendering. For example email rendering by third party packages, middleware that runs early or unittests that mock a request object without taking all middleware into account.