### PR TITLE
Fix some style errors in the documentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{css,js,json,py,yml}]
+[*.{css,js,json,py,yml,rst}]
 indent_style = space
 
 [*.{js,py}]

--- a/docs/advanced_topics/customisation/branding.rst
+++ b/docs/advanced_topics/customisation/branding.rst
@@ -8,16 +8,18 @@ In your projects with Wagtail, you may wish to replace elements such as the Wagt
 .. note::
    Using ``{% extends %}`` in this way on a template you're currently overriding is only supported in Django 1.9 and above. On Django 1.8, you will need to use `django-overextends <https://github.com/stephenmcd/django-overextends>`_ instead.
 
-You need to create a ``templates/wagtailadmin/`` folder within one of your apps - this may be an existing one, or a new one created for this purpose, for example, ``dashboard``. This app must be registered in ``INSTALLED_APPS`` before ``wagtail.wagtailadmin``::
+You need to create a ``templates/wagtailadmin/`` folder within one of your apps - this may be an existing one, or a new one created for this purpose, for example, ``dashboard``. This app must be registered in ``INSTALLED_APPS`` before ``wagtail.wagtailadmin``:
+
+.. code-block:: python
 
     INSTALLED_APPS = (
         # ...
 
         'dashboard',
-      
+
         'wagtail.wagtailcore',
         'wagtail.wagtailadmin',
-      
+
         # ...
     )
 
@@ -26,11 +28,13 @@ The template blocks that are available to be overridden are as follows:
 ``branding_logo``
 -----------------
 
-To replace the default logo, create a template file ``dashboard/templates/wagtailadmin/base.html`` that overrides the block ``branding_logo``::
+To replace the default logo, create a template file ``dashboard/templates/wagtailadmin/base.html`` that overrides the block ``branding_logo``:
+
+.. code-block:: html+django
 
     {% extends "wagtailadmin/base.html" %}
     {% load staticfiles %}
-    
+
     {% block branding_logo %}
         <img src="{% static 'images/custom-logo.svg' %}" alt="Custom Project" width="80" />
     {% endblock %}
@@ -38,7 +42,9 @@ To replace the default logo, create a template file ``dashboard/templates/wagtai
 ``branding_favicon``
 --------------------
 
-To replace the favicon displayed when viewing admin pages, create a template file ``dashboard/templates/wagtailadmin/admin_base.html`` that overrides the block ``branding_favicon``::
+To replace the favicon displayed when viewing admin pages, create a template file ``dashboard/templates/wagtailadmin/admin_base.html`` that overrides the block ``branding_favicon``:
+
+.. code-block:: html+django
 
     {% extends "wagtailadmin/admin_base.html" %}
     {% load staticfiles %}
@@ -50,7 +56,9 @@ To replace the favicon displayed when viewing admin pages, create a template fil
 ``branding_login``
 ------------------
 
-To replace the login message, create a template file ``dashboard/templates/wagtailadmin/login.html`` that overrides the block ``branding_login``::
+To replace the login message, create a template file ``dashboard/templates/wagtailadmin/login.html`` that overrides the block ``branding_login``:
+
+.. code-block:: html+django
 
     {% extends "wagtailadmin/login.html" %}
 
@@ -59,7 +67,9 @@ To replace the login message, create a template file ``dashboard/templates/wagta
 ``branding_welcome``
 --------------------
 
-To replace the welcome message on the dashboard, create a template file ``dashboard/templates/wagtailadmin/home.html`` that overrides the block ``branding_welcome``::
+To replace the welcome message on the dashboard, create a template file ``dashboard/templates/wagtailadmin/home.html`` that overrides the block ``branding_welcome``:
+
+.. code-block:: html+django
 
     {% extends "wagtailadmin/home.html" %}
 

--- a/docs/advanced_topics/customisation/page_editing_interface.rst
+++ b/docs/advanced_topics/customisation/page_editing_interface.rst
@@ -6,8 +6,6 @@ Customising the editing interface
 Customising the tabbed interface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 1.0
-
 As standard, Wagtail organises panels for pages into three tabs: 'Content', 'Promote' and 'Settings'. For snippets Wagtail puts all panels into one page. Depending on the requirements of your site, you may wish to customise this for specific page types or snippets - for example, adding an additional tab for sidebar content. This can be done by specifying an ``edit_handler`` attribute on the page or snippet model. For example:
 
 .. code-block:: python

--- a/docs/advanced_topics/customisation/page_editing_interface.rst
+++ b/docs/advanced_topics/customisation/page_editing_interface.rst
@@ -102,7 +102,7 @@ To begin, import the ``Format`` class, ``register_image_format`` function, and o
   The label used in the chooser form when inserting the image into the :class:`~wagtail.wagtailcore.fields.RichTextField`.
 
 ``classnames``
-  The string to assign to the ``class`` attribute of the generated ``<img>`` tag. 
+  The string to assign to the ``class`` attribute of the generated ``<img>`` tag.
 
   .. note::
     Any class names you provide must have CSS rules matching them written separately, as part of the front end CSS code. Specifying a ``classnames`` value of ``left`` will only ensure that class is output in the generated markup, it won't cause the image to align itself left.

