### PR TITLE
Add the `alters_data` attribute on `Page.copy()`.

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1181,6 +1181,8 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
 
         return page_copy
 
+    copy.alters_data = True
+
     def permissions_for_user(self, user):
         """
         Return a PagePermissionsTester object defining what actions the user can perform on this page


### PR DESCRIPTION
This makes sure the variable can't be printed in the template, performing an accidental copy of the page. That also happened when using the `{% print page %}` tag from my django-debugtools package.