### PR TITLE
Fix for issue 3202 Updated dependencies on setup.py 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ install_requires = [
     "Unidecode>=0.04.14",
     "Willow>=0.4,<0.5",
     "requests>=2.11.1,<3.0",
+    "pyenchant==1.6.6",
+    "sphinxcontrib-spelling>=2.3.0", 
 ]
 
 # Testing dependencies
@@ -56,8 +58,6 @@ documentation_extras = [
     'Sphinx>=1.3.1',
     'sphinx-autobuild>=0.5.2',
     'sphinx_rtd_theme>=0.1.8',
-    'sphinxcontrib-spelling==2.1.1',
-    'pyenchant==1.6.6',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,7 @@ install_requires = [
     "html5lib>=0.999,<1",
     "Unidecode>=0.04.14",
     "Willow>=0.4,<0.5",
-    "requests>=2.11.1,<3.0",
-    "pyenchant==1.6.6",
-    "sphinxcontrib-spelling>=2.3.0", 
+    "requests>=2.11.1,<3.0", 
 ]
 
 # Testing dependencies
@@ -55,6 +53,8 @@ testing_extras = [
 
 # Documentation dependencies
 documentation_extras = [
+    'pyenchant==1.6.6',
+    'sphinxcontrib-spelling>=2.3.0',
     'Sphinx>=1.3.1',
     'sphinx-autobuild>=0.5.2',
     'sphinx_rtd_theme>=0.1.8',


### PR DESCRIPTION
#issue 3202
	
Problem:
	Sphinx-spelling is throwing an error when installing from setup.py
Fix: 
	Add pyenchant==1.6.6 before sphinxcontrib-spelling>=2.3.0 in install_requires [from documentation_extras]
	Run pyenhant before sphinxcontrib-spelling and before document requirement packages (in required installs). pyenhant must be set to 1.6.6 (pip on ubuntu wants to install 1.6.8. This throws and error with other packages install. Wont install [babel, imagesize, docutils, sphinxcontrib-spelling])
	Then update sphinxcontrib-spelling version -> changing to 2.3.0 works (was 2.1.1).
	Every thing should install and python runtests.py  - all tests ran with no E.
	
	Techincal details
	Wagtail: 1.7
	Python version: 2.7.6.
	Django version: Django==1.10.4
	Tested on Ubuntu 14.04.3 LTS, MacOS, Windows7
