### PR TITLE
wagtailapi.serializers.PageSerializer was calling super(BaseSerializer)

### DIFF
--- a/wagtail/contrib/wagtailapi/serializers.py
+++ b/wagtail/contrib/wagtailapi/serializers.py
@@ -268,7 +268,7 @@ class PageSerializer(BaseSerializer):
             if field_name in child_relations and hasattr(child_relations[field_name], 'api_fields'):
                 return ChildRelationField, {'child_fields': child_relations[field_name].api_fields}
 
-        return super(BaseSerializer, self).build_relational_field(field_name, relation_info)
+        return super(PageSerializer, self).build_relational_field(field_name, relation_info)
 
 
 class ImageSerializer(BaseSerializer):


### PR DESCRIPTION
First argument to super() should be PageSerializer rather than BaseSerializer.

I'm getting an intermittent failure on `test_thumbnail (wagtail.wagtailadmin.tests.api.test_images.TestAdminImageDetail)` but I don't see it is related to this change?

This issue was found via [lgtm.com](https://lgtm.com/projects/g/torchbox/wagtail/) (@lgtmhq)