### PR TITLE
Fix #3167 - Ensure TableBlock content is indexed

### DIFF
--- a/wagtail/contrib/table_block/blocks.py
+++ b/wagtail/contrib/table_block/blocks.py
@@ -74,6 +74,12 @@ class TableBlock(FieldBlock):
     def is_html_renderer(self):
         return self.table_options['renderer'] == 'html'
 
+    def get_searchable_content(self, value):
+        content = []
+        for row in value.get('data', []):
+            content.extend([v for v in row if v])
+        return content
+
     def render(self, value, context=None):
         template = getattr(self.meta, 'template', None)
         if template and value:

--- a/wagtail/contrib/table_block/tests.py
+++ b/wagtail/contrib/table_block/tests.py
@@ -172,6 +172,14 @@ class TestTableBlock(TestTableBlockRenderingBase):
         block2 = TableBlock(table_options=new_options)
         self.assertEqual(block2.is_html_renderer(), True)
 
+    def test_searchable_content(self):
+        value = {'first_row_is_table_header': False, 'first_col_is_header': False,
+                 'data': [['Test 1', 'Test 2', 'Test 3'], [None, 'Bar', None],
+                          [None, 'Foo', None]]}
+        block = TableBlock()
+        content = block.get_searchable_content(value)
+        self.assertEqual(content, ['Test 1', 'Test 2', 'Test 3', 'Bar', 'Foo', ])
+
     def test_render_with_extra_context(self):
         """
         Test that extra context variables passed in block.render are passed through


### PR DESCRIPTION
Ref: #3167 

Changes include:
* adding the 'get_searchable_content' method on the TableBlock
* ... and the related test