--- a/docs/advanced_topics/i18n/duplicate_tree.rst
+++ b/docs/advanced_topics/i18n/duplicate_tree.rst
@@ -78,7 +78,7 @@ Here's an example of how this could be implemented (with English as the main lan
             This returns the language code for this page.
             """
             # Look through ancestors of this page for its language homepage
-            # The language homepage is located at depth 3 
+            # The language homepage is located at depth 3
             language_homepage = self.get_ancestors(inclusive=True).get(depth=3)
 
             # The slug of language homepages should always be set to the language code

--- a/docs/advanced_topics/images/animated_gifs.rst
+++ b/docs/advanced_topics/images/animated_gifs.rst
@@ -4,7 +4,7 @@ Animated GIF support
 Pillow, Wagtail's default image library, doesn't support animated
 GIFs.
 
-To get animated GIF support, you will have to 
+To get animated GIF support, you will have to
 `install Wand <http://docs.wand-py.org/en/0.4.2/guide/install.html>`_.
 Wand is a binding to ImageMagick so make sure that has been installed as well.
 

--- a/docs/advanced_topics/images/feature_detection.rst
+++ b/docs/advanced_topics/images/feature_detection.rst
@@ -19,9 +19,9 @@ Installing OpenCV on Debian/Ubuntu
 
 Debian and ubuntu provide an apt-get package called ``python-opencv``:
 
- .. code-block:: sh
+ .. code-block:: console
 
-    sudo apt-get install python-opencv python-numpy
+    $ sudo apt-get install python-opencv python-numpy
 
 This will install PyOpenCV into your site packages. If you are using a virtual environment, you need to make sure site packages are enabled or Wagtail will not be able to import PyOpenCV.
 

--- a/docs/advanced_topics/performance.rst
+++ b/docs/advanced_topics/performance.rst
@@ -17,15 +17,15 @@ We recommend `Redis <http://redis.io/>`_ as a fast, persistent cache. Install Re
 
 .. code-block:: python
 
-	CACHES = {
-	    'default': {
-	        'BACKEND': 'django_redis.cache.RedisCache',
-	        'LOCATION': '127.0.0.1:6379',
-	        'OPTIONS': {
-	            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-	        }
-	    }
-	}
+    CACHES = {
+        'default': {
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': '127.0.0.1:6379',
+            'OPTIONS': {
+                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+            }
+        }
+    }
 
 
 Search
@@ -74,12 +74,12 @@ The overhead from reading and compiling templates can add up. In some cases a si
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'OPTIONS': {
-	    'loaders': [
-	        ('django.template.loaders.cached.Loader', [
-		    'django.template.loaders.filesystem.Loader',
-		    'django.template.loaders.app_directories.Loader',
-	        ]),
-	    ],
+        'loaders': [
+            ('django.template.loaders.cached.Loader', [
+            'django.template.loaders.filesystem.Loader',
+            'django.template.loaders.app_directories.Loader',
+            ]),
+        ],
         },
     }]
 

--- a/docs/advanced_topics/performance.rst
+++ b/docs/advanced_topics/performance.rst
@@ -13,7 +13,9 @@ We have tried to minimise external dependencies for a working installation of Wa
 Cache
 -----
 
-We recommend `Redis <http://redis.io/>`_ as a fast, persistent cache. Install Redis through your package manager (on Debian or Ubuntu: ``sudo apt-get install redis-server``), add ``django-redis`` to your ``requirements.txt``, and enable it as a cache backend::
+We recommend `Redis <http://redis.io/>`_ as a fast, persistent cache. Install Redis through your package manager (on Debian or Ubuntu: ``sudo apt-get install redis-server``), add ``django-redis`` to your ``requirements.txt``, and enable it as a cache backend:
+
+.. code-block:: python
 
 	CACHES = {
 	    'default': {
@@ -33,9 +35,9 @@ Wagtail has strong support for `Elasticsearch <http://www.elasticsearch.org/>`_ 
 
 Once the Elasticsearch server is installed and running. Install the ``elasticsearch`` Python module with::
 
-    pip install elasticsearch
+then add the following to your settings:
 
-then add the following to your settings::
+.. code-block:: python
 
     WAGTAILSEARCH_BACKENDS = {
         'default': {
@@ -58,7 +60,9 @@ Wagtail is tested on SQLite, and should work on other Django-supported database 
 Templates
 ---------
 
-The overhead from reading and compiling templates can add up. In some cases a significant performance improvement can be gained by using `Django's cached template loader <https://docs.djangoproject.com/en/1.10/ref/templates/api/#django.template.loaders.cached.Loader>`_::
+The overhead from reading and compiling templates can add up. In some cases a significant performance improvement can be gained by using `Django's cached template loader <https://docs.djangoproject.com/en/1.10/ref/templates/api/#django.template.loaders.cached.Loader>`_:
+
+.. code-block:: python
 
     TEMPLATES = [{
         'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/docs/advanced_topics/performance.rst
+++ b/docs/advanced_topics/performance.rst
@@ -33,7 +33,11 @@ Search
 
 Wagtail has strong support for `Elasticsearch <http://www.elasticsearch.org/>`_ - both in the editor interface and for users of your site - but can fall back to a database search if Elasticsearch isn't present. Elasticsearch is faster and more powerful than the Django ORM for text search, so we recommend installing it or using a hosted service like `Searchly <http://www.searchly.com/>`_.
 
-Once the Elasticsearch server is installed and running. Install the ``elasticsearch`` Python module with::
+Once the Elasticsearch server is installed and running. Install the ``elasticsearch`` Python module with:
+
+.. code-block:: console
+
+    $ pip install elasticsearch
 
 then add the following to your settings:
 
@@ -46,9 +50,11 @@ then add the following to your settings:
         },
     }
 
-Once Elasticsearch is configured, you can index any existing content you may have::
+Once Elasticsearch is configured, you can index any existing content you may have:
 
-    ./manage.py update_index
+.. code-block:: console
+
+    $ ./manage.py update_index
 
 
 Database

--- a/docs/advanced_topics/privacy.rst
+++ b/docs/advanced_topics/privacy.rst
@@ -87,5 +87,5 @@ The attribute ``password_required_template`` can be defined on a page model to u
 
     class VideoPage(Page):
         ...
-        
+
         password_required_template = 'video/password_required.html'

--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -225,9 +225,9 @@ Providing an API key for the Embedly service will use that as a embed backend, w
 
 To use Embedly, you must also install their Python module:
 
-.. code-block:: sh
+.. code-block:: console
 
-  pip install embedly
+  $ pip install embedly
 
 
 Images

--- a/docs/contributing/committing.rst
+++ b/docs/contributing/committing.rst
@@ -10,8 +10,8 @@ by at least one other reviewer or committer,
 unless the change is a small documentation change or fixing a typo.
 
 Most code contributions will be in the form of pull requests from Github.
-Pull requests should not be merged from Github, apart from small documentation fixes, 
-which can be merged with the 'Squash and merge' option. Instead, the code should 
+Pull requests should not be merged from Github, apart from small documentation fixes,
+which can be merged with the 'Squash and merge' option. Instead, the code should
 be checked out by a committer locally, the changes examined and rebased,
 the ``CHANGELOG.txt`` and release notes updated,
 and finally the code should be pushed to the master branch.
@@ -42,16 +42,16 @@ You can fix up any small mistakes in the commits,
 such as typos and formatting, as part of the rebase.
 ``git rebase --interactive`` is an excellent tool for this job.
 
-.. code-block:: sh
+.. code-block:: console
 
-    # Get the latest commits from Wagtail
+    $ # Get the latest commits from Wagtail
     $ git fetch upstream
     $ git checkout master
     $ git merge --ff-only upstream/master
-    # Rebase this pull request on to master
+    $ # Rebase this pull request on to master
     $ git checkout pr/xxxx
     $ git rebase master
-    # Update master to this commit
+    $ # Update master to this commit
     $ git checkout master
     $ git merge --ff-only pr/xxxx
 
@@ -92,7 +92,7 @@ If the changes to be merged are small enough to be a single commit,
 amend this single commit with the additions to
 the ``CHANGELOG.txt``, release notes, and contributors:
 
-.. code-block:: sh
+.. code-block:: console
 
     $ git add CHANGELOG.txt docs/releases/x.x.x.rst CONTRIBUTORS.rst
     $ git commit --amend --no-edit
@@ -101,7 +101,7 @@ If the changes do not fit in a single commit, make a new commit with the updates
 the ``CHANGELOG.txt``, release notes, and contributors.
 The commit message should say ``Release notes for #xxxx``:
 
-.. code-block:: sh
+.. code-block:: console
 
     $ git add CHANGELOG.txt docs/releases/x.x.x.rst CONTRIBUTORS.rst
     $ git commit -m 'Release notes for #xxxx'
@@ -111,11 +111,11 @@ Push to master
 
 The changes are ready to be pushed to ``master`` now.
 
-.. code-block:: sh
+.. code-block:: console
 
-    # Check that everything looks OK
+    $ # Check that everything looks OK
     $ git log upstream/master..master --oneline
     $ git push --dry-run upstream master
-    # Push the commits!
+    $ # Push the commits!
     $ git push upstream master
     $ git branch -d pr/xxxx

--- a/docs/contributing/css_guidelines.rst
+++ b/docs/contributing/css_guidelines.rst
@@ -12,14 +12,14 @@ This requires `node.js <http://nodejs.org>`_ to run.
 To install the libraries required for compiling the SCSS,
 run the following from the Wagtail repository root:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ npm install
 
 
 To compile the assets, run:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ npm run build
 
@@ -27,7 +27,7 @@ To compile the assets, run:
 Alternatively, the SCSS files can be monitored,
 automatically recompiling when any changes are observed, by running:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ npm start
 
@@ -39,14 +39,14 @@ Wagtail uses the "scss-lint" Ruby Gem for linting.
 
 Install it thus:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ gem install scss-lint
 
 
 Then run the linter from the wagtail project root:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ scss-lint
 

--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -19,28 +19,28 @@ Install Node.js, v5.3.0 or higher. Instructions for installing Node.js can be fo
 
 Clone a copy of `the Wagtail codebase <https://github.com/torchbox/wagtail>`_:
 
-.. code-block:: sh
+.. code-block:: console
 
-    git clone https://github.com/torchbox/wagtail.git
-    cd wagtail
+    $ git clone https://github.com/torchbox/wagtail.git
+    $ cd wagtail
 
 With your preferred virtualenv activated, install the Wagtail package in development mode with the included testing and documentation dependencies:
 
-.. code-block:: sh
+.. code-block:: console
 
-    pip install -e .[testing,docs] -U
+    $ pip install -e .[testing,docs] -U
 
 Install the tool chain for building static assets:
 
-.. code-block:: sh
+.. code-block:: console
 
-    npm install
+    $ npm install
 
 Compile the assets:
 
-.. code-block:: sh
+.. code-block:: console
 
-    npm run build
+    $ npm run build
 
 Any Wagtail sites you start up in this virtualenv will now run against this development instance of Wagtail. We recommend using the `Wagtail demo site <https://github.com/torchbox/wagtaildemo/>`_ as a basis for developing Wagtail.
 
@@ -49,33 +49,41 @@ Any Wagtail sites you start up in this virtualenv will now run against this deve
 Testing
 ~~~~~~~
 
-From the root of the Wagtail codebase, run the following command to run all the tests::
+From the root of the Wagtail codebase, run the following command to run all the tests:
 
-    python runtests.py
+.. code-block:: console
+
+    $ python runtests.py
 
 **Running only some of the tests**
 
 At the time of writing, Wagtail has well over 1000 tests, which takes a while to
 run. You can run tests for only one part of Wagtail by passing in the path as
-an argument to ``runtests.py``::
+an argument to ``runtests.py``:
 
-    python runtests.py wagtail.wagtailcore
+.. code-block:: console
+
+    $ python runtests.py wagtail.wagtailcore
 
 **Testing against PostgreSQL**
 
 By default, Wagtail tests against SQLite. You can switch to using PostgreSQL by
-using the ``--postgres`` argument::
+using the ``--postgres`` argument:
 
-    python runtests.py --postgres
+.. code-block:: console
+
+    $ python runtests.py --postgres
 
 If you need to use a different user, password or host. Use the ``PGUSER``, ``PGPASSWORD`` and ``PGHOST`` environment variables.
 
 **Testing against a different database**
 
 If you need to test against a different database, set the ``DATABASE_ENGINE``
-environment variable to the name of the Django database backend to test against::
+environment variable to the name of the Django database backend to test against:
 
-    DATABASE_ENGINE=django.db.backends.mysql python runtests.py
+.. code-block:: console
+
+    $ DATABASE_ENGINE=django.db.backends.mysql python runtests.py
 
 This will create a new database called ``test_wagtail`` in MySQL and run
 the tests against it.
@@ -83,18 +91,22 @@ the tests against it.
 **Testing Elasticsearch**
 
 You can test Wagtail against Elasticsearch by passing the ``--elasticsearch``
-argument to ``runtests.py``::
+argument to ``runtests.py``:
 
-    python runtests.py --elasticsearch
+.. code-block:: console
+
+    $ python runtests.py --elasticsearch
 
 
 Wagtail will attempt to connect to a local instance of Elasticsearch
 (``http://localhost:9200``) and use the index ``test_wagtail``.
 
 If your Elasticsearch instance is located somewhere else, you can set the
-``ELASTICSEARCH_URL`` environment variable to point to its location::
+``ELASTICSEARCH_URL`` environment variable to point to its location:
 
-    ELASTICSEARCH_URL=http://my-elasticsearch-instance:9200 python runtests.py --elasticsearch
+.. code-block:: console
+
+    $ ELASTICSEARCH_URL=http://my-elasticsearch-instance:9200 python runtests.py --elasticsearch
 
 Compiling static assets
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -103,41 +115,41 @@ All static assets such as JavaScript, CSS, images, and fonts for the Wagtail adm
 
 To compile the assets, run:
 
-.. code-block:: sh
+.. code-block:: console
 
-    npm run build
+    $ npm run build
 
 This must be done after every change to the source files. To watch the source files for changes and then automatically recompile the assets, run:
 
-.. code-block:: sh
+.. code-block:: console
 
-    npm start
+    $ npm start
 
 Compiling the documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Wagtail documentation is built by Sphinx. To install Sphinx and compile the documentation, run:
 
-.. code-block:: sh
+.. code-block:: console
 
-    cd /path/to/wagtail
-    # Install the documentation dependencies
-    pip install -e .[docs]
-    # Compile the docs
-    cd docs/
-    make html
+    $ cd /path/to/wagtail some text
+    $ # Install the documentation dependencies
+    $ pip install -e .[docs]
+    $ # Compile the docs
+    $ cd docs/
+    $ make html
 
 The compiled documentation will now be in ``docs/_build/html``.
 Open this directory in a web browser to see it.
 Python comes with a module that makes it very easy to preview static files in a web browser.
 To start this simple server, run the following commands:
 
-.. code-block:: sh
+.. code-block:: console
 
     $ cd docs/_build/html/
-    # Python 2
+    $ # Python 2
     $ python2 -mSimpleHTTPServer 8080
-    # Python 3
+    $ # Python 3
     $ python3 -mhttp.server 8080
 
 Now you can open <http://localhost:8080/> in your web browser to see the compiled documentation.
@@ -146,7 +158,7 @@ Sphinx caches the built documentation to speed up subsequent compilations.
 Unfortunately, this cache also hides any warnings thrown by unmodified documentation source files.
 To clear the built HTML and start fresh, so you can see all warnings thrown when building the documentation, run:
 
-.. code-block:: sh
+.. code-block:: console
 
     $ cd docs/
     $ make clean

--- a/docs/contributing/javascript_guidelines.rst
+++ b/docs/contributing/javascript_guidelines.rst
@@ -17,10 +17,12 @@ Wagtail provides some tooling configuration to help check your code meets the
 styleguide. You'll need node.js and npm on your development machine.
 Ensure project dependencies are installed by running ``npm install``
 
+Linting code
+------------
 
-**Linting code**
+.. code-block:: console
 
-``npm run lint:js``
+    $ npm run lint:js
 
 This will lint all the JS in the wagtail project, excluding vendor
 files and compiled libraries.
@@ -29,10 +31,12 @@ Some of the modals are generated via server-side scripts. These include
 template tags that upset the linter, so modal workflow JavaScript is
 excluded from the linter.
 
+Formatting code
+---------------
 
-**Formatting code**
+.. code-block:: console
 
-``npm run format:js``
+    $ npm run format:js
 
 This will perform safe edits to conform your JS code to the styleguide.
 It won't touch the line-length, or convert quotemarks from double to single.
@@ -40,7 +44,8 @@ It won't touch the line-length, or convert quotemarks from double to single.
 Run the linter after you've formatted the code to see what manual fixes
 you need to make to the codebase.
 
-**Changing the linter configuration**
+Changing the linter configuration
+---------------------------------
 
 Under the hood, the tasks use the `JavaScript Code Style <http://jscs.info/>`_ library.
 

--- a/docs/contributing/python_guidelines.rst
+++ b/docs/contributing/python_guidelines.rst
@@ -67,8 +67,8 @@ If a new function has been introduced by Django that you think would be very use
             pass
 
 Tests
-~~~~~ 
+~~~~~
 
-Wagtail has a suite of tests, which we are committed to improving and expanding. See :ref:`testing`. 
+Wagtail has a suite of tests, which we are committed to improving and expanding. See :ref:`testing`.
 
 We run continuous integration at `travis-ci.org/torchbox/wagtail <https://travis-ci.org/torchbox/wagtail>`_ to ensure that no commits or pull requests introduce test failures. If your contributions add functionality to Wagtail, please include the additional tests to cover it; if your contributions alter existing functionality, please update the relevant tests accordingly.

--- a/docs/editor_manual/administrator_tasks/managing_users.rst
+++ b/docs/editor_manual/administrator_tasks/managing_users.rst
@@ -16,11 +16,11 @@ You can sort this listing either via Name or Username.
 Clicking on a user's name will open their profile details. From here you can then edit that users details.
 
 .. Note::
-	It is possible to change user's passwords in this interface, but it is worth encouraging your users to use the 'Forgotten password' link on the login screen instead. This should save you some time!
+    It is possible to change user's passwords in this interface, but it is worth encouraging your users to use the 'Forgotten password' link on the login screen instead. This should save you some time!
 
 Click the 'Roles' tab to edit the level of access your users have. By default there are three roles:
 
-+--------------+--------------+-----------------+-----------------+ 
++--------------+--------------+-----------------+-----------------+
 | Role         | Create drafts| Publish content | Access Settings |
 +==============+==============+=================+=================+
 | Editor       |      Yes     |       No        |       No        |

--- a/docs/editor_manual/documents_images_snippets/documents.rst
+++ b/docs/editor_manual/documents_images_snippets/documents.rst
@@ -14,7 +14,7 @@ Documents such as PDFs can be managed from the Documents interface, available in
 
 * When editing a document you can replace the file associated with that document record. This means you can update documents without having to update the pages on which they are placed. Changing the file will change it on all pages that use the document.
 * Add or remove tags using the Tags field.
-* Save or delete documents using the buttons at the bottom of the interface. 
+* Save or delete documents using the buttons at the bottom of the interface.
 
-.. Warning:: 
-	Deleted documents cannot be recovered.
+.. Warning::
+    Deleted documents cannot be recovered.

--- a/docs/editor_manual/documents_images_snippets/images.rst
+++ b/docs/editor_manual/documents_images_snippets/images.rst
@@ -5,20 +5,20 @@ If you want to edit, add or remove images from the CMS outside of the individual
 
 .. image:: ../../_static/images/screen31_images_page.png
 
-* Clicking an image will allow you to edit the data associated with it. This includes the Alt text, the photographers credit, the medium of the subject matter and much more. 
+* Clicking an image will allow you to edit the data associated with it. This includes the Alt text, the photographers credit, the medium of the subject matter and much more.
 
-.. Warning:: 
-	Changing the alt text here will alter it for all occurrences of the image in carousels, but not in inline images, where the alt text can be set separately.
+.. Warning::
+    Changing the alt text here will alter it for all occurrences of the image in carousels, but not in inline images, where the alt text can be set separately.
 
 .. image:: ../../_static/images/screen32_image_edit_page.png
 
 Changing the image
 __________________
 
-* When editing an image you can replace the file associated with that image record. This means you can update images without having to update the pages on which they are placed. 
+* When editing an image you can replace the file associated with that image record. This means you can update images without having to update the pages on which they are placed.
 
 .. Warning::
-	Changing the file will change it on all pages that use the image.
+    Changing the file will change it on all pages that use the image.
 
 Focal point
 ___________

--- a/docs/editor_manual/documents_images_snippets/snippets.rst
+++ b/docs/editor_manual/documents_images_snippets/snippets.rst
@@ -20,7 +20,7 @@ The Snippets menu
 * Click on an individual snippet to edit, or click 'Add ...' in the top right to add a new snippet
 
 .. Warning::
-	Editing a snippet will change it on all of the pages on which it has been used. In the top-right of the Snippet edit screen you will see a label saying how many times the snippet has been used. Clicking this label will display a listing of all of these pages.
+    Editing a snippet will change it on all of the pages on which it has been used. In the top-right of the Snippet edit screen you will see a label saying how many times the snippet has been used. Clicking this label will display a listing of all of these pages.
 
 .. image:: ../../_static/images/screen34_snippet_used_times.png
 
@@ -35,4 +35,4 @@ If you are editing a page, and you find yourself in need of a new snippet, do no
 * You should now see your new snippet, even though you didn't leave the edit page.
 
 .. Note::
-	Even though this is possible, it is worth saving your page as a draft as often as possible, to avoid your changes being lost by navigating away from the edit page accidentally.
+    Even though this is possible, it is worth saving your page as a draft as often as possible, to avoid your changes being lost by navigating away from the edit page accidentally.

--- a/docs/editor_manual/finding_your_way_around/the_dashboard.rst
+++ b/docs/editor_manual/finding_your_way_around/the_dashboard.rst
@@ -20,7 +20,7 @@ You can return to the Dashboard at any time by clicking the Wagtail logo in the 
   - Clicking the name of a page will take you to the ‘Edit page’ interface for this page.
   - Clicking approve or reject will either change the page status to live or return the page to draft status. An email will be sent to the creator of the page giving the result of moderation either way.
   - The *Parent* column tells you what the parent page of the page awaiting moderation is called. Clicking the parent page name will take you to its Edit page.
-  
+
 - The *Your most recent edits* table displays the five pages that you most recently edited.
 - The date column displays the date that you edited the page. Hover your mouse over the date for a more exact time/date.
 - The status column displays the current status of the page. A page will have one of three statuses:

--- a/docs/editor_manual/getting_started.rst
+++ b/docs/editor_manual/getting_started.rst
@@ -6,7 +6,7 @@ _____________________
 
 This examples in this document are based on `Torchbox.com <https://torchbox.com>`_. However, the instructions are general enough as to be applicable to any Wagtail site.
 
-For the purposes of this documentation we will be using the URL, **www.example.com**, to represent the root (homepage) of your website. 
+For the purposes of this documentation we will be using the URL, **www.example.com**, to represent the root (homepage) of your website.
 
 Logging in
 __________

--- a/docs/editor_manual/new_pages/creating_body_content.rst
+++ b/docs/editor_manual/new_pages/creating_body_content.rst
@@ -29,7 +29,7 @@ Basic text fields have no formatting options. How these display will be determin
 Rich text fields
 ================
 
-Most of the time though, you need formatting options to create beautiful looking pages. So some fields, like the fields in the 'Paragraph block' shown in the screenshot, have many of the options you would expect from a word processor. These are referred to as rich text fields. 
+Most of the time though, you need formatting options to create beautiful looking pages. So some fields, like the fields in the 'Paragraph block' shown in the screenshot, have many of the options you would expect from a word processor. These are referred to as rich text fields.
 
 So, when you click into one of these fields, you will be presented with a set of tools which allow you to format and style your text. These tools also allow you to insert links, images, videos clips and links to documents.
 
@@ -84,4 +84,4 @@ Reordering and deleting content in StreamField
 * Click the rubbish bin on the far right to delete a field
 
 .. Warning::
-	Once a StreamField field is deleted it cannot be retrieved if the page has not been saved. Save your pages regularly so that if you accidentally delete a field you can reload the page to undo your latest edit.
+    Once a StreamField field is deleted it cannot be retrieved if the page has not been saved. Save your pages regularly so that if you accidentally delete a field you can reload the page to undo your latest edit.

--- a/docs/editor_manual/new_pages/inserting_images.rst
+++ b/docs/editor_manual/new_pages/inserting_images.rst
@@ -61,4 +61,4 @@ The alignments available are described below:
 * **Half-width left/right aligned:** Inserts the image at half the width of the text area. If inserted in a block of text the text will wrap around the image. If two half-width images are inserted together they will display next to each other.
 
 .. Note::
-	The display of images aligned in this way is dependent on your implementation of Wagtail, so you may get slightly different results.
+    The display of images aligned in this way is dependent on your implementation of Wagtail, so you may get slightly different results.

--- a/docs/editor_manual/new_pages/inserting_videos.rst
+++ b/docs/editor_manual/new_pages/inserting_videos.rst
@@ -6,10 +6,10 @@ Inserting videos into body content
 
 As well as inserting videos into a carousel, Wagtail's rich text fields allow you to add videos into the body of a page by clicking the *Add video* button in the toolbar.
 
-.. image:: ../../_static/images/screen20_insert_video_form.png	
+.. image:: ../../_static/images/screen20_insert_video_form.png
 
 * Copy and paste the web address for the video (either YouTube or Vimeo) into the URL field and click Insert.
 
-.. image:: ../../_static/images/screen21_video_in_editor.png	
+.. image:: ../../_static/images/screen21_video_in_editor.png
 
 * A placeholder with the name of the video and a screenshot will be inserted into the text area. Clicking the X in the top corner will remove the video.

--- a/docs/editor_manual/new_pages/the_promote_tab.rst
+++ b/docs/editor_manual/new_pages/the_promote_tab.rst
@@ -13,4 +13,4 @@ The second, *Promote*, is where you can set all the 'metadata' (data about data!
 .. image:: ../../_static/images/screen26.5_promote_tab.png
 
 .. Note::
-	You may see more fields than this in your promote tab. These are just the default fields, but you are free to add other fields to this section as necessary.
+    You may see more fields than this in your promote tab. These are just the default fields, but you are free to add other fields to this section as necessary.

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -14,24 +14,30 @@ We'd also recommend Virtualenv, which provides isolated Python environments:
 .. important::
    Before installing Wagtail, it is necessary to install the **libjpeg** and **zlib** libraries, which provide support for working with JPEG, PNG and GIF images (via the Python **Pillow** library). The way to do this varies by platform - see Pillow's `platform-specific installation instructions <http://pillow.readthedocs.org/en/latest/installation.html#external-libraries>`_.
 
-With the above installed, the quickest way to install Wagtail is::
+With the above installed, the quickest way to install Wagtail is:
 
-    pip install wagtail
+.. code-block:: console
+
+    $ pip install wagtail
 
 (``sudo`` may be required if installing system-wide or without virtualenv)
 
-Once installed, Wagtail provides a command similar to Django's ``django-admin startproject`` which stubs out a new site/project::
+Once installed, Wagtail provides a command similar to Django's ``django-admin startproject`` which stubs out a new site/project:
 
-    wagtail start mysite
+.. code-block:: console
+
+    $ wagtail start mysite
 
 This will create a new folder ``mysite``, based on a template containing all you need to get started. More information on that template is available :doc:`here </reference/project_template>`.
 
-Inside your ``mysite`` folder, we now just run the setup steps necessary for any Django project::
+Inside your ``mysite`` folder, we now just run the setup steps necessary for any Django project:
 
-    pip install -r requirements.txt
-    ./manage.py migrate
-    ./manage.py createsuperuser
-    ./manage.py runserver
+.. code-block:: console
+
+    $ pip install -r requirements.txt
+    $ ./manage.py migrate
+    $ ./manage.py createsuperuser
+    $ ./manage.py runserver
 
 Your site is now accessible at ``http://localhost:8000``, with the admin backend available at ``http://localhost:8000/admin/``.
 

--- a/docs/getting_started/integrating_into_django.rst
+++ b/docs/getting_started/integrating_into_django.rst
@@ -5,16 +5,20 @@ Integrating Wagtail into a Django project
 
 Wagtail provides the ``wagtail start`` command and project template to get you started with a new Wagtail project as quickly as possible, but it's easy to integrate Wagtail into an existing Django project too.
 
-Wagtail is currently compatible with Django 1.8, 1.9 and 1.10. First, install the ``wagtail`` package from PyPI::
+Wagtail is currently compatible with Django 1.8, 1.9 and 1.10. First, install the ``wagtail`` package from PyPI:
 
-    pip install wagtail
+.. code-block:: console
+
+    $ pip install wagtail
 
 or add the package to your existing requirements file. This will also install the **Pillow** library as a dependency, which requires libjpeg and zlib - see Pillow's `platform-specific installation instructions <http://pillow.readthedocs.org/en/latest/installation.html#external-libraries>`_.
 
 Settings
 --------
 
-In your settings file, add the following apps to ``INSTALLED_APPS``::
+In your settings file, add the following apps to ``INSTALLED_APPS``:
+
+.. code-block:: python
 
     'wagtail.wagtailforms',
     'wagtail.wagtailredirects',
@@ -31,7 +35,9 @@ In your settings file, add the following apps to ``INSTALLED_APPS``::
     'modelcluster',
     'taggit',
 
-Add the following entries to ``MIDDLEWARE_CLASSES``::
+Add the following entries to ``MIDDLEWARE_CLASSES``:
+
+.. code-block:: python
 
     'wagtail.wagtailcore.middleware.SiteMiddleware',
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
@@ -75,7 +81,9 @@ The URL paths here can be altered as necessary to fit your project's URL scheme.
 
 ``wagtaildocs_urls`` is the location from where document files will be served. This can be omitted if you do not intend to use Wagtail's document management features.
 
-``wagtail_urls`` is the base location from where the pages of your Wagtail site will be served. In the above example, Wagtail will handle URLs under ``/pages/``, leaving the root URL and other paths to be handled as normal by your Django project. If you want Wagtail to handle the entire URL space including the root URL, this can be replaced with::
+``wagtail_urls`` is the base location from where the pages of your Wagtail site will be served. In the above example, Wagtail will handle URLs under ``/pages/``, leaving the root URL and other paths to be handled as normal by your Django project. If you want Wagtail to handle the entire URL space including the root URL, this can be replaced with:
+
+.. code-block:: python
 
     url(r'', include(wagtail_urls)),
 

--- a/docs/getting_started/tutorial.rst
+++ b/docs/getting_started/tutorial.rst
@@ -4,14 +4,18 @@ Your first Wagtail site
 .. note::
    This tutorial covers setting up a brand new Wagtail project. If you'd like to add Wagtail to an existing Django project instead, see :doc:`integrating_into_django`.
 
-1. Install Wagtail and its dependencies::
+1. Install Wagtail and its dependencies:
 
-    pip install wagtail
+   .. code-block:: console
 
-2. Start your site::
+       $ pip install wagtail
 
-    wagtail start mysite
-    cd mysite
+2. Start your site:
+
+   .. code-block:: console
+
+       $ wagtail start mysite
+       $ cd mysite
 
    Wagtail provides a ``start`` command similar to
    ``django-admin.py startproject``. Running ``wagtail start mysite`` in
@@ -20,22 +24,28 @@ Your first Wagtail site
    "home" app with a blank ``HomePage`` model and basic templates and a sample
    "search" app.
 
-3. Install project dependencies::
+3. Install project dependencies:
 
-    pip install -r requirements.txt
+   .. code-block:: console
+
+       $ pip install -r requirements.txt
 
    This ensures that you have the relevant version of Django for the project you've just created.
 
-4. Create the database::
+4. Create the database:
 
-    python manage.py migrate
+   .. code-block:: console
+
+       $ python manage.py migrate
 
    If you haven't updated the project settings, this will be a SQLite
    database file in the project directory.
 
-5. Create an admin user::
+5. Create an admin user:
 
-    python manage.py createsuperuser
+   .. code-block:: console
+
+       $ python manage.py createsuperuser
 
 6. ``python manage.py runserver`` If everything worked,
    http://127.0.0.1:8000 will show you a welcome page

--- a/docs/reference/contrib/api/configuration.rst
+++ b/docs/reference/contrib/api/configuration.rst
@@ -30,7 +30,7 @@ You can add more fields to the pages endpoint by setting an attribute called ``a
 
 .. code-block:: python
 
-    class BlogPage(Page):  
+    class BlogPage(Page):
         posted_by = models.CharField()
         posted_at = models.DateTimeField()
         content = RichTextField()
@@ -48,7 +48,7 @@ This list also supports child relations (which will be nested inside the returne
 
         api_fields = ['link']
 
-    class BlogPage(Page):  
+    class BlogPage(Page):
         posted_by = models.CharField()
         posted_at = models.DateTimeField()
         content = RichTextField()

--- a/docs/reference/contrib/api/usage.rst
+++ b/docs/reference/contrib/api/usage.rst
@@ -581,26 +581,26 @@ This is what a typical response from a ``GET`` request to this listing would loo
     {
         "meta": {
             "total_count": 3
-        }, 
+        },
         "images": [
             {
-                "id": 4, 
+                "id": 4,
                 "meta": {
                     "type": "wagtailimages.Image",
                     "detail_url": "http://api.example.com/api/v1/images/4/"
                 },
                 "title": "Wagtail by Mark Harkin"
-            }, 
+            },
             {
-                "id": 5, 
+                "id": 5,
                 "meta": {
                     "type": "wagtailimages.Image",
                     "detail_url": "http://api.example.com/api/v1/images/5/"
                 },
                 "title": "James Joyce"
-            }, 
+            },
             {
-                "id": 6, 
+                "id": 6,
                 "meta": {
                     "type": "wagtailimages.Image",
                     "detail_url": "http://api.example.com/api/v1/images/6/"
@@ -631,36 +631,36 @@ By default, this will allow you to add the ``width`` and ``height`` fields to yo
     {
         "meta": {
             "total_count": 3
-        }, 
+        },
         "images": [
             {
-                "id": 4, 
+                "id": 4,
                 "meta": {
                     "type": "wagtailimages.Image",
                     "detail_url": "http://api.example.com/api/v1/images/4/"
                 },
-                "title": "Wagtail by Mark Harkin", 
-                "width": 640, 
+                "title": "Wagtail by Mark Harkin",
+                "width": 640,
                 "height": 427
-            }, 
+            },
             {
-                "id": 5, 
+                "id": 5,
                 "meta": {
                     "type": "wagtailimages.Image",
                     "detail_url": "http://api.example.com/api/v1/images/5/"
                 },
-                "title": "James Joyce", 
-                "width": 500, 
+                "title": "James Joyce",
+                "width": 500,
                 "height": 392
-            }, 
+            },
             {
-                "id": 6, 
+                "id": 6,
                 "meta": {
                     "type": "wagtailimages.Image",
                     "detail_url": "http://api.example.com/api/v1/images/6/"
                 },
-                "title": "David Mitchell", 
-                "width": 360, 
+                "title": "David Mitchell",
+                "width": 360,
                 "height": 282
             }
         ]
@@ -682,10 +682,10 @@ Exact matches on field values can be done by using a query parameter with the sa
     {
         "meta": {
             "total_count": 3
-        }, 
+        },
         "images": [
             {
-                "id": 5, 
+                "id": 5,
                 "meta": {
                     "type": "wagtailimages.Image",
                     "detail_url": "http://api.example.com/api/v1/images/5/"
@@ -711,33 +711,33 @@ The images endpoint also accepts the ``order`` parameter which should be set to 
     {
         "meta": {
             "total_count": 3
-        }, 
+        },
         "images": [
             {
-                "id": 6, 
+                "id": 6,
                 "meta": {
                     "type": "wagtailimages.Image",
                     "detail_url": "http://api.example.com/api/v1/images/6/"
                 },
-                "title": "David Mitchell", 
+                "title": "David Mitchell",
                 "width": 360
             },
             {
-                "id": 5, 
+                "id": 5,
                 "meta": {
                     "type": "wagtailimages.Image",
                     "detail_url": "http://api.example.com/api/v1/images/5/"
                 },
-                "title": "James Joyce", 
+                "title": "James Joyce",
                 "width": 500
             },
             {
-                "id": 4, 
+                "id": 4,
                 "meta": {
                     "type": "wagtailimages.Image",
                     "detail_url": "http://api.example.com/api/v1/images/4/"
                 },
-                "title": "Wagtail by Mark Harkin", 
+                "title": "Wagtail by Mark Harkin",
                 "width": 640
             }
         ]
@@ -762,13 +762,13 @@ Pagination is done using two query parameters called ``limit`` and ``offset``. `
         },
         "images": [
             {
-                "id": 5, 
+                "id": 5,
                 "meta": {
                     "type": "wagtailimages.Image",
                     "detail_url": "http://api.example.com/api/v1/images/5/"
                 },
-                "title": "James Joyce", 
-                "width": 500, 
+                "title": "James Joyce",
+                "width": 500,
                 "height": 392
             }
         ]
@@ -796,13 +796,13 @@ To perform a full-text search, set the ``search`` parameter to the query string 
         },
         "pages": [
             {
-                "id": 5, 
+                "id": 5,
                 "meta": {
                     "type": "wagtailimages.Image",
                     "detail_url": "http://api.example.com/api/v1/images/5/"
                 },
-                "title": "James Joyce", 
-                "width": 500, 
+                "title": "James Joyce",
+                "width": 500,
                 "height": 392
             }
         ]
@@ -826,13 +826,13 @@ This view gives you access to all of the details for a particular image.
     Content-Type: application/json
 
     {
-        "id": 5, 
+        "id": 5,
         "meta": {
             "type": "wagtailimages.Image",
             "detail_url": "http://api.example.com/api/v1/images/5/"
         },
-        "title": "James Joyce", 
-        "width": 500, 
+        "title": "James Joyce",
+        "width": 500,
         "height": 392
     }
 
@@ -862,11 +862,11 @@ This view gives you access to all of the details for a particular document.
     Content-Type: application/json
 
     {
-        "id": 1, 
+        "id": 1,
         "meta": {
             "type": "wagtaildocs.Document",
             "detail_url": "http://api.example.com/api/v1/documents/1/",
             "download_url": "http://api.example.com/documents/1/usage.md"
-        }, 
+        },
         "title": "Wagtail API usage"
     }

--- a/docs/reference/contrib/api/usage.rst
+++ b/docs/reference/contrib/api/usage.rst
@@ -293,8 +293,6 @@ For example, to get all the pages that are direct children of page 7.
 
 **descendant_of**
 
-.. versionadded:: 1.1
-
 Filters the listing to only include descendants of the specified page.
 
 For example, to get all pages underneath the homepage:

--- a/docs/reference/contrib/index.rst
+++ b/docs/reference/contrib/index.rst
@@ -1,7 +1,7 @@
 Contrib modules
 ===============
 
-Wagtail ships with a variety of extra optional modules. 
+Wagtail ships with a variety of extra optional modules.
 
 
 .. toctree::

--- a/docs/reference/contrib/modeladmin/chooseparentview.rst
+++ b/docs/reference/contrib/modeladmin/chooseparentview.rst
@@ -27,7 +27,7 @@ do, modeladmin offers the following attributes that you can override:
 ``ModelAdmin.choose_parent_template_name``
 ------------------------------------------
 
-**Expected value**: The path to a custom template to use for 
+**Expected value**: The path to a custom template to use for
 ``ChooseParentView``
 
 See the following part of the docs to find out more:
@@ -39,7 +39,7 @@ See the following part of the docs to find out more:
 ``ModelAdmin.choose_parent_view_class``
 ------------------------------------------
 
-**Expected value**: A custom ``view`` class to replace 
+**Expected value**: A custom ``view`` class to replace
 ``modeladmin.views.ChooseParentView``
 
 See the following part of the docs to find out more:

--- a/docs/reference/contrib/modeladmin/create_edit_delete_views.rst
+++ b/docs/reference/contrib/modeladmin/create_edit_delete_views.rst
@@ -3,7 +3,7 @@ Customising ``CreateView``, ``EditView`` and ``DeleteView``
 ===========================================================
 
 **NOTE:** ``modeladmin`` only provides 'create', 'edit' and 'delete'
-functionality for non page type models (i.e. models that do not extend 
+functionality for non page type models (i.e. models that do not extend
 ``wagtailcore.models.Page``). If your model is a 'page type' model, customising
 any of the following will not have any effect:
 
@@ -27,7 +27,7 @@ model class.
         first_name = models.CharField(max_length=100)
         last_name = models.CharField(max_length=100)
         address = models.TextField()
-        
+
         panels = [
             MultiFieldPanel([
                 FieldRowPanel([
@@ -45,7 +45,7 @@ Or alternatively:
         first_name = models.CharField(max_length=100)
         last_name = models.CharField(max_length=100)
         address = models.TextField()
-        
+
         custom_panels = [
             MultiFieldPanel([
                 FieldRowPanel([
@@ -99,7 +99,7 @@ See the following part of the docs to find out more:
 ``ModelAdmin.create_view_class``
 -----------------------------------
 
-**Expected value**: A custom ``view`` class to replace 
+**Expected value**: A custom ``view`` class to replace
 ``modeladmin.views.CreateView``
 
 See the following part of the docs to find out more:
@@ -122,7 +122,7 @@ See the following part of the docs to find out more:
 ``ModelAdmin.edit_view_class``
 -----------------------------------
 
-**Expected value**: A custom ``view`` class to replace 
+**Expected value**: A custom ``view`` class to replace
 ``modeladmin.views.EditView``
 
 See the following part of the docs to find out more:
@@ -145,7 +145,7 @@ See the following part of the docs to find out more:
 ``ModelAdmin.delete_view_class``
 -----------------------------------
 
-**Expected value**: A custom ``view`` class to replace 
+**Expected value**: A custom ``view`` class to replace
 ``modeladmin.views.DeleteView``
 
 See the following part of the docs to find out more:

--- a/docs/reference/contrib/modeladmin/indexview.rst
+++ b/docs/reference/contrib/modeladmin/indexview.rst
@@ -25,18 +25,18 @@ on the ``ModelAdmin`` class itself.
 
 Default value: ``('__str__',)``
 
-Set ``list_display`` to control which fields are displayed in the IndexView 
+Set ``list_display`` to control which fields are displayed in the IndexView
 for your model.
 
 Example
 
 ```
-list_display = ('first_name', 'last_name')  
+list_display = ('first_name', 'last_name')
 ```
 
 You have three possible values that can be used in list_display:
 
--   A field of the model. For example: 
+-   A field of the model. For example:
 
     .. code-block:: python
 
@@ -173,9 +173,9 @@ A few special cases to note about ``list_display``:
 
 
     By default, the ability to sort results by an item in ``list_display`` is
-    only offered when it's a field that has an actual database value (because 
+    only offered when it's a field that has an actual database value (because
     sorting is done at the database level). However, if the output of the
-    method is representative of a database field, you can indicate this fact by 
+    method is representative of a database field, you can indicate this fact by
     setting the ``admin_order_field`` attribute on that method, like so:
 
     .. code-block:: python
@@ -222,8 +222,8 @@ A few special cases to note about ``list_display``:
     .. code-block:: python
 
         from django.db import models
-        
-        
+
+
         class Blog(models.Model):
             title = models.CharField(max_length=255)
             author = models.ForeignKey(Person, on_delete=models.CASCADE)
@@ -235,8 +235,8 @@ A few special cases to note about ``list_display``:
 
 
 -   Elements of ``list_display`` can also be properties. Please note however,
-    that due to the way properties work in Python, setting 
-    ``short_description`` on a property is only possible when using the 
+    that due to the way properties work in Python, setting
+    ``short_description`` on a property is only possible when using the
     ``property()`` function and **not** with the ``@property`` decorator.
 
     For example:
@@ -256,7 +256,7 @@ A few special cases to note about ``list_display``:
 
             full_name = property(full_name_property)
 
-        
+
         class PersonAdmin(ModelAdmin):
             list_display = ('full_name',)
 
@@ -268,7 +268,7 @@ A few special cases to note about ``list_display``:
 ---------------------------
 
 **Expected value**: A list or tuple, where each item is the name of model field
-of type ``BooleanField``, ``CharField``, ``DateField``, ``DateTimeField``, 
+of type ``BooleanField``, ``CharField``, ``DateField``, ``DateTimeField``,
 ``IntegerField`` or ``ForeignKey``.
 
 Set ``list_filter`` to activate filters in the right sidebar of the list page
@@ -290,7 +290,7 @@ for your model. For example:
 of type ``CharField``, ``TextField``, ``RichTextField`` or ``StreamField``.
 
 Set ``search_fields`` to enable a search box at the top of the index page
-for your model. You should add names of any fields on the model that should 
+for your model. You should add names of any fields on the model that should
 be searched whenever somebody submits a search query using the search box.
 
 Searching is all handled via Django's queryset API, rather than using Wagtail's
@@ -303,7 +303,7 @@ your project is using, and without any additional setup or configuration.
 ``ModelAdmin.ordering``
 ---------------------------
 
-**Expected value**: A list or tuple in the same format as a model’s 
+**Expected value**: A list or tuple in the same format as a model’s
 [``ordering``](https://docs.djangoproject.com/en/1.9/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_display) parameter.
 
 Set ``ordering`` to specify the default ordering of objects when listed by
@@ -338,7 +338,7 @@ method of your model's default manager is used. But, if for any reason you
 only want a certain sub-set of objects to appear in the IndexView listing,
 overriding the ``get_queryset`` method on your ``ModelAdmin`` class can help
 you with that. The method takes an ``HttpRequest`` object as a parameter, so
-limiting objects by the current logged-in user is possible. 
+limiting objects by the current logged-in user is possible.
 
 For example:
 
@@ -374,7 +374,7 @@ The `get_extra_attrs_for_row` method allows you to add html attributes to
 the opening `<tr>` tag for each result, in addition to the `data-object_pk` and
 `class` attributes already added by the `result_row_display` tag.
 
-If you want to add additional CSS classes, simply provide those class names 
+If you want to add additional CSS classes, simply provide those class names
 as a string value using the `class` key, and the `odd`/`even` will be appended
 to your custom class names when rendering.
 
@@ -464,7 +464,7 @@ depending on the row's value, you could do something like:
 The ``get_extra_attrs_for_field_col`` method allows you to add additional HTML
 attributes to any of the columns defined in ``list_display``. Like the
 ``get_extra_class_names_for_field_col`` method above, this method takes two
-parameters: 
+parameters:
 
 -   ``obj``: the object being represented by the current row
 -   ``field_name``: the item from ``list_display`` being represented by the
@@ -539,10 +539,10 @@ kind of interactivity using javascript:
 ----------------------------------------------------
 
 If you're using ``wagtailimages.Image`` to define an image for each item in
-your model, ``ThumbnailMixin`` can help you add thumbnail versions of that 
+your model, ``ThumbnailMixin`` can help you add thumbnail versions of that
 image to each row in ``IndexView``. To use it, simply extend ``ThumbnailMixin``
 as well as ``ModelAdmin`` when defining your ``ModelAdmin`` class, and
-change a few attributes to change the thumbnail to your liking, like so: 
+change a few attributes to change the thumbnail to your liking, like so:
 
 .. code-block:: python
 
@@ -555,7 +555,7 @@ change a few attributes to change the thumbnail to your liking, like so:
         likes_cat_gifs = models.NullBooleanField()
 
     class PersonAdmin(ThumbnailMixin, ModelAdmin):
-        
+
         # Add 'admin_thumb' to list_display, where you want the thumbnail to appear
         list_display = ('admin_thumb', 'name', 'likes_cat_gifs')
 
@@ -569,7 +569,7 @@ change a few attributes to change the thumbnail to your liking, like so:
         links to 'wagtailimages.Image'
         """
         thumb_image_field_name = 'avatar'
