### PR TITLE
Perform a deep copy when cloning global Elasticsearch settings

### DIFF
--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import copy
 import json
 import warnings
 
@@ -763,7 +764,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                     'http_auth': http_auth,
                 })
 
-        self.settings = self.settings.copy()  # Make the class settings attribute as instance settings attribute
+        self.settings = copy.deepcopy(self.settings)  # Make the class settings attribute as instance settings attribute
         self.settings = deep_update(self.settings, params.pop("INDEX_SETTINGS", {}))
 
         # Get Elasticsearch interface


### PR DESCRIPTION
Fixes test failures triggered by #3036 on some combinations of Python and ES versions. These occurred because we were performing deep_update on a shallow copy of the global settings, which meant that if any dicts were merged at a level below the top level, the global settings would be mutated (causing the instance-specific settings to leak into other instances).