### PR TITLE
Add BlockQuoteBlock to core block types

### DIFF
--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -190,6 +190,14 @@ A text area for entering raw HTML which will be rendered unescaped in the page o
 .. WARNING::
    When this block is in use, there is nothing to prevent editors from inserting malicious scripts into the page, including scripts that would allow the editor to acquire administrator privileges when another administrator views the page. Do not use this block unless your editors are fully trusted.
 
+BlockQuoteBlock
+~~~~~~~~~~~~~~~
+
+``wagtail.wagtailcore.blocks.BlockQuoteBlock``
+
+A text field, the contents of which will be wrapped in an HTML `<blockquote>` tag pair. The keyword arguments ``required``, ``max_length``, ``min_length`` and ``help_text`` are accepted.
+
+
 ChoiceBlock
 ~~~~~~~~~~~
 

--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -141,12 +141,6 @@ class TextBlock(FieldBlock):
 
 class BlockQuoteBlock(TextBlock):
 
-    def __init__(self, required=True, help_text=None, max_length=None, min_length=None, **kwargs):
-        super(BlockQuoteBlock, self).__init__(**kwargs)
-
-    def get_searchable_content(self, value):
-        return [force_text(value)]
-
     def render_basic(self, value, context=None):
         if value:
             return format_html('<blockquote>{0}</blockquote>', value)

--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -139,6 +139,24 @@ class TextBlock(FieldBlock):
         icon = "pilcrow"
 
 
+class BlockQuoteBlock(TextBlock):
+
+    def __init__(self, required=True, help_text=None, max_length=None, min_length=None, **kwargs):
+        super(BlockQuoteBlock, self).__init__(**kwargs)
+
+    def get_searchable_content(self, value):
+        return [force_text(value)]
+
+    def render_basic(self, value, context=None):
+        if value:
+            return format_html('<blockquote>{0}</blockquote>', value)
+        else:
+            return ''
+
+    class Meta:
+        icon = "openquote"
+
+
 class FloatBlock(FieldBlock):
 
     def __init__(self, required=True, max_value=None, min_value=None, *args,

--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -618,7 +618,7 @@ block_classes = [
     FieldBlock, CharBlock, URLBlock, RichTextBlock, RawHTMLBlock, ChooserBlock,
     PageChooserBlock, TextBlock, BooleanBlock, DateBlock, TimeBlock,
     DateTimeBlock, ChoiceBlock, EmailBlock, IntegerBlock, FloatBlock,
-    DecimalBlock, RegexBlock
+    DecimalBlock, RegexBlock, BlockQuoteBlock
 ]
 DECONSTRUCT_ALIASES = {
     cls: 'wagtail.wagtailcore.blocks.%s' % cls.__name__

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -221,6 +221,14 @@ class TestEmailBlock(unittest.TestCase):
             block.clean("example.email.com")
 
 
+class TestBlockQuoteBlock(unittest.TestCase):
+    def test_render(self):
+        block = blocks.BlockQuoteBlock()
+        quote = block.render("Now is the time...")
+
+        self.assertEqual(quote, "<blockquote>Now is the time...</blockquote>")
+
+
 class TestFloatBlock(TestCase):
     def test_type(self):
         block = blocks.FloatBlock()


### PR DESCRIPTION
As discussed at https://github.com/torchbox/wagtail/issues/532

I ended up subclassing TextBlock rather than CharBlock because the input needs to be multi-line (I was still able to shorten the definition this way).

One bit I'm not sure of - because `wagtailcore.blocks.__init__` imports * from all of the block modules, I should be able to import `blocks.BlockQuoteBlock`, as with other core block types. But for some reason I'm forced to import `blocks.field_block.BlockQuoteBlock` - not sure whether this means I'm missing something.