-        
+
         # Optionally override the filter spec used to create each thumb
         thumb_image_filter_spec = 'fill-100x100' # this is the default
 
@@ -597,12 +597,12 @@ change a few attributes to change the thumbnail to your liking, like so:
 **Expected value**: A string matching one of the items in ``list_display``.
 
 If for any reason you'd like to change which column the action buttons appear
-in for each row, you can specify a different column using 
+in for each row, you can specify a different column using
 ``list_display_add_buttons`` on your ``ModelAdmin`` class. The value must
 match one of the items your class's ``list_display`` attribute. By default,
-buttons are added to the first column of each row. 
+buttons are added to the first column of each row.
 
-See the ``ThumbnailMixin`` example above to see how 
+See the ``ThumbnailMixin`` example above to see how
 ``list_display_add_buttons`` can be used.
 
 .. _modeladmin_index_view_extra_css:
@@ -646,7 +646,7 @@ See the following part of the docs to find out more:
 ``ModelAdmin.index_view_class``
 ---------------------------------------
 
-**Expected value**: A custom ``view`` class to replace 
+**Expected value**: A custom ``view`` class to replace
 ``modeladmin.views.IndexView``
 
 See the following part of the docs to find out more:

--- a/docs/reference/contrib/modeladmin/inspectview.rst
+++ b/docs/reference/contrib/modeladmin/inspectview.rst
@@ -27,15 +27,15 @@ class:
 ``ModelAdmin.inspect_view_fields``
 ------------------------------------------
 
