### PR TITLE
Convert explorer breadcrumb into a custom template tag

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/_browse_results.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/_browse_results.html
@@ -1,7 +1,7 @@
 {% load i18n wagtailadmin_tags %}
 
 <h2>{% trans "Explorer" %}</h2>
-{% include "wagtailadmin/shared/breadcrumb.html" with page=parent_page choosing=1 %}
+{% include "wagtailadmin/shared/chooser_breadcrumb.html" with page=parent_page %}
 
 {% if pages %}
     {% include "wagtailadmin/pages/listing/_list_choose.html" with allow_navigation=1 orderable=0 pages=pages parent_page=parent_page %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
@@ -8,7 +8,7 @@
 {% block content %}
 
     <header class="merged tab-merged nice-padding">
-        {% include "wagtailadmin/shared/breadcrumb.html" with page=parent_page include_self=1 %}
+        {% explorer_breadcrumb parent_page include_self=1 %}
 
         <div class="row row-flush">
             <div class="left col9">

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -8,7 +8,7 @@
 {% block content %}
     {% page_permissions page as page_perms %}
     <header class="merged tab-merged nice-padding">
-        {% include "wagtailadmin/shared/breadcrumb.html" with page=page %}
+        {% explorer_breadcrumb page %}
 
         <div class="row row-flush">
             <div class="left col9">

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/index.html
@@ -7,7 +7,7 @@
     <header class="merged no-border nice-padding no-v-padding">
         <h1 class="visuallyhidden">Explorer</h1>
 
-        {% include "wagtailadmin/shared/breadcrumb.html" with page=parent_page %}
+        {% explorer_breadcrumb parent_page %}
     </header>
 
     <form id="page-reorder-form">

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/breadcrumb.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/breadcrumb.html
@@ -1,14 +1,11 @@
 {% load i18n %}
 
 <ul class="breadcrumb">
-    {% for page in page.get_ancestors %}
+    {% for page in pages %}
         {% if page.is_root %}
             <li class="home"><a href="{% url 'wagtailadmin_explore_root' %}" class="icon icon-home text-replace">{% trans 'Home' %}</a></li>
         {% else %}
             <li><a href="{% url 'wagtailadmin_explore' page.id %}">{{ page.get_admin_display_title }}</a></li>
         {% endif %}
     {% endfor %}
-    {% if include_self %}
-        <li><a href="{% url 'wagtailadmin_explore' page.id %}">{{ page.get_admin_display_title }}</a></li>
-    {% endif %}
 </ul>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/breadcrumb.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/breadcrumb.html
@@ -1,14 +1,14 @@
-{% load i18n wagtailadmin_tags %}
+{% load i18n %}
 
 <ul class="breadcrumb">
     {% for page in page.get_ancestors %}
         {% if page.is_root %}
-            <li class="home"><a href="{% if choosing %}{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}{% else %}{% url 'wagtailadmin_explore_root' %}{% endif %}" class="{% if choosing %}navigate-pages{% endif %} icon icon-home text-replace">{% trans 'Home' %}</a></li>
+            <li class="home"><a href="{% url 'wagtailadmin_explore_root' %}" class="icon icon-home text-replace">{% trans 'Home' %}</a></li>
         {% else %}
-            <li><a href="{% if choosing %}{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}{% else %}{% url 'wagtailadmin_explore' page.id %}{% endif %}" {% if choosing %}class="navigate-pages"{% endif %}>{{ page.get_admin_display_title }}</a></li>
+            <li><a href="{% url 'wagtailadmin_explore' page.id %}">{{ page.get_admin_display_title }}</a></li>
         {% endif %}
     {% endfor %}
     {% if include_self %}
-        <li><a href="{% if choosing %}{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}{% else %}{% url 'wagtailadmin_explore' page.id %}{% endif %}" {% if choosing %}class="navigate-pages"{% endif %}>{{ page.get_admin_display_title }}</a></li>
+        <li><a href="{% url 'wagtailadmin_explore' page.id %}">{{ page.get_admin_display_title }}</a></li>
     {% endif %}
 </ul>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/chooser_breadcrumb.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/chooser_breadcrumb.html
@@ -1,0 +1,11 @@
+{% load i18n wagtailadmin_tags %}
+
+<ul class="breadcrumb">
+    {% for page in page.get_ancestors %}
+        {% if page.is_root %}
+            <li class="home"><a href="{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}" class="navigate-pages icon icon-home text-replace">{% trans 'Home' %}</a></li>
+        {% else %}
+            <li><a href="{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}" class="navigate-pages">{{ page.get_admin_display_title }}</a></li>
+        {% endif %}
+    {% endfor %}
+</ul>

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -55,6 +55,13 @@ def main_nav(context):
     }
 
 
+@register.inclusion_tag('wagtailadmin/shared/breadcrumb.html')
+def explorer_breadcrumb(page, include_self=False):
+    return {
+        'pages': page.get_ancestors(inclusive=include_self)
+    }
+
+
 @register.inclusion_tag('wagtailadmin/shared/search_other.html', takes_context=True)
 def search_other(context, current=None):
     request = context['request']


### PR DESCRIPTION
Precursor to refactoring #3133 - split off the chooser/explorer versions of the breadcrumb into separate templates, and convert the explorer version into a template tag (which means we can generate the page queryset more intelligently, and don't need a special case in the template for `include_self`)