-**Expected value:** A list or tuple, where each item is the name of a field 
+**Expected value:** A list or tuple, where each item is the name of a field
 that you'd like ``InpectView`` to render.
 
 A sensible value will be rendered for most field types.
 
-If a field happens to be a ``ForeignKey`` linking to the 
-``wagtailimages.Image`` model, a thumbnail of that image will be rendered. 
+If a field happens to be a ``ForeignKey`` linking to the
+``wagtailimages.Image`` model, a thumbnail of that image will be rendered.
 
-If a field happens to be a ``ForeignKey`` linking to the 
+If a field happens to be a ``ForeignKey`` linking to the
 ``wagtaildocs.Document`` model, a link to that document will be rendered.
 
 
@@ -45,7 +45,7 @@ If a field happens to be a ``ForeignKey`` linking to the
 ``ModelAdmin.inspect_view_fields_exclude``
 ------------------------------------------
 
-**Expected value:** A list or tuple, where each item is the name of a field 
+**Expected value:** A list or tuple, where each item is the name of a field
 that you'd like to exclude from ``InpectView``
 
 **Note:** If both ``inspect_view_fields`` and ``inspect_view_fields_exclude``
@@ -92,7 +92,7 @@ See the following part of the docs to find out more:
 ``ModelAdmin.inspect_view_class``
 ---------------------------------------
 
-**Expected value**: A custom ``view`` class to replace 
+**Expected value**: A custom ``view`` class to replace
 ``modeladmin.views.InspectView``
 
 See the following part of the docs to find out more:

--- a/docs/reference/contrib/modeladmin/menu_item.rst
+++ b/docs/reference/contrib/modeladmin/menu_item.rst
@@ -17,7 +17,7 @@ alter the menu item used to represent your model in Wagtail's admin area.
 
 **Expected value**: A string.
 
-Set this attribute to a string value to override the label used for the menu 
+Set this attribute to a string value to override the label used for the menu
 item that appears in Wagtail's sidebar. If not set, the menu item will use
 ``verbose_name_plural`` from your model's ``Meta`` data.
 
@@ -36,7 +36,7 @@ sidebar, and will also appear in the header on the list page and other views
 for your model. If not set, ``'doc-full-inverse'`` will be used for
 page-type models, and ``'snippet'`` for others.
 
-If you're using a ``ModelAdminGroup`` class to group together several 
+If you're using a ``ModelAdminGroup`` class to group together several
 ``ModelAdmin`` classes in their own sub-menu, and want to change the menu item
 used to represent the group, you should override the ``menu_icon`` attribute on
 your ``ModelAdminGroup`` class (``'icon-folder-open-inverse'`` is the default).
@@ -67,7 +67,7 @@ greater than that if you wish to keep the explorer menu item at the top.
 
 If you'd like the menu item for your model to appear in Wagtail's 'Settings'
 sub-menu instead of at the top level, add ``add_to_setings_menu = True`` to
-your ``ModelAdmin`` class. 
+your ``ModelAdmin`` class.
 
 This will only work for indivdual ``ModelAdmin`` classes registered with their
 own ``modeladmin_register`` call. It won't work for members of a

--- a/docs/reference/contrib/modeladmin/primer.rst
+++ b/docs/reference/contrib/modeladmin/primer.rst
@@ -2,7 +2,7 @@
 ``modeladmin`` customisation primer
 ===================================
 
-The ``modeladmin`` app is designed to offer you as much flexibility as possible 
+The ``modeladmin`` app is designed to offer you as much flexibility as possible
 in how your model and its objects are represented in Wagtail's CMS. This page
 aims to provide you with some background information to help you gain a better
 understanding of what the app can do, and to point you in the right direction,
@@ -36,13 +36,13 @@ to using to configure Django's add/edit views, simply aren't supported by
 Wagtail's version.
 
 'Page type' models need to be treated differently to other models
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 While ``modeladmin``'s listing view and it's supported customisation
 options work in exactly the same way for all types of ``Model``, when it
 comes to the other management views, the treatment differs depending on
 whether your ModelAdmin class is representing a page type model (that
-extends ``wagtailcore.models.Page``) or not. 
+extends ``wagtailcore.models.Page``) or not.
 
 Pages in Wagtail have some unique properties, and require additional views,
 interface elements and general treatment in order to be managed
@@ -58,13 +58,13 @@ In order to deliver a consistent experience for users, ``modeladmin``
 simply redirects users to Wagtail's existing page management views wherever
 possible. You should bare this in mind if you ever find yourself wanting to
 change what happens when pages of a certain type are added, deleted,
-published, or have some other action applied to them. Customising the 
+published, or have some other action applied to them. Customising the
 ``CreateView`` or ``EditView`` for your a page type ``Model`` (even it just
 to add an additional stylesheet or javascript), simply won't have any
 effect, as those views are not used.
 
 If you do find yourself needing to customise the add, edit or other
-behaviour for a page type model, you should take a look at the following 
+behaviour for a page type model, you should take a look at the following
 part of the documentation: :ref:`admin_hooks`.
 
 Wagtail's ``ModelAdmin`` class is 'modular'
@@ -80,7 +80,7 @@ separate, swappable components.
 The theory is: If you want to do something differently, or add some
 functionality that ``modeladmin`` doesn't already have, you can create new
 classes (or extend the ones provided by ``modeladmin``) and easily
-configure your ``ModelAdmin`` class to use them instead of the defaults. 
+configure your ``ModelAdmin`` class to use them instead of the defaults.
 
 - Learn more about :ref:`modeladmin_overriding_views`
 - Learn more about :ref:`modeladmin_overriding_helper_classes`
@@ -89,10 +89,10 @@ configure your ``ModelAdmin`` class to use them instead of the defaults.
 Changing what appears in the listing
 ------------------------------------
 
-You should familarise yourself with the attributes and methods supported by 
+You should familarise yourself with the attributes and methods supported by
 the ``ModelAdmin`` class, that allow you to change what is displayed in the
 ``IndexView``. The following page should give you everything you need to get
-going: :doc:`indexview` 
+going: :doc:`indexview`
 
 
 .. _modeladmin_adding_css_and_js:
@@ -151,7 +151,7 @@ within your project, before resorting to the defaults:
 So, to override the template used by ``IndexView`` for example, you'd create a
 new ``index.html`` template and put it in one of those locations.  For example,
 if you wanted to do this for an ``ArticlePage`` model in a ``news`` app, you'd
-add your custom template as ``modeladmin/news/article/index.html``. 
+add your custom template as ``modeladmin/news/article/index.html``.
 
 For reference, ``modeladmin`` looks for templates with the following names for
 each view:
@@ -211,7 +211,7 @@ For example, if you'd like to create your own view class and use it for the
 
 Or, if you have no need for any of ``IndexView``'s exisiting functionality in
 your view, and would rather create your own view from scratch, ``modeladmin``
-will support that, too. However, it's highly recommended that you use 
+will support that, too. However, it's highly recommended that you use
 ``modeladmin.views.WMABaseView`` as a base for your view. It'll make
 integrating with your ``ModelAdmin`` class much easier, and provides a bunch of
 useful attributes and methods to get you started.
@@ -222,10 +222,10 @@ useful attributes and methods to get you started.
 Overriding helper classes
 -------------------------
 
-While 'view classes' are responsible for a lot of the work, there are also 
+While 'view classes' are responsible for a lot of the work, there are also
 a number of other tasks that ``modeladmin`` must do regularly, that need to be
 handled in a consistent way, and in a number of different places. These tasks
-are designated to set of simple classes (in ``modeladmin``, these are termed 
+are designated to set of simple classes (in ``modeladmin``, these are termed
 'helper' classes) and can be found in ``wagtail.contrib.modeladmin.helpers``.
 
 If you ever intend to write and use your own custom views with ``modeladmin``,
@@ -243,7 +243,7 @@ There are three types of 'helper class':
   generation of buttons for use in a number of places.
 
 The ``ModelAdmin`` class allows you to define and use your own helper classes
-by setting values on the following attributes: 
+by setting values on the following attributes:
 
 .. _modeladmin_url_helper_class:
 
@@ -252,10 +252,10 @@ by setting values on the following attributes:
 
 By default, the ``modeladmin.helpers.PageAdminURLHelper`` class is used when
 your model extends ``wagtailcore.models.Page``, otherwise
-``modeladmin.helpers.AdminURLHelper`` is used. 
+``modeladmin.helpers.AdminURLHelper`` is used.
 
 If you find that the above helper classes don't cater for your needs, you can
-easily create your own helper class, by sub-classing ``AdminURLHelper`` or 
+easily create your own helper class, by sub-classing ``AdminURLHelper`` or
 ``PageAdminURLHelper`` (if your  model extend's Wagtail's ``Page`` model), and
 making any neccessary additions/overrides.
 
@@ -280,7 +280,7 @@ your ``ModelAdmin`` class to use your custom URLHelper, like so:
     modeladmin_register(MyModelAdmin)
 
 
-Or, if you have a more complicated use case, where simply setting that 
+Or, if you have a more complicated use case, where simply setting that
 attribute isn't possible (due to circular imports, for example) or doesn't
 meet your needs, you can override the  ``get_url_helper_class`` method, like
 so:
@@ -289,7 +289,7 @@ so:
 
     class MyModelAdmin(ModelAdmin):
         model = MyModel
-        
+
         def get_url_helper_class(self):
             if self.some_attribute is True:
                 return MyURLHelper
@@ -303,11 +303,11 @@ so:
 
 By default, the ``modeladmin.helpers.PagePermissionHelper``
 class is used when your model extends ``wagtailcore.models.Page``,
-otherwise ``wagtail.contrib.modeladmin.helpers.PermissionHelper`` is used. 
+otherwise ``wagtail.contrib.modeladmin.helpers.PermissionHelper`` is used.
 
 If you find that the above helper classes don't cater for your needs, you can
 easily create your own helper class, by sub-classing
-``PermissionHelper`` or (if your  model extend's Wagtail's ``Page`` model) 
+``PermissionHelper`` or (if your  model extend's Wagtail's ``Page`` model)
 ``PagePermissionHelper``, and making any neccessary additions/overrides. Once
 defined, you set the ``permission_helper_class`` attribute on your
 ``ModelAdmin`` class to use your custom class instead of the default, like so:
@@ -330,15 +330,15 @@ defined, you set the ``permission_helper_class`` attribute on your
     modeladmin_register(MyModelAdmin)
 
 
-Or, if you have a more complicated use case, where simply setting an attribute 
-isn't possible or doesn't meet your needs, you can override the 
+Or, if you have a more complicated use case, where simply setting an attribute
+isn't possible or doesn't meet your needs, you can override the
 ``get_permission_helper_class`` method, like so:
 
 .. code-block:: python
 
     class MyModelAdmin(ModelAdmin):
         model = MyModel
-        
+
         def get_get_permission_helper_class(self):
             if self.some_attribute is True:
                 return MyPermissionHelper
@@ -351,8 +351,8 @@ isn't possible or doesn't meet your needs, you can override the
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 By default, the ``modeladmin.helpers.PageButtonHelper`` class is used when your
-model extends ``wagtailcore.models.Page``, otherwise 
-``modeladmin.helpers.ButtonHelper`` is used. 
+model extends ``wagtailcore.models.Page``, otherwise
+``modeladmin.helpers.ButtonHelper`` is used.
 
 If you wish to add or change buttons for your model's IndexView, you'll need to
 create  your own button helper class, by sub-classing ``ButtonHelper`` or (if
@@ -379,15 +379,15 @@ custom class instead of the default, like so:
     modeladmin_register(MyModelAdmin)
 
 
-Or, if you have a more complicated use case, where simply setting an attribute 
-isn't possible or doesn't meet your needs, you can override the 
+Or, if you have a more complicated use case, where simply setting an attribute
+isn't possible or doesn't meet your needs, you can override the
 ``get_button_helper_class`` method, like so:
 
 .. code-block:: python
 
     class MyModelAdmin(ModelAdmin):
         model = MyModel
-        
+
         def get_button_helper_class(self):
             if self.some_attribute is True:
                 return MyButtonHelper
@@ -411,6 +411,6 @@ Unlike the other two, `self.button_helper` isn't populated right away when
 the view is instantiated. In order to show the right buttons for the right
 users, ButtonHelper instances need to be 'request aware', so
 ``self.button_helper`` is only set once the view's ``dispatch()`` method has
-run, which takes a ``HttpRequest`` object as an argument, from which the 
+run, which takes a ``HttpRequest`` object as an argument, from which the
 current user can be identified.
 

--- a/docs/reference/contrib/staticsitegen.rst
+++ b/docs/reference/contrib/staticsitegen.rst
@@ -12,9 +12,9 @@ Installing ``django-medusa``
 
 First, install ``django-medusa`` and ``django-sendfile`` from pip:
 
-.. code-block:: sh
+.. code-block:: console
 
-    pip install django-medusa django-sendfile
+    $ pip install django-medusa django-sendfile
 
 Then add ``django_medusa`` and ``wagtail.contrib.wagtailmedusa`` to ``INSTALLED_APPS``:
 

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -69,8 +69,6 @@ Hooks for building new areas of the admin interface (alongside pages, images, do
 ``construct_homepage_summary_items``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  .. versionadded:: 1.0
-
   Add or remove items from the 'site summary' bar on the admin homepage (which shows the number of pages and other object that exist on the site). The callable passed into this hook should take a ``request`` object and a list of ``SummaryItem`` objects to be modified as required. These objects have a ``render()`` method, which returns an HTML string, and an ``order`` property, which is an integer that specifies the order in which the items will appear.
 
 

--- a/docs/reference/management_commands.rst
+++ b/docs/reference/management_commands.rst
@@ -9,7 +9,9 @@ Management commands
 publish_scheduled_pages
 -----------------------
 
-:code:`./manage.py publish_scheduled_pages`
+.. code-block:: console
+
+    $ ./manage.py publish_scheduled_pages
 
 This command publishes or unpublishes pages that have had these actions scheduled by an editor. It is recommended to run this command once an hour.
 
@@ -19,7 +21,9 @@ This command publishes or unpublishes pages that have had these actions schedule
 fixtree
 -------
 
-:code:`./manage.py fixtree`
+.. code-block:: console
+
+    $ ./manage.py fixtree
 
 This command scans for errors in your database and attempts to fix any issues it finds.
 
@@ -29,7 +33,9 @@ This command scans for errors in your database and attempts to fix any issues it
 move_pages
 ----------
 
-:code:`manage.py move_pages from to`
+.. code-block:: console
+
+    $ manage.py move_pages from to
 
 This command moves a selection of pages from one section of the tree to another.
 
@@ -47,7 +53,9 @@ Options:
 update_index
 ------------
 
-:code:`./manage.py update_index [--backend <backend name>]`
+.. code-block:: console
+
+    $ ./manage.py update_index [--backend <backend name>]
 
 This command rebuilds the search index from scratch. It is only required when using Elasticsearch.
 
@@ -71,9 +79,9 @@ If you have multiple backends and would only like to update one of them, you can
 
 For example, to update just the default backend:
 
-.. code-block:: sh
+.. code-block:: console
 
-    python manage.py update_index --backend default
+    $ python manage.py update_index --backend default
 
 
 Indexing the schema only
@@ -83,9 +91,9 @@ Indexing the schema only
 
 You can prevent the ``update_index`` command from indexing any data by using the ``--schema-only`` option:
 
-.. code-block:: sh
+.. code-block:: console
 
-    python manage.py update_index --schema-only
+    $ python manage.py update_index --schema-only
 
 
 .. _search_garbage_collect:
@@ -93,6 +101,8 @@ You can prevent the ``update_index`` command from indexing any data by using the
 search_garbage_collect
 ----------------------
 
-:code:`./manage.py search_garbage_collect`
+.. code-block:: console
+
+    $ ./manage.py search_garbage_collect
 
 Wagtail keeps a log of search queries that are popular on your website. On high traffic websites, this log may get big and you may want to clean out old search queries. This command cleans out all search query logs that are more than one week old (or a number of days configurable through the :ref:`WAGTAILSEARCH_HITS_MAX_AGE <wagtailsearch_hits_max_age>` setting).

--- a/docs/reference/management_commands.rst
+++ b/docs/reference/management_commands.rst
@@ -70,9 +70,6 @@ The search may not return any results while this command is running, so avoid ru
 Specifying which backend to update
 ``````````````````````````````````
 
-.. versionadded:: 0.7
-
-
 By default, ``update_index`` will rebuild all the search indexes listed in ``WAGTAILSEARCH_BACKENDS``.
 
 If you have multiple backends and would only like to update one of them, you can use the ``--backend`` option.
@@ -86,8 +83,6 @@ For example, to update just the default backend:
 
 Indexing the schema only
 ````````````````````````
-
-.. versionadded:: 1.5
 
 You can prevent the ``update_index`` command from indexing any data by using the ``--schema-only`` option:
 

--- a/docs/reference/pages/model_recipes.rst
+++ b/docs/reference/pages/model_recipes.rst
@@ -94,11 +94,11 @@ First, ``models.py``:
     from wagtail.wagtailcore.url_routing import RouteResult
     from django.http.response import Http404
     from wagtail.wagtailcore.models import Page
-    
+
     ...
 
     class Echoer(Page):
-  
+
         def route(self, request, path_components):
             if path_components:
                 # tell Wagtail to call self.serve() with an additional 'path_components' kwarg

--- a/docs/releases/0.5.rst
+++ b/docs/releases/0.5.rst
@@ -117,9 +117,11 @@ Since Wagtail 0.3, the wagtailadmin module automatically takes care of registeri
 New fields on Image and Rendition models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Several new fields have been added to the Image and Rendition models to support :ref:`image_feature_detection`. These will be added to the database when you run ``./manage.py migrate``. If you have defined a custom image model (by extending the ``wagtailimages.AbstractImage`` and ``wagtailimages.AbstractRendition`` classes and specifying ``WAGTAILIMAGES_IMAGE_MODEL`` in settings), the change needs to be applied to that model's database table too. Running the command::
+Several new fields have been added to the Image and Rendition models to support :ref:`image_feature_detection`. These will be added to the database when you run ``./manage.py migrate``. If you have defined a custom image model (by extending the ``wagtailimages.AbstractImage`` and ``wagtailimages.AbstractRendition`` classes and specifying ``WAGTAILIMAGES_IMAGE_MODEL`` in settings), the change needs to be applied to that model's database table too. Running the command:
 
-  ./manage.py schemamigration myapp --auto add_image_focal_point_fields
+.. code-block:: console
+
+    $ ./manage.py schemamigration myapp --auto add_image_focal_point_fields
 
 (with 'myapp' replaced with your app name) will generate the necessary migration file.
 

--- a/docs/releases/0.6.rst
+++ b/docs/releases/0.6.rst
@@ -62,4 +62,4 @@ Deprecated features
 ===================
 
  * The ``wagtail.wagtailsearch.indexed`` module has been renamed to ``wagtail.wagtailsearch.index``
- 
+

--- a/docs/releases/0.7.rst
+++ b/docs/releases/0.7.rst
@@ -70,7 +70,9 @@ Upgrade considerations
 Addition of ``wagtailsites`` app
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Sites administration interface is contained within a new app, ``wagtailsites``. To enable this on an existing Wagtail project, add the line::
+The Sites administration interface is contained within a new app, ``wagtailsites``. To enable this on an existing Wagtail project, add the line:
+
+.. code-block:: python
 
     'wagtail.wagtailsites',
 

--- a/docs/releases/0.8.6.rst
+++ b/docs/releases/0.8.6.rst
@@ -30,9 +30,11 @@ Upgrade considerations
 Orphaned pages may need deleting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This release fixes a bug with page deletion introduced in 0.8, where deleting a page with child pages will result in those child pages being left behind in the database (unless the child pages are of the same type as the parent). This may cause errors later on when creating new pages in the same position. To identify and delete these orphaned pages, it is recommended that you run the following command (from the project root) after upgrading to 0.8.6::
+This release fixes a bug with page deletion introduced in 0.8, where deleting a page with child pages will result in those child pages being left behind in the database (unless the child pages are of the same type as the parent). This may cause errors later on when creating new pages in the same position. To identify and delete these orphaned pages, it is recommended that you run the following command (from the project root) after upgrading to 0.8.6:
 
-    ./manage.py fixtree
+.. code-block:: console
+
+    $ ./manage.py fixtree
 
 This will output a list of any orphaned pages found, and request confirmation before deleting them.
 

--- a/docs/releases/0.8.rst
+++ b/docs/releases/0.8.rst
@@ -72,18 +72,24 @@ This change shouldn't affect most people as ``SearchResults`` behaves very simil
 Removal of validate_image_format from custom image model migrations (Django 1.7+)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If your project is running on Django 1.7, and you have defined a custom image model (by extending the ``wagtailimages.AbstractImage`` class), the migration that creates this model will probably have a reference to ``wagtail.wagtailimages.utils.validators.validate_image_format``. This module has now been removed, which will cause ``manage.py migrate`` to fail with an ``ImportError`` (even if the migration has already been applied). You will need to edit the migration file to remove the line::
+If your project is running on Django 1.7, and you have defined a custom image model (by extending the ``wagtailimages.AbstractImage`` class), the migration that creates this model will probably have a reference to ``wagtail.wagtailimages.utils.validators.validate_image_format``. This module has now been removed, which will cause ``manage.py migrate`` to fail with an ``ImportError`` (even if the migration has already been applied). You will need to edit the migration file to remove the line:
+
+.. code-block:: python
 
     import wagtail.wagtailimages.utils.validators
 
-and the ``validators`` attribute of the 'file' field - that is, the line::
+and the ``validators`` attribute of the 'file' field - that is, the line:
+
+.. code-block:: python
 
     ('file', models.ImageField(upload_to=wagtail.wagtailimages.models.get_upload_to,
         width_field='width', height_field='height',
         validators=[wagtail.wagtailimages.utils.validators.validate_image_format],
         verbose_name='File')),
 
-should become::
+should become:
+
+    .. code-block:: python
 
     ('file', models.ImageField(upload_to=wagtail.wagtailimages.models.get_upload_to,
         width_field='width', height_field='height', verbose_name='File')),

--- a/docs/releases/1.0.rst
+++ b/docs/releases/1.0.rst
@@ -153,18 +153,24 @@ If you are upgrading from Elasticsearch 0.90.x, you may also need to update the 
 Wagtail version upgrade notifications are enabled by default
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Starting from Wagtail 1.0, the admin dashboard will (for admin users only) perform a check to see if newer releases are available. This also provides the Wagtail team with the hostname of your Wagtail site. If you’d rather not receive update notifications, or if you’d like your site to remain unknown, you can disable it by adding this line to your settings file::
+Starting from Wagtail 1.0, the admin dashboard will (for admin users only) perform a check to see if newer releases are available. This also provides the Wagtail team with the hostname of your Wagtail site. If you’d rather not receive update notifications, or if you’d like your site to remain unknown, you can disable it by adding this line to your settings file:
+
+.. code-block:: python
 
     WAGTAIL_ENABLE_UPDATE_CHECK = False
 
 ``InlinePanel`` definitions no longer need to specify the base model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In previous versions of Wagtail, inline child blocks on a page or snippet were defined using a declaration like::
+In previous versions of Wagtail, inline child blocks on a page or snippet were defined using a declaration like:
+
+.. code-block:: python
 
     InlinePanel(HomePage, 'carousel_items', label="Carousel items")
 
-It is no longer necessary to pass the base model as a parameter, so this declaration should be changed to::
+It is no longer necessary to pass the base model as a parameter, so this declaration should be changed to:
+
+.. code-block:: python
 
     InlinePanel('carousel_items', label="Carousel items")
 
@@ -207,11 +213,15 @@ If you were previously using the external ``wagtailapi`` module (which has now b
 **1. Representation of foreign keys has changed**
 
 Foreign keys were previously represented by just the value of their primary key.
-For example::
+For example:
+
+.. code-block:: python
 
     "feed_image": 1
 
-This has now been changed to add some ``meta`` information::
+This has now been changed to add some ``meta`` information:
+
+.. code-block:: python
 
     "feed_image": {
         "id": 1,
@@ -225,7 +235,9 @@ This has now been changed to add some ``meta`` information::
 **2. On the page detail view, the "parent" field has been moved out of meta**
 
 Previously, there was a "parent" field in the "meta" section on the page detail
-view::
+view:
+
+.. code-block:: python
 
     {
         "id": 10,
@@ -239,7 +251,9 @@ view::
 
 
 This has now been moved to the top level. Also, the above change to how foreign
-keys are represented applies to this field too::
+keys are represented applies to this field too:
+
+.. code-block:: python
 
     {
         "id": 10,
@@ -308,7 +322,9 @@ Previously, the ``document_served`` signal (which is fired whenever a user downl
 Custom image models must specify an ``admin_form_fields`` list
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Previously, the forms for creating and editing images followed Django's default behaviour of showing all fields defined on the model; this would include any custom fields specific to your project that you defined by subclassing ``AbstractImage`` and setting ``WAGTAILIMAGES_IMAGE_MODEL``. This behaviour is risky as it may lead to fields being unintentionally exposed to the user, and so Django has deprecated this, for removal in Django 1.8. Accordingly, if you create your own custom subclass of ``AbstractImage``, you must now provide an ``admin_form_fields`` property, listing the fields that should appear on the image creation / editing form - for example::
+Previously, the forms for creating and editing images followed Django's default behaviour of showing all fields defined on the model; this would include any custom fields specific to your project that you defined by subclassing ``AbstractImage`` and setting ``WAGTAILIMAGES_IMAGE_MODEL``. This behaviour is risky as it may lead to fields being unintentionally exposed to the user, and so Django has deprecated this, for removal in Django 1.8. Accordingly, if you create your own custom subclass of ``AbstractImage``, you must now provide an ``admin_form_fields`` property, listing the fields that should appear on the image creation / editing form - for example:
+
+.. code-block:: python
 
     from wagtail.wagtailimages.models import AbstractImage, Image
 

--- a/docs/releases/1.7.rst
+++ b/docs/releases/1.7.rst
@@ -111,16 +111,20 @@ The data model for image renditions will be changed in Wagtail 1.8 to eliminate 
 
  * Run ``manage.py makemigrations`` to create the schema migration
  * Run ``manage.py makemigrations --empty myapp`` (replacing ``myapp`` with the name of the app containing the custom image model) to create an empty migration
- * Edit the created migration to contain::
+ * Edit the created migration to contain:
 
-    from wagtail.wagtailimages.utils import get_fill_filter_spec_migrations
+   .. code-block:: python
 
-   and, for the ``operations`` list::
+       from wagtail.wagtailimages.utils import get_fill_filter_spec_migrations
 
-    forward, reverse = get_fill_filter_spec_migrations('myapp', 'CustomRendition')
-    operations = [
-        migrations.RunPython(forward, reverse),
-    ]
+   and, for the ``operations`` list:
+
+   .. code-block:: python
+
+       forward, reverse = get_fill_filter_spec_migrations('myapp', 'CustomRendition')
+       operations = [
+           migrations.RunPython(forward, reverse),
+       ]
 
    replacing ``myapp`` and ``CustomRendition`` with the app and model name for the custom rendition model.
 

--- a/docs/topics/images.rst
+++ b/docs/topics/images.rst
@@ -5,7 +5,9 @@ Using images in templates
 
 The ``image`` tag inserts an XHTML-compatible ``img`` element into the page, setting its ``src``, ``width``, ``height`` and ``alt``. See also :ref:`image_tag_alt`.
 
-The syntax for the tag is thus::
+The syntax for the tag is thus:
+
+.. code-block:: html+django
 
     {% image [image] [resize-rule] %}
 

--- a/docs/topics/permissions.rst
+++ b/docs/topics/permissions.rst
@@ -12,17 +12,12 @@ Page permissions
 
 Permissions can be attached at any point in the page tree, and propagate down the tree. For example, if a site had the page tree::
 
-    MegaCorp
-     |
-     |-- About us
-     |
-      -- Offices
-         |
-         |- UK
-         |
-         |- France
-         |
-         |- Germany
+    MegaCorp/
+        About us
+        Offices/
+            UK
+            France
+            Germany
 
 then a group with 'edit' permissions on the 'Offices' page would automatically receive the ability to edit the 'UK', 'France' and 'Germany' pages. Permissions can be set globally for the entire tree by assigning them on the 'root' page - since all pages must exist underneath the root node, and the root cannot be deleted, this permission will cover all pages that exist now and in future.
 

--- a/docs/topics/search/backends.rst
+++ b/docs/topics/search/backends.rst
@@ -90,13 +90,13 @@ Prerequisites are the `Elasticsearch`_ service itself and, via pip, the `elastic
 
 .. _Elasticsearch: https://www.elastic.co/downloads/past-releases/elasticsearch-1-7-3
 
-.. code-block:: sh
+.. code-block:: console
 
-  pip install "elasticsearch>=1.0.0,<2.0.0"  # for Elasticsearch 1.x
+  $ pip install "elasticsearch>=1.0.0,<2.0.0"  # for Elasticsearch 1.x
 
-.. code-block:: sh
+.. code-block:: console
 
-  pip install "elasticsearch>=2.0.0,<3.0.0"  # for Elasticsearch 2.x
+  $ pip install "elasticsearch>=2.0.0,<3.0.0"  # for Elasticsearch 2.x
 
 The backend is configured in settings:
 

--- a/docs/topics/search/searching.rst
+++ b/docs/topics/search/searching.rst
@@ -102,8 +102,6 @@ Changing search behaviour
 Search operator
 ^^^^^^^^^^^^^^^
 
-.. versionadded:: 1.2
-
 The search operator specifies how search should behave when the user has typed in multiple search terms. There are two possible values:
 
  - "or" - The results must match at least one term (default for Elasticsearch)
@@ -150,8 +148,6 @@ For page, image and document models, the ``operator`` keyword argument is also s
 
 Custom ordering
 ^^^^^^^^^^^^^^^
-
-.. versionadded:: 1.2
 
 By default, search results are ordered by relevance, if the backend supports it. To preserve the QuerySet's existing ordering, the ``order_by_relevance`` keyword argument needs to be set to ``False`` on the ``search()`` method.
 

--- a/docs/topics/snippets.rst
+++ b/docs/topics/snippets.rst
@@ -28,12 +28,12 @@ Here's an example snippet from the Wagtail demo website:
   class Advert(models.Model):
       url = models.URLField(null=True, blank=True)
       text = models.CharField(max_length=255)
-  
+
       panels = [
           FieldPanel('url'),
           FieldPanel('text'),
       ]
-      
+
       def __str__(self):
           return self.text
 
@@ -90,9 +90,9 @@ Then, in your own page templates, you can include your snippet template tag with
   ...
 
   {% block content %}
-  
+
       ...
-  
+
       {% adverts %}
 
   {% endblock %}
@@ -115,7 +115,7 @@ In the above example, the list of adverts is a fixed list, displayed independent
           on_delete=models.SET_NULL,
           related_name='+'
       )
-  
+
       content_panels = Page.content_panels + [
           SnippetChooserPanel('advert'),
           # ...
@@ -135,28 +135,28 @@ To attach multiple adverts to a page, the ``SnippetChooserPanel`` can be placed 
   from wagtail.wagtailsnippets.edit_handlers import SnippetChooserPanel
 
   from modelcluster.fields import ParentalKey
-  
+
   ...
 
   class BookPageAdvertPlacement(Orderable, models.Model):
       page = ParentalKey('demo.BookPage', related_name='advert_placements')
       advert = models.ForeignKey('demo.Advert', related_name='+')
-  
+
       class Meta:
           verbose_name = "advert placement"
           verbose_name_plural = "advert placements"
-  
+
       panels = [
           SnippetChooserPanel('advert'),
       ]
-  
+
       def __str__(self):
           return self.page.title + " -> " + self.advert.text
-  
-  
+
+
   class BookPage(Page):
       ...
-  
+
       content_panels = Page.content_panels + [
           InlinePanel('advert_placements', label="Adverts"),
           # ...

--- a/docs/topics/writing_templates.rst
+++ b/docs/topics/writing_templates.rst
@@ -85,7 +85,9 @@ Images (tag)
 
 The ``image`` tag inserts an XHTML-compatible ``img`` element into the page, setting its ``src``, ``width``, ``height`` and ``alt``. See also :ref:`image_tag_alt`.
 
-The syntax for the ``image`` tag is thus::
+The syntax for the ``image`` tag is thus:
+
+.. code-block:: html+django
 
     {% image [image] [resize-rule] %}
 


### PR DESCRIPTION
All instances of `::` for marking code have been replaced with a more relevant `.. code-block::` line. The are a few `::` instances left in the docs, but only for marking plain text preformatted code.

`.. code-block:: console` has been used for all shell commands. According to [the pygments documentation](http://pygments.org/docs/lexers/), this is the correct lexer for interactive shell sessions, as opposed to shell scripts.

All trailing whitespace has been trimmed, and tabs replaced with spaces.

`versionadded` notes for old versions have been dropped - there was one in the docs from version 0.7! I updated [Creating a new Wagtail release](https://github.com/torchbox/wagtail/wiki/Creating-a-new-Wagtail-release) to remind the release manager to remove old `versionadded` notes.

As a side note, should [Creating a new Wagtail release](https://github.com/torchbox/wagtail/wiki/Creating-a-new-Wagtail-release) be moved in to the repo so that it is version controlled, and can have PRs made